### PR TITLE
chore: update cypress version

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@types/node": "^16.11.10",
     "@vue/test-utils": "^1.1.3",
     "babel-jest": "^27.3.1",
-    "cypress": "^9.1.0",
+    "cypress": "^9.1.1",
     "cypress-file-upload": "^5.0.8",
     "dotenv-cli": "^4.0.0",
     "electron": "^13.2.1",


### PR DESCRIPTION


**What this PR does** 📖

Updates Cypress version from `9.1.0` to `9.1.1`

