### PR TITLE
chore(textile-store): update textile convo to have timestamps on top level

### DIFF
--- a/libraries/Enums/enums.ts
+++ b/libraries/Enums/enums.ts
@@ -1,6 +1,8 @@
 import {KeybindingEnum} from '~/libraries/Enums/types/keybindings'
 import { PropCommonEnum } from '~/libraries/Enums/types/prop-common-events'
+import { MessageRouteEnum } from '~/libraries/Enums/types/message-routes'
 export{
     KeybindingEnum as KeybindingEnum,
     PropCommonEnum as PropCommonEnum,
+    MessageRouteEnum,
 }

--- a/libraries/Enums/types/message-routes.ts
+++ b/libraries/Enums/types/message-routes.ts
@@ -1,0 +1,6 @@
+export enum MessageRouteEnum {
+    INBOUND = "INBOUND",
+    OUTBOUND = "OUTBOUND",
+}
+
+export type MessageRoute  = keyof typeof MessageRouteEnum

--- a/store/textile/actions.ts
+++ b/store/textile/actions.ts
@@ -154,6 +154,7 @@ export default {
 
       commit('addMessageToConversation', {
         address: sender.address,
+        sender: 'other',
         message,
       })
     })
@@ -213,6 +214,7 @@ export default {
 
     commit('addMessageToConversation', {
       address: friend.address,
+      sender: 'self',
       message: result,
     })
   },
@@ -252,6 +254,7 @@ export default {
 
     commit('addMessageToConversation', {
       address: friend.address,
+      sender: 'self',
       message: result,
     })
   },
@@ -291,6 +294,7 @@ export default {
 
     commit('addMessageToConversation', {
       address: friend.address,
+      sender: 'self',
       message: result,
     })
   },

--- a/store/textile/actions.ts
+++ b/store/textile/actions.ts
@@ -4,6 +4,7 @@ import { ActionsArguments } from '~/types/store/store'
 import TextileManager from '~/libraries/Textile/TextileManager'
 import { TextileConfig } from '~/types/textile/manager'
 import { MailboxManager } from '~/libraries/Textile/MailboxManager'
+import { MessageRouteEnum } from '~/libraries/Enums/enums'
 import { Config } from '~/config'
 import { MailboxSubscriptionType } from '~/types/textile/mailbox'
 
@@ -154,7 +155,7 @@ export default {
 
       commit('addMessageToConversation', {
         address: sender.address,
-        sender: 'other',
+        sender: MessageRouteEnum.INBOUND,
         message,
       })
     })
@@ -214,7 +215,7 @@ export default {
 
     commit('addMessageToConversation', {
       address: friend.address,
-      sender: 'self',
+      sender: MessageRouteEnum.OUTBOUND,
       message: result,
     })
   },
@@ -254,7 +255,7 @@ export default {
 
     commit('addMessageToConversation', {
       address: friend.address,
-      sender: 'self',
+      sender: MessageRouteEnum.OUTBOUND,
       message: result,
     })
   },
@@ -294,7 +295,7 @@ export default {
 
     commit('addMessageToConversation', {
       address: friend.address,
-      sender: 'self',
+      sender: MessageRouteEnum.OUTBOUND,
       message: result,
     })
   },

--- a/store/textile/mutations.ts
+++ b/store/textile/mutations.ts
@@ -26,6 +26,8 @@ const mutations = {
       messages: state.conversations[address]?.messages || [],
       replies: state.conversations[address]?.replies || [],
       reactions: state.conversations[address]?.reactions || [],
+      lastMsgReceived: state.conversations[address]?.lastMsgReceived || 0,
+      lastConvoUpdate: state.conversations[address]?.lastConvoUpdate || 0,
     }
 
     const tracked = updateMessageTracker(messages, initialValues)
@@ -36,6 +38,8 @@ const mutations = {
         messages: tracked.messages,
         replies: tracked.replies,
         reactions: tracked.reactions,
+        lastMsgReceived: initialValues.lastMsgReceived,
+        lastConvoUpdate: initialValues.lastConvoUpdate,
         limit,
         skip,
         end,
@@ -49,6 +53,8 @@ const mutations = {
         messages: {},
         replies: {},
         reactions: {},
+        lastMsgReceived: 0,
+        lastConvoUpdate: 0,
         limit: 0,
         skip: 0,
         end: false,
@@ -57,17 +63,19 @@ const mutations = {
   },
   addMessageToConversation(
     state: TextileState,
-    { address, message }: { address: string; message: Message }
+    { address, sender, message }: { address: string; sender:string; message: Message }
   ) {
     // No need to copy since we are going to
     // update the whole conversation object
-    const { messages, replies, reactions, limit, skip, end } =
+    const { messages, replies, reactions, lastMsgReceived, lastConvoUpdate, limit, skip, end } =
       state.conversations[address]
 
     const initialValues = {
       messages,
       replies,
       reactions,
+      lastMsgReceived,
+      lastConvoUpdate,
     }
 
     const tracked = updateMessageTracker([message], initialValues)
@@ -78,6 +86,8 @@ const mutations = {
         messages: tracked.messages,
         replies: tracked.replies,
         reactions: tracked.reactions,
+        lastMsgReceived: (sender !== 'self' ? message.at : lastMsgReceived),
+        lastConvoUpdate: message.at,
         limit,
         skip,
         end,

--- a/store/textile/mutations.ts
+++ b/store/textile/mutations.ts
@@ -1,6 +1,7 @@
 import { TextileState } from './types'
 import { Message } from '~/types/textile/mailbox'
 import { updateMessageTracker } from '~/utilities/Messaging'
+import { MessageRouteEnum } from '~/libraries/Enums/enums'
 
 const mutations = {
   textileInitialized(state: TextileState, status: boolean) {
@@ -26,8 +27,8 @@ const mutations = {
       messages: state.conversations[address]?.messages || [],
       replies: state.conversations[address]?.replies || [],
       reactions: state.conversations[address]?.reactions || [],
-      lastMsgReceived: state.conversations[address]?.lastMsgReceived || 0,
-      lastConvoUpdate: state.conversations[address]?.lastConvoUpdate || 0,
+      lastInbound: state.conversations[address]?.lastInbound || 0,  // the last time a message was received by any member of conversation, EXCEPT account owner
+      lastUpdate: state.conversations[address]?.lastUpdate || 0, // the last time a message was received by any member of conversation, INCLUDING account owner
     }
 
     const tracked = updateMessageTracker(messages, initialValues)
@@ -38,8 +39,8 @@ const mutations = {
         messages: tracked.messages,
         replies: tracked.replies,
         reactions: tracked.reactions,
-        lastMsgReceived: initialValues.lastMsgReceived,
-        lastConvoUpdate: initialValues.lastConvoUpdate,
+        lastInbound: initialValues.lastInbound,  // the last time a message was received by any member of conversation, EXCEPT account owner
+        lastUpdate: initialValues.lastUpdate, // the last time a message was received by any member of conversation, INCLUDING account owner
         limit,
         skip,
         end,
@@ -53,8 +54,8 @@ const mutations = {
         messages: {},
         replies: {},
         reactions: {},
-        lastMsgReceived: 0,
-        lastConvoUpdate: 0,
+        lastInbound: 0,  // the last time a message was received by any member of conversation, EXCEPT account owner
+        lastUpdate: 0, // the last time a message was received by any member of conversation, INCLUDING account owner
         limit: 0,
         skip: 0,
         end: false,
@@ -67,15 +68,15 @@ const mutations = {
   ) {
     // No need to copy since we are going to
     // update the whole conversation object
-    const { messages, replies, reactions, lastMsgReceived, lastConvoUpdate, limit, skip, end } =
+    const { messages, replies, reactions, lastInbound, lastUpdate, limit, skip, end } =
       state.conversations[address]
 
     const initialValues = {
       messages,
       replies,
       reactions,
-      lastMsgReceived,
-      lastConvoUpdate,
+      lastInbound,  // the last time a message was received by any member of conversation, EXCEPT account owner
+      lastUpdate, // the last time a message was received by any member of conversation, INCLUDING account owner
     }
 
     const tracked = updateMessageTracker([message], initialValues)
@@ -86,8 +87,8 @@ const mutations = {
         messages: tracked.messages,
         replies: tracked.replies,
         reactions: tracked.reactions,
-        lastMsgReceived: (sender !== 'self' ? message.at : lastMsgReceived),
-        lastConvoUpdate: message.at,
+        lastInbound: (sender !== MessageRouteEnum.OUTBOUND ? message.at : lastInbound),  // the last time a message was received by any member of conversation, EXCEPT account owner
+        lastUpdate: message.at, // the last time a message was received by any member of conversation, INCLUDING account owner
         limit,
         skip,
         end,

--- a/store/textile/types.ts
+++ b/store/textile/types.ts
@@ -11,8 +11,8 @@ export interface TextileState {
       messages: MessagesTracker
       replies: RepliesTracker
       reactions: ReactionsTracker
-      lastMsgReceived: number // the last time a message was received by any member of conversation other than account owner
-      lastConvoUpdate: number // the last time a message was received by any member of conversation
+      lastInbound: number // the last time a message was received by any member of conversation, other than account owner
+      lastUpdate: number // the last time a message was received by any member of conversation, including account owner
       limit: number
       skip: number
       end: boolean

--- a/store/textile/types.ts
+++ b/store/textile/types.ts
@@ -11,6 +11,8 @@ export interface TextileState {
       messages: MessagesTracker
       replies: RepliesTracker
       reactions: ReactionsTracker
+      lastMsgReceived: number // the last time a message was received by any member of conversation other than account owner
+      lastConvoUpdate: number // the last time a message was received by any member of conversation
       limit: number
       skip: number
       end: boolean


### PR DESCRIPTION

Added timestamps for user and convo on conversation object

#AP-125

<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Satellite-Absolute/wiki/Contributing
-->

**What this PR does** 📖
This adds two timestamps to the conversations textile object, which will make it easier for UI updates in the sidebar (sorting based on last message sent/received, show timestamp for last time friend responded, etc)

**Which issue(s) this PR fixes** 🔨

Fixes #
AP-125

**Special notes for reviewers** 🗒️

No UI changes, you can see the object being updated in the debugger > application > local storage > satellite-store > and see the new lastMsgReceived and lastConvoUpdate keys in the textile conversations object.

**Additional comments** 🎤
