### PR TITLE
chore(textile-store): update textile convo to have timestamps on top …

### DIFF
--- a/store/textile/actions.ts
+++ b/store/textile/actions.ts
@@ -154,6 +154,7 @@ export default {
 
       commit('addMessageToConversation', {
         address: sender.address,
+        sender: 'other',
         message,
       })
     })
@@ -213,6 +214,7 @@ export default {
 
     commit('addMessageToConversation', {
       address: friend.address,
+      sender: 'self',
       message: result,
     })
   },
@@ -252,6 +254,7 @@ export default {
 
     commit('addMessageToConversation', {
       address: friend.address,
+      sender: 'self',
       message: result,
     })
   },
@@ -291,6 +294,7 @@ export default {
 
     commit('addMessageToConversation', {
       address: friend.address,
+      sender: 'self',
       message: result,
     })
   },

--- a/store/textile/mutations.ts
+++ b/store/textile/mutations.ts
@@ -26,6 +26,8 @@ const mutations = {
       messages: state.conversations[address]?.messages || [],
       replies: state.conversations[address]?.replies || [],
       reactions: state.conversations[address]?.reactions || [],
+      lastMsgReceived: state.conversations[address]?.lastMsgReceived || 0,
+      lastConvoUpdate: state.conversations[address]?.lastConvoUpdate || 0,
     }
 
     const tracked = updateMessageTracker(messages, initialValues)
@@ -36,6 +38,8 @@ const mutations = {
         messages: tracked.messages,
         replies: tracked.replies,
         reactions: tracked.reactions,
+        lastMsgReceived: initialValues.lastMsgReceived,
+        lastConvoUpdate: initialValues.lastConvoUpdate,
         limit,
         skip,
         end,
@@ -49,6 +53,8 @@ const mutations = {
         messages: {},
         replies: {},
         reactions: {},
+        lastMsgReceived: 0,
+        lastConvoUpdate: 0,
         limit: 0,
         skip: 0,
         end: false,
@@ -57,17 +63,19 @@ const mutations = {
   },
   addMessageToConversation(
     state: TextileState,
-    { address, message }: { address: string; message: Message }
+    { address, sender, message }: { address: string; sender:string; message: Message }
   ) {
     // No need to copy since we are going to
     // update the whole conversation object
-    const { messages, replies, reactions, limit, skip, end } =
+    const { messages, replies, reactions, lastMsgReceived, lastConvoUpdate, limit, skip, end } =
       state.conversations[address]
 
     const initialValues = {
       messages,
       replies,
       reactions,
+      lastMsgReceived,
+      lastConvoUpdate,
     }
 
     const tracked = updateMessageTracker([message], initialValues)
@@ -78,6 +86,8 @@ const mutations = {
         messages: tracked.messages,
         replies: tracked.replies,
         reactions: tracked.reactions,
+        lastMsgReceived: (sender !== 'self' ? message.at : lastMsgReceived),
+        lastConvoUpdate: message.at,
         limit,
         skip,
         end,

--- a/store/textile/types.ts
+++ b/store/textile/types.ts
@@ -11,6 +11,8 @@ export interface TextileState {
       messages: MessagesTracker
       replies: RepliesTracker
       reactions: ReactionsTracker
+      lastMsgReceived: number // the last time a message was received by any member of conversation other than account owner
+      lastConvoUpdate: number // the last time a message was received by any member of conversation
       limit: number
       skip: number
       end: boolean


### PR DESCRIPTION
…level

Added timestamps for user and convo on conversations

<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Satellite-Absolute/wiki/Contributing
-->

**What this PR does** 📖
This updates the store so the conversations have the most recent message timestamp, and the most recent received message timestamp at the top level.

**Which issue(s) this PR fixes** 🔨
This doesn't fix anything, but it enables some features to be worked on related to the friend list in the sidebar, including sorting messages by most recent message in the conversation, and showing the time of the last message received.

Fixes #

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
