### PR TITLE
test(Cypress): increase timeout on cypress tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
     "projectId": "4offi6",
-    "baseUrl": "http://localhost:3000"
+    "baseUrl": "http://localhost:3000",
+    "numTestsKeptInMemory": 0
 }

--- a/cypress/integration/create-account.js
+++ b/cypress/integration/create-account.js
@@ -50,7 +50,7 @@ it('Create Account', () => {
   cy.contains('Crop').click()
   cy.get('[data-cy=sign-in-button]').click()
   cy.contains('Linking Satellites...')
-  cy.contains('Working on the space station', { timeout: 30000 }).should(
+  cy.contains('Working on the space station', { timeout: 60000 }).should(
     'be.visible',
   )
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -51,7 +51,7 @@ Cypress.Commands.add('importAccount', () => {
   )
   cy.get('[data-cy=add-passphrase]').type('{enter}')
   cy.contains('Recover Account').click()
-  cy.contains('Working on the space station', { timeout: 30000 }).should(
+  cy.contains('Working on the space station', { timeout: 60000 }).should(
     'be.visible',
   )
 })

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@types/node": "^16.11.10",
     "@vue/test-utils": "^1.1.3",
     "babel-jest": "^27.3.1",
-    "cypress": "^9.1.1",
+    "cypress": "9.2.0",
     "cypress-file-upload": "^5.0.8",
     "dotenv-cli": "^4.0.0",
     "electron": "^13.2.1",


### PR DESCRIPTION
**What this PR does** 📖

- increase the timeout on cypress tests from 30s to 60s because sometimes takes a while to enter the application
- updates Cypress version
- avoid memory issue