### PR TITLE
feat(import account): recover account from phrases you input

### DIFF
--- a/components/ui/TypeHead/TypeHead.vue
+++ b/components/ui/TypeHead/TypeHead.vue
@@ -77,6 +77,7 @@ export default Vue.extend({
         this.searchList = this.list
         return
       }
+      if(!this.isFocus) this.isFocus = true
       this.searchList = this.list.filter((item: any) =>
         this.label
           ? item[this.label].indexOf(this.searchText) === 0

--- a/pages/setup/InputAccount/InputAccount.html
+++ b/pages/setup/InputAccount/InputAccount.html
@@ -3,7 +3,7 @@
     <TypographyTitle :size="4" :text="$t('pages.inputAccount.title')" />
     <TypographySubtitle :size="6" :text="$t('pages.inputAccount.subtitle')" />
     <UiTypeHead
-      :list="availableBipList"
+      :list="bipList"
       size="small"
       type="primary"
       :placeholder="$t('pages.inputAccount.enter')"

--- a/pages/setup/InputAccount/README.md
+++ b/pages/setup/InputAccount/README.md
@@ -1,0 +1,3 @@
+# Input Account
+
+You can input 12 mnemonic phrases and recover account with that

--- a/pages/setup/InputAccount/index.vue
+++ b/pages/setup/InputAccount/index.vue
@@ -23,8 +23,21 @@ export default Vue.extend({
     },
   },
   methods: {
-    recoverAccount() {
-      /* recover account action will be implemented on bip39 service ticket */
+    /**
+     * @method recoverAccount DocsTODO
+     * @description recover account with 12 mnemonic recover phrases
+     * @param
+     * @example
+     */
+    async recoverAccount() {
+      try {
+        const mnemonic = this.phrases.join(' ')
+        await this.$store.dispatch('accounts/setRecoverMnemonic', mnemonic)
+        await this.$store.dispatch('accounts/loadAccount')
+        this.$router.replace('/chat/direct')
+      } catch (error: any) {
+        this.error = error.message
+      }
     },
     isOdd(num: number) {
       return num % 2

--- a/pages/setup/InputAccount/index.vue
+++ b/pages/setup/InputAccount/index.vue
@@ -26,8 +26,7 @@ export default Vue.extend({
     /**
      * @method recoverAccount DocsTODO
      * @description recover account with 12 mnemonic recover phrases
-     * @param
-     * @example
+     * @example this.recoverAccount()
      */
     async recoverAccount() {
       try {

--- a/pages/setup/InputAccount/index.vue
+++ b/pages/setup/InputAccount/index.vue
@@ -17,11 +17,6 @@ export default Vue.extend({
       bipList: bip39.wordlists.english,
     }
   },
-  computed: {
-    availableBipList() {
-      return this.bipList.filter((elm) => !this.phrases.includes(elm))
-    },
-  },
   methods: {
     /**
      * @method recoverAccount DocsTODO
@@ -45,8 +40,7 @@ export default Vue.extend({
       this.phrases.splice(index, 1)
     },
     onSelected(item: string) {
-      if (this.phrases.length < 12 && !this.phrases.includes(item))
-        this.phrases.push(item)
+      if (this.phrases.length < 12) this.phrases.push(item)
     },
   },
 })

--- a/store/accounts/actions.ts
+++ b/store/accounts/actions.ts
@@ -100,6 +100,28 @@ export default {
     commit('setEncryptedPhrase', encryptedPhrase)
   },
   /**
+   * @method generateWallet DocsTODO
+   * @description
+   * @param
+   * @example
+   */
+   async setRecoverMnemonic({ commit, state }: ActionsArguments<AccountsState>, mnemonic: string) {
+    const { pin } = state
+
+    if (!pin) {
+      throw new Error(AccountsError.INVALID_PIN)
+    }
+    
+    await commit('setPhrase', mnemonic)
+    const $Crypto: Crypto = Vue.prototype.$Crypto
+    const encryptedPhrase = await $Crypto.encryptWithPassword(
+      mnemonic,
+      pin,
+    )
+
+    commit('setEncryptedPhrase', encryptedPhrase)
+   },
+  /**
    * @method loadAccount DocsTODO
    * @description
    * @param

--- a/store/accounts/actions.ts
+++ b/store/accounts/actions.ts
@@ -100,9 +100,9 @@ export default {
     commit('setEncryptedPhrase', encryptedPhrase)
   },
   /**
-   * @method generateWallet DocsTODO
+   * @method setRecoverMnemonic DocsTODO
    * @description
-   * @param
+   * @param mnemonic
    * @example
    */
    async setRecoverMnemonic({ commit, state }: ActionsArguments<AccountsState>, mnemonic: string) {


### PR DESCRIPTION
**What this PR does** 📖
Recover account from phrases you input

**Which issue(s) this PR fixes** 🔨

Fixes # AP-15

**Special notes for reviewers** 🗒️
Test Case for reviewers:
1. create an account
2. while creating an account, you should save recover phrases
![image](https://user-images.githubusercontent.com/28632174/145203451-a193e6e5-0193-4009-a896-ea5f488be88c.png)
3. after you register and login.. clear localStorage and go to '/'
4. input pin and click import account
5. input recover phrases you saved
6. after clicking import account you can log in with your created account
