### PR TITLE
chore: update jest coverage rules + update prettier rules

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "semi": false,
   "singleQuote": true,
-  "endOfLine": "auto"
+  "endOfLine": "auto",
+  "trailingComma": "none"
 }

--- a/cypress/integration/create-account-negative-tests.js
+++ b/cypress/integration/create-account-negative-tests.js
@@ -7,5 +7,4 @@ it('Try to create account with PIN less than 5 digits', () => {
   cy.reload()
   cy.get('[data-cy=submit-input]').click()
   cy.contains('Pin must be at least 5 characters.')
-  testinglint
 })

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,23 +8,28 @@ module.exports = {
     '!**/*.config.ts',
     '!**/config.ts',
     '!**/startup.js',
-    '!**/*.eslintrc.js',
+    '!**/*.eslintrc.js'
   ],
   moduleDirectories: ['node_modules', 'src'],
   moduleNameMapper: {
     '^.+\\.module\\.(css|sass|scss)$': 'identity-obj-proxy',
     '^.+\\.(css|sass|scss)$': '<rootDir>/__mocks__/styleMock.js',
-    '^.+\\.(jpg|jpeg|png|gif|webp|svg)$': '<rootDir>/__mocks__/fileMock.js',
+    '^.+\\.(jpg|jpeg|png|gif|webp|svg)$': '<rootDir>/__mocks__/fileMock.js'
   },
   testPathIgnorePatterns: ['<rootDir>/node_modules/'],
-  coveragePathIgnorePatterns: ['<rootDir>/.nuxt', '<rootDir>/cypress','<rootDir>/coverage', '<rootDir>/plugins' ],
+  coveragePathIgnorePatterns: [
+    '<rootDir>/.nuxt',
+    '<rootDir>/cypress',
+    '<rootDir>/coverage',
+    '<rootDir>/plugins'
+  ],
   testEnvironment: 'jsdom',
   transform: {
-    '^.+\\.(js|jsx|ts|tsx)$': ['babel-jest'],
+    '^.+\\.(js|jsx|ts|tsx)$': ['babel-jest']
   },
   transformIgnorePatterns: [
     '/node_modules/',
     'node_modules/(?!@mylibrary/)',
-    '^.+\\.module\\.(css|sass|scss)$',
-  ],
+    '^.+\\.module\\.(css|sass|scss)$'
+  ]
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,11 @@ module.exports = {
     '**/*.{js,jsx,ts,tsx}',
     '!**/*.d.ts',
     '!**/node_modules/**',
+    '!**/*.config.js',
+    '!**/*.config.ts',
+    '!**/config.ts',
+    '!**/startup.js',
+    '!**/*.eslintrc.js',
   ],
   moduleDirectories: ['node_modules', 'src'],
   moduleNameMapper: {
@@ -12,6 +17,7 @@ module.exports = {
     '^.+\\.(jpg|jpeg|png|gif|webp|svg)$': '<rootDir>/__mocks__/fileMock.js',
   },
   testPathIgnorePatterns: ['<rootDir>/node_modules/'],
+  coveragePathIgnorePatterns: ['<rootDir>/.nuxt', '<rootDir>/cypress','<rootDir>/coverage', '<rootDir>/plugins' ],
   testEnvironment: 'jsdom',
   transform: {
     '^.+\\.(js|jsx|ts|tsx)$': ['babel-jest'],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
       "nuxt-i18n",
       "@nuxtjs/device",
       "types/modules/satellite-lucide-icons.d.ts",
+      "jest",
     ]
   },
   "exclude": [


### PR DESCRIPTION
**What this PR does** 📖

- Removes not needed files and directories from Jest coverage report
- Adds `jest` to `tsconfig.json`
- Updates prettier rules, they were conflicting with the eslint ones, `prettier` wanted '','' on the last line, `eslint` doesn't want the'','' on the last line
- Removes not needed line on Cypress test