### PR TITLE
fix(call): fix 'video viewers are not adjusting to size when entering fullscreen'

### DIFF
--- a/components/views/media/Media.less
+++ b/components/views/media/Media.less
@@ -77,6 +77,12 @@
     #media {
       justify-content: center;
       flex-direction: row;
+      .user {
+        .video-stream-container {
+          width: 100%;
+          height: 100%;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
**What this PR does** 📖
fix 'video viewers are not adjusting to size when entering fullscreen'

**Which issue(s) this PR fixes** 🔨

AP-388

**Special notes for reviewers** 🗒️
-When entering to fullscreen and resize, it has some issues while resizing. we can make that as another ticket.
