### PR TITLE
fix(call): set incoming call properties in webrtc in blacklist for vuex-persist

### DIFF
--- a/plugins/thirdparty/persist.ts
+++ b/plugins/thirdparty/persist.ts
@@ -29,6 +29,7 @@ const propertiesBlacklist = [
   'prerequisites',
   'webrtc.activeStream',
   'webrtc.connectedPeer',
+  'webrtc.incomingCall',
 ]
 
 const propertiesBlacklistWhenStorePin = [
@@ -36,6 +37,7 @@ const propertiesBlacklistWhenStorePin = [
   'prerequisites',
   'webrtc.activeStream',
   'webrtc.connectedPeer',
+  'webrtc.incomingCall',
 ]
 export default ({ store }: { store: any }) => {
   new VuexPersistence({


### PR DESCRIPTION
**What this PR does** 📖
Fix 'Video call modal should be removed from state so if something goes wrong with the app they don't get fake phone call notifications when they reload'

**Which issue(s) this PR fixes** 🔨

AP-351

**Special notes for reviewers** 🗒️
- This needs to be tested on fresh env ( that means if you need to initialize webrtc state on localstorage before test... of course If you already stored values)