### PR TITLE
feat(Quick Profile): Implement Quick Profile

### DIFF
--- a/components/interactables/QuickProfile/QuickProfile.html
+++ b/components/interactables/QuickProfile/QuickProfile.html
@@ -18,7 +18,7 @@
   <InteractablesInputGroup
     type="primary"
     v-model="text"
-    :placeholder="`Message ${user.name}...`"
+    :placeholder="`${$t('friends.message')} ${user.name}...`"
     :action="sendMessage"
   >
     <arrow-right-icon size="1x" />

--- a/components/interactables/QuickProfile/QuickProfile.html
+++ b/components/interactables/QuickProfile/QuickProfile.html
@@ -1,13 +1,26 @@
-<div id="quick-profile"
+<div
+  id="quick-profile"
   ref="quickProfile"
   v-click-outside="close"
-  :style="$device.isDesktop ? `top: ${ui.quickProfilePosition.y}px; left: ${ui.quickProfilePosition.x}px;` : ''">
+  :style="$device.isDesktop ? `top: ${ui.quickProfilePosition.y}px; left: ${ui.quickProfilePosition.x}px;` : ''"
+>
   <div class="header">
     <UiCircle type="random" :seed="user.address" :size="45" />
   </div>
   <TypographyTitle :text="user.name" :size="6" />
-  <TypographyText :text="user.publicKey ? `${user.publicKey.substr(0, 23)}...` : ``" :size="6" class="address" />
+  <TypographyText
+    :text="user.publicKey ? `${user.publicKey.substr(0, 23)}...` : ``"
+    :size="6"
+    class="address"
+  />
   <TypographyText :text="user.status" :size="6" />
   <UiHorizontalRule />
-  <InteractablesInputGroup :icon="{ style: 'far', name: 'arrow-circle-right' }" type="primary" v-model="text" :placeholder="`Message ${user.name}...`" :action="sendMessage"/>
+  <InteractablesInputGroup
+    type="primary"
+    v-model="text"
+    :placeholder="`Message ${user.name}...`"
+    :action="sendMessage"
+  >
+    <arrow-right-icon size="1x" />
+  </InteractablesInputGroup>
 </div>

--- a/components/interactables/QuickProfile/QuickProfile.html
+++ b/components/interactables/QuickProfile/QuickProfile.html
@@ -14,13 +14,15 @@
     class="address"
   />
   <TypographyText :text="user.status" :size="6" />
-  <UiHorizontalRule />
-  <InteractablesInputGroup
-    type="primary"
-    v-model="text"
-    :placeholder="`${$t('friends.message')} ${user.name}...`"
-    :action="sendMessage"
-  >
-    <arrow-right-icon size="1x" />
-  </InteractablesInputGroup>
+  <template v-if="!isMe()">
+    <UiHorizontalRule />
+    <InteractablesInputGroup
+      type="primary"
+      v-model="text"
+      :placeholder="`${$t('friends.message')} ${user.name}...`"
+      :action="sendMessage"
+    >
+      <arrow-right-icon size="1x" />
+    </InteractablesInputGroup>
+  </template>
 </div>

--- a/components/interactables/QuickProfile/QuickProfile.html
+++ b/components/interactables/QuickProfile/QuickProfile.html
@@ -9,5 +9,5 @@
   <TypographyText :text="user.publicKey ? `${user.publicKey.substr(0, 23)}...` : ``" :size="6" class="address" />
   <TypographyText :text="user.status" :size="6" />
   <UiHorizontalRule />
-  <InteractablesInputGroup :icon="{ style: 'far', name: 'arrow-circle-right' }" type="primary" :placeholder="`Message ${user.name}...`" />
+  <InteractablesInputGroup :icon="{ style: 'far', name: 'arrow-circle-right' }" type="primary" v-model="text" :placeholder="`Message ${user.name}...`" :action="sendMessage"/>
 </div>

--- a/components/interactables/QuickProfile/QuickProfile.vue
+++ b/components/interactables/QuickProfile/QuickProfile.vue
@@ -11,6 +11,11 @@ export default Vue.extend({
       default: () => {},
     },
   },
+  data() {
+    return {
+      text: '',
+    }
+  },
   computed: {
     ...mapState(['ui']),
   },
@@ -57,6 +62,13 @@ export default Vue.extend({
           }
         }
       }
+    },
+    sendMessage() {
+      this.$store.dispatch('textile/sendTextMessage', {
+        to: this.user?.textilePubkey,
+        text: this.text,
+      })
+      this.close()
     },
   },
 })

--- a/components/interactables/QuickProfile/QuickProfile.vue
+++ b/components/interactables/QuickProfile/QuickProfile.vue
@@ -3,8 +3,12 @@
 import Vue, { PropType } from 'vue'
 import { mapState } from 'vuex'
 import { User } from '~/types/ui/user'
+import { ArrowRightIcon } from 'satellite-lucide-icons'
 
 export default Vue.extend({
+  components: {
+    ArrowRightIcon,
+  },
   props: {
     user: {
       type: Object as PropType<User>,

--- a/components/interactables/QuickProfile/QuickProfile.vue
+++ b/components/interactables/QuickProfile/QuickProfile.vue
@@ -21,7 +21,7 @@ export default Vue.extend({
     }
   },
   computed: {
-    ...mapState(['ui']),
+    ...mapState(['ui', 'accounts']),
   },
   mounted() {
     this.handleOverflow()
@@ -73,6 +73,12 @@ export default Vue.extend({
         text: this.text,
       })
       this.close()
+    },
+    isMe() {
+      return (
+        this.accounts.details &&
+        this.accounts.details.textilePubkey === this.user?.textilePubkey
+      )
     },
   },
 })

--- a/components/ui/Global/Global.html
+++ b/components/ui/Global/Global.html
@@ -55,6 +55,6 @@
     v-click-outside="() => toggleModal(ModalWindows.CHANGELOG)"
   />
   <transition :name="$device.isMobile ? 'slide' : ''">
-    <InteractablesQuickProfile v-if="ui.quickProfile" :user="$mock.user" />
+    <InteractablesQuickProfile v-if="ui.quickProfile" :user="ui.quickProfile" />
   </transition>
 </div>

--- a/components/views/chat/group/Group.vue
+++ b/components/views/chat/group/Group.vue
@@ -9,6 +9,7 @@ import { User } from '~/types/ui/user'
 import {
   getUsernameFromState,
   getAddressFromState,
+  getFullUserInfoFromState,
   refreshTimestampInterval,
 } from '~/utilities/Messaging'
 
@@ -46,8 +47,9 @@ export default Vue.extend({
      * @example v-on:click="showQuickProfile"
      */
     showQuickProfile(e: Event) {
+      const selectedUser = getFullUserInfoFromState(this.group.from, this.$store.state)
       this.$store.commit('ui/setQuickProfilePosition', e)
-      this.$store.commit('ui/quickProfile', true)
+      this.$store.commit('ui/quickProfile', selectedUser)
     },
   },
   created() {

--- a/components/views/chat/message/reply/Reply.vue
+++ b/components/views/chat/message/reply/Reply.vue
@@ -6,7 +6,7 @@ import VueMarkdown from 'vue-markdown'
 import { PlusSquareIcon, MinusSquareIcon } from 'satellite-lucide-icons'
 
 import { Message, Group } from '~/types/messaging'
-import { getUsernameFromState } from '~/utilities/Messaging'
+import { getUsernameFromState, getFullUserInfoFromState } from '~/utilities/Messaging'
 
 export default Vue.extend({
   components: {
@@ -112,6 +112,7 @@ export default Vue.extend({
      * @example
      */
     showQuickProfile(e: Event) {
+      const selectedUser = getFullUserInfoFromState(this.$props.message.from, this.$store.state)
       this.$store.commit('ui/setQuickProfilePosition', e)
       this.$store.commit('ui/quickProfile', true)
     },

--- a/components/views/chat/message/reply/Reply.vue
+++ b/components/views/chat/message/reply/Reply.vue
@@ -114,7 +114,7 @@ export default Vue.extend({
     showQuickProfile(e: Event) {
       const selectedUser = getFullUserInfoFromState(this.$props.message.from, this.$store.state)
       this.$store.commit('ui/setQuickProfilePosition', e)
-      this.$store.commit('ui/quickProfile', true)
+      this.$store.commit('ui/quickProfile', selectedUser)
     },
     /**
      * @method toggleReplies DocsTODO

--- a/utilities/Messaging.ts
+++ b/utilities/Messaging.ts
@@ -14,7 +14,7 @@ import {
 
 function messageRepliesToUIReplies(
   replies: ReplyMessage[],
-  reactions: ReactionMessage[]
+  reactions: ReactionMessage[],
 ) {
   return replies.map((reply) => replyMessageToUIReply(reply, reactions))
 }
@@ -23,7 +23,8 @@ function getMessageUIReactions(message: Message, reactions: ReactionMessage[]) {
   let groupedReactions: { [key: string]: UIReaction } = {}
   reactions.forEach((reactionMessage) => {
     let reactors = groupedReactions[reactionMessage.payload]?.reactors || []
-    if (!reactors.includes(reactionMessage.from)) reactors = [...reactors, reactionMessage.from]
+    if (!reactors.includes(reactionMessage.from))
+      reactors = [...reactors, reactionMessage.from]
     groupedReactions[reactionMessage.payload] = {
       emoji: reactionMessage.payload,
       reactors,
@@ -36,7 +37,7 @@ function getMessageUIReactions(message: Message, reactions: ReactionMessage[]) {
 
 function replyMessageToUIReply(
   reply: ReplyMessage,
-  reactions: ReactionMessage[]
+  reactions: ReactionMessage[],
 ): UIReply {
   return { ...reply, reactions: getMessageUIReactions(reply, reactions) }
 }
@@ -44,7 +45,7 @@ function replyMessageToUIReply(
 export function groupMessages(
   messages: MessagesTracker,
   replies: RepliesTracker,
-  reactions: ReactionsTracker
+  reactions: ReactionsTracker,
 ): MessageGroup {
   let groupedMessages: MessageGroup = []
 
@@ -110,11 +111,11 @@ export function groupMessages(
             ...currentMessage,
             replies: messageRepliesToUIReplies(
               currentMessageReplies,
-              currentMessageReactions
+              currentMessageReactions,
             ),
             reactions: getMessageUIReactions(
               currentMessage,
-              currentMessageReactions
+              currentMessageReactions,
             ),
           },
         ],
@@ -147,7 +148,7 @@ type TrackingValues = {
 
 export function updateMessageTracker(
   inputMessages: Message[],
-  initialValues?: TrackingValues
+  initialValues?: TrackingValues,
 ): TrackingValues {
   let messagesTracker: MessagesTracker = initialValues?.messages || {}
   let repliesTracker: RepliesTracker = initialValues?.replies || {}
@@ -160,13 +161,21 @@ export function updateMessageTracker(
       case 'reply':
         const reply: ReplyMessage = currentMessage
         repliesTracker[reply.repliedTo]
-          ? repliesTracker[reply.repliedTo].some(function(value) { return value.id === reply.id}) ? repliesTracker[reply.repliedTo] : repliesTracker[reply.repliedTo].push(reply)
+          ? repliesTracker[reply.repliedTo].some(function (value) {
+              return value.id === reply.id
+            })
+            ? repliesTracker[reply.repliedTo]
+            : repliesTracker[reply.repliedTo].push(reply)
           : (repliesTracker[currentMessage.repliedTo] = [reply])
         break
       case 'reaction':
         const reaction: ReactionMessage = currentMessage
         reactionsTracker[reaction.reactedTo]
-          ? reactionsTracker[reaction.reactedTo].some(function(value) {return value.id === reaction.id}) ? reactionsTracker[reaction.reactedTo] : reactionsTracker[reaction.reactedTo].push(reaction)
+          ? reactionsTracker[reaction.reactedTo].some(function (value) {
+              return value.id === reaction.id
+            })
+            ? reactionsTracker[reaction.reactedTo]
+            : reactionsTracker[reaction.reactedTo].push(reaction)
           : (reactionsTracker[reaction.reactedTo] = [reaction])
         break
       case 'file':
@@ -192,37 +201,44 @@ export function updateMessageTracker(
 
 export function getUsernameFromState(
   textilePublicKey: string,
-  state: RootState
+  state: RootState,
 ) {
-  const accountDetails = state.accounts.details
-  const isMe =
-    accountDetails && accountDetails.textilePubkey === textilePublicKey
-
-  const username = isMe
-    ? accountDetails.name
-    : state.friends.all.find(
-      (friend) => friend.textilePubkey === textilePublicKey
-    )?.name || 'unknown'
-
-  return username
+  return getFullUserInfoFromState(textilePublicKey, state)?.name || 'unknown'
 }
 
 export function getAddressFromState(
   textilePublicKey: string,
-  state: RootState
+  state: RootState,
 ) {
   const address =
     state.friends.all.find(
-      (friend) => friend.textilePubkey === textilePublicKey
+      (friend) => friend.textilePubkey === textilePublicKey,
     )?.address || 'unknown'
 
   return address
 }
 
+export function getFullUserInfoFromState(
+  textilePublicKey: string,
+  state: RootState,
+) {
+  const accountDetails = state.accounts.details
+  const isMe =
+    accountDetails && accountDetails.textilePubkey === textilePublicKey
+
+  const userInfo = isMe
+    ? accountDetails
+    : state.friends.all.find(
+        (friend) => friend.textilePubkey === textilePublicKey,
+      )
+
+  return userInfo
+}
+
 export function refreshTimestampInterval(
   timestamp: number,
   action: (timePassed: string) => any,
-  interval: number
+  interval: number,
 ) {
   return setInterval(() => {
     const updatedTimestamp = dayjs(timestamp).fromNow()


### PR DESCRIPTION
**What this PR does** 📖
When you click a users picture in chat, and the quick profile appears, it should have their name/icon, and the ability to message them
**Which issue(s) this PR fixes** 🔨

Fixes # AP-268

**Special notes for reviewers** 🗒️
I think all functionalities are implemented except icon.
I can't test user icon on quick profile because.. updating icon on settings/profile is not fully implemented.
We can create individual ticket for that.
