### PR TITLE
fix(nsfw): don't allow nsfw images to be sent

### DIFF
--- a/components/ui/Chat/Image/Image.html
+++ b/components/ui/Chat/Image/Image.html
@@ -18,19 +18,6 @@
     v-on:click='() => $data.showfull = !$data.showfull' />
   <div class='file-info'>
     <div class='download-container'>
-      <image-icon class='icon' />
-      <TypographySubtitle class='name-text' :size='6' :text='`${image.name}`' />
-
-      <a class='dl-text link' href='#' :download='image.url'>
-        <download-icon size='1x' class='icon' />
-        <TypographyText class='name-text text link' :text="$t('controls.download')" />
-      </a>
-    </div>
-
-    <TypographyText class='size-text' :text='`${image.type} - ${getFileSize}`' />
-
-  <div class='file-info'>
-    <div class='download-container'>
       <div class=' dl-icon-text'>
         <image-icon class='icon imag-icon' />
         <TypographySubtitle class='name-text' :size='6' :text='`${image.name}`' />

--- a/components/ui/Chat/Image/Image.html
+++ b/components/ui/Chat/Image/Image.html
@@ -16,6 +16,18 @@
     :class="`is-image ${full ? 'is-full-image' : 'is-normal-image'}`"
     :src='image.url'
     v-on:click='() => $data.showfull = !$data.showfull' />
+  <div class='file-info'>
+    <div class='download-container'>
+      <image-icon class='icon' />
+      <TypographySubtitle class='name-text' :size='6' :text='`${image.name}`' />
+
+      <a class='dl-text link' href='#' :download='image.url'>
+        <download-icon size='1x' class='icon' />
+        <TypographyText class='name-text text link' :text="$t('controls.download')" />
+      </a>
+    </div>
+
+    <TypographyText class='size-text' :text='`${image.type} - ${getFileSize}`' />
 
   <div class='file-info'>
     <div class='download-container'>

--- a/components/ui/Chat/Image/Image.vue
+++ b/components/ui/Chat/Image/Image.vue
@@ -10,9 +10,6 @@ export default Vue.extend({
     DownloadIcon,
   },
   props: {
-    components: {
-      ImageIcon,
-    },
     alt: {
       type: String,
       default: 'Image',

--- a/components/ui/Chat/Image/Image.vue
+++ b/components/ui/Chat/Image/Image.vue
@@ -10,6 +10,9 @@ export default Vue.extend({
     DownloadIcon,
   },
   props: {
+    components: {
+      ImageIcon,
+    },
     alt: {
       type: String,
       default: 'Image',

--- a/components/views/files/upload/Upload.vue
+++ b/components/views/files/upload/Upload.vue
@@ -218,6 +218,18 @@ export default Vue.extend({
         this.$data.fileAmount = nsfwCheck.length
         this.dispatchFile(file)
       })
+        nsfwCheck.map((file: UploadDropItemType) => {
+          this.fileAmount = nsfwCheck.length
+          this.$store.dispatch('textile/sendFileMessage', {
+            to: this.recipient.textilePubkey,
+            file: file,
+          }).then( () =>
+            this.finishUploads())
+        })
+
+        // }
+
+      console.log(nsfwCheck)
     },
   },
 })

--- a/components/views/files/upload/Upload.vue
+++ b/components/views/files/upload/Upload.vue
@@ -155,18 +155,21 @@ export default Vue.extend({
      * @description Keeps track of how many files have been uploaded
      */
     finishUploads() {
-      this.$data.fileAmount--
-      if (this.$data.fileAmount === 0) {
-        if (this.$data.containsNsfw) {
-          this.$data.alertNsfw = true
-          this.alertNsfwFile()
-        }
-        if (!this.$data.containsNsfw) {
-          this.cancelUpload()
-          document.body.style.cursor = PropCommonEnum.DEFAULT
-          this.$store.dispatch('textile/clearUploadStatus')
-        }
+      this.fileAmount--
+      if (this.fileAmount === 0) {
+        this.$data.fileAmount--
+        if (this.$data.fileAmount === 0) {
+          if (this.$data.containsNsfw) {
+            this.$data.alertNsfw = true
+            this.alertNsfwFile()
+          }
+          if (!this.$data.containsNsfw) {
+            this.cancelUpload()
+            document.body.style.cursor = PropCommonEnum.DEFAULT
+            this.$store.dispatch('textile/clearUploadStatus')
+          }
 
+        }
       }
     },
     alertNsfwFile() {
@@ -218,18 +221,10 @@ export default Vue.extend({
         this.$data.fileAmount = nsfwCheck.length
         this.dispatchFile(file)
       })
-        nsfwCheck.map((file: UploadDropItemType) => {
-          this.fileAmount = nsfwCheck.length
-          this.$store.dispatch('textile/sendFileMessage', {
-            to: this.recipient.textilePubkey,
-            file: file,
-          }).then( () =>
-            this.finishUploads())
-        })
-
-        // }
-
-      console.log(nsfwCheck)
+      nsfwCheck.map((file: UploadDropItemType) => {
+        this.fileAmount = nsfwCheck.length
+        this.dispatchFile(file)
+      })
     },
   },
 })

--- a/components/views/files/upload/Upload.vue
+++ b/components/views/files/upload/Upload.vue
@@ -159,13 +159,7 @@ export default Vue.extend({
       if (this.$data.fileAmount === 0) {
         if (this.$data.containsNsfw) {
           this.$data.alertNsfw = true
-          setTimeout(() => {
-            this.$data.alertNsfw = false
-            this.$data.containsNsfw = false
-            this.cancelUpload()
-            document.body.style.cursor = PropCommonEnum.DEFAULT
-            this.$store.dispatch('textile/clearUploadStatus')
-          }, 5000)
+          this.alertNsfwFile()
         }
         if (!this.$data.containsNsfw) {
           this.cancelUpload()

--- a/components/views/files/upload/Upload.vue
+++ b/components/views/files/upload/Upload.vue
@@ -198,6 +198,7 @@ export default Vue.extend({
             new Error(error)
             document.body.style.cursor = PropCommonEnum.DEFAULT
             this.$store.dispatch('textile/clearUploadStatus')
+            this.$data.disabledButton = false
           }
         })
     },
@@ -206,6 +207,7 @@ export default Vue.extend({
      * @description Sends action to Upload the file to textile.
      */
     async sendMessage() {
+      this.$data.disabledButton = true
       const nsfwCheck = this.$data.files.filter((file: UploadDropItemType) => {
         if (!file.nsfw.status) {
           return file
@@ -222,7 +224,7 @@ export default Vue.extend({
         this.dispatchFile(file)
       })
       nsfwCheck.map((file: UploadDropItemType) => {
-        this.fileAmount = nsfwCheck.length
+        this.$data.fileAmount = nsfwCheck.length
         this.dispatchFile(file)
       })
     },

--- a/components/views/files/upload/Upload.vue
+++ b/components/views/files/upload/Upload.vue
@@ -155,21 +155,24 @@ export default Vue.extend({
      * @description Keeps track of how many files have been uploaded
      */
     finishUploads() {
-      this.fileAmount--
-      if (this.fileAmount === 0) {
-        this.$data.fileAmount--
-        if (this.$data.fileAmount === 0) {
-          if (this.$data.containsNsfw) {
-            this.$data.alertNsfw = true
-            this.alertNsfwFile()
-          }
-          if (!this.$data.containsNsfw) {
+      this.$data.fileAmount--
+      if (this.$data.fileAmount === 0) {
+        if (this.$data.containsNsfw) {
+          this.$data.alertNsfw = true
+          setTimeout(() => {
+            this.$data.alertNsfw = false
+            this.$data.containsNsfw = false
             this.cancelUpload()
             document.body.style.cursor = PropCommonEnum.DEFAULT
             this.$store.dispatch('textile/clearUploadStatus')
-          }
-
+          }, 5000)
         }
+        if (!this.$data.containsNsfw) {
+          this.cancelUpload()
+          document.body.style.cursor = PropCommonEnum.DEFAULT
+          this.$store.dispatch('textile/clearUploadStatus')
+        }
+
       }
     },
     alertNsfwFile() {
@@ -198,7 +201,6 @@ export default Vue.extend({
             new Error(error)
             document.body.style.cursor = PropCommonEnum.DEFAULT
             this.$store.dispatch('textile/clearUploadStatus')
-            this.$data.disabledButton = false
           }
         })
     },
@@ -207,7 +209,6 @@ export default Vue.extend({
      * @description Sends action to Upload the file to textile.
      */
     async sendMessage() {
-      this.$data.disabledButton = true
       const nsfwCheck = this.$data.files.filter((file: UploadDropItemType) => {
         if (!file.nsfw.status) {
           return file


### PR DESCRIPTION
**What this PR does** 📖
Blocks sending images deemed nsfw and shows an alert notifying user that file/s were not sent that were nsfw

**Which issue(s) this PR fixes** 🔨
AP-285

**Special notes for reviewers** 🗒️
Alert should pop up on it's own and auto close after 5ish seconds, the user can also click the close on the alert to close before then.
