### PR TITLE
fix(call): disable call buttons after it is clicked until hang up or error happened

### DIFF
--- a/components/views/navigation/toolbar/Toolbar.html
+++ b/components/views/navigation/toolbar/Toolbar.html
@@ -40,7 +40,7 @@
       <ToolbarAlerts />
     </UiFloatingContainer>
     <div
-      :class="`has-tooltip has-tooltip-bottom has-tooltip-primary ${!webrtc.connectedPeer ? 'disabled' : ''}`"
+      :class="`has-tooltip has-tooltip-bottom has-tooltip-primary ${!webrtc.connectedPeer || webrtc.activeCall ? 'disabled' : ''}`"
       :data-tooltip="webrtc.connectedPeer ? $t('controls.call') : $t('controls.not_connected')"
       v-if="server"
       @click="() => call(['audio'])"


### PR DESCRIPTION
**What this PR does** 📖
Disable call buttons after it is clicked until hang up or error happened
**Which issue(s) this PR fixes** 🔨

AP-348

