### PR TITLE
fix: fix wrong string on emoji reaction on chat

### DIFF
--- a/components/tailored/messaging/message/actions/Actions.html
+++ b/components/tailored/messaging/message/actions/Actions.html
@@ -1,7 +1,7 @@
 <div class="message-actions">
   <div
     class="reply-command has-tooltip has-tooltip-primary"
-    :data-tooltip="$t('ui.glyphs')"
+    :data-tooltip="$t('ui.emotes')"
     @click="emojiReaction"
   >
     <smile-icon


### PR DESCRIPTION

**What this PR does** 📖

fix wrong string on emoji reaction on chat

before 
<img width="246" alt="Captura de ecrã 2021-12-14, às 00 00 32" src="https://user-images.githubusercontent.com/29093946/145908412-69b35812-f613-484d-bcff-e78867717190.png">

after
<img width="242" alt="Captura de ecrã 2021-12-14, às 00 01 59" src="https://user-images.githubusercontent.com/29093946/145908421-275a4e92-431c-44ea-b212-23d6816dfc58.png">


