### PR TITLE
chore(build): dev build fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "satellite-absolute",
+  "name": "Core-PWA",
   "version": "0.1.0",
   "private": true,
   "scripts": {
@@ -67,10 +67,10 @@
     "nuxt-edge": "latest",
     "nuxt-i18n": "^6.26.0",
     "nuxt-mq": "^2.0.2",
-    "p2pt": "Satellite-im/P2PT#fixed-dependencies",
+    "p2pt": "git+https://git@github.com/Satellite-im/P2PT#fixed-dependencies",
     "qrcode.vue": "^1.7.0",
     "remarkable": "^2.0.1",
-    "satellite-lucide-icons": "Satellite-im/satellite-lucide-vue",
+    "satellite-lucide-icons": "git+https://git@github.com/Satellite-im/satellite-lucide-vue",
     "sharp": "^0.29.0",
     "simple-peer": "^9.11.0",
     "uuid": "^8.3.2",
@@ -145,14 +145,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Satellite-im/Satellite-Absolute.git"
+    "url": "git+https://github.com/Satellite-im/Core-PWA.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/Satellite-im/Satellite-Absolute/issues"
+    "url": "https://github.com/Satellite-im/Core-PWA/issues"
   },
-  "homepage": "https://github.com/Satellite-im/Satellite-Absolute#readme",
+  "homepage": "https://github.com/Satellite-im/Core-PWA#readme",
   "lint-staged": {
     "*.js": "eslint --cache --fix"
   }


### PR DESCRIPTION
Git is forcing ssl even when explicitely requesting http

#AP-00

<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Satellite-Absolute/wiki/Contributing
-->

**What this PR does** 📖
This fixes the build on netlify. The build is failing because yarn is forcing ssh instead of https for the submodules and satellite owned git repos our packages point to. Here is the same issue in NPM's repos, https://github.com/npm/cli/issues/2610 the same fix helps us.

**Which issue(s) this PR fixes** 🔨

Fixes #

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
