### PR TITLE
fix(friends): friends - account id should be cleared after friend request is sent

### DIFF
--- a/components/views/friends/add/Add.vue
+++ b/components/views/friends/add/Add.vue
@@ -82,6 +82,7 @@ export default Vue.extend({
     },
     onFriendRequestSent(error: string) {
       this.friend = null
+      this.accountID = ''
       if (!error) {
         // @ts-ignore
         this.$toast.show(this.$t('friends.request_sent'))


### PR DESCRIPTION
**What this PR does** 📖
friends - account id should be cleared after friend request is sent
**Which issue(s) this PR fixes** 🔨

Fixes # AP-294

