### PR TITLE
feat(cache): use service worker to cache ipfs responses

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -153,7 +153,7 @@ export default defineNuxtConfig({
       runtimeCaching: [
         {
           urlPattern: 'https://satellite.mypinata.cloud/ipfs/*',
-          handler: 'cacheFirst',
+          handler: 'StaleWhileRevalidate',
           method: 'GET',
           strategyOptions: {
             cacheName: 'ipfs',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -147,6 +147,23 @@ export default defineNuxtConfig({
     icon: {
       source: '/static/favicon.png',
     },
+    workbox: {
+      // uncomment next line to test dev
+      // enabled: true,
+      runtimeCaching: [
+        {
+          urlPattern: 'https://satellite.mypinata.cloud/ipfs/*',
+          handler: 'cacheFirst',
+          method: 'GET',
+          strategyOptions: {
+            cacheName: 'ipfs',
+            cacheExpiration: {
+              maxAgeSeconds: 7 * 24 * 60 * 60 * 52, // 1 year
+            },
+          },
+        },
+      ],
+    },
   },
 
   i18n: {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -148,7 +148,7 @@ export default defineNuxtConfig({
       source: '/static/favicon.png',
     },
     workbox: {
-      // uncomment next line to test dev
+      // uncomment next line to test local
       // enabled: true,
       runtimeCaching: [
         {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- service worker caches ipfs responses like glyphs and mute/deafen/video mp3
- using StaleWhileRevalidate since ipfs sends opaque responses. If we enable CORS on ipfs, we could look into cacheFirst

**Which issue(s) this PR fixes** 🔨
N/A

**Special notes for reviewers** 🗒️
https://pwa.nuxtjs.org/workbox/#enabled
- documentation recommends testing by running prod locally. I couldn't get that to work, so I just switch enabled to true in nuxt.config
- you will need to check application tab of chrome dev tools to see details about service worker

**Additional comments** 🎤
