### PR TITLE
fix(replies): render replies for all messages AP-271

### DIFF
--- a/components/views/chat/message/reply/Reply.vue
+++ b/components/views/chat/message/reply/Reply.vue
@@ -6,7 +6,7 @@ import VueMarkdown from 'vue-markdown'
 import { mapState } from 'vuex'
 import { PlusSquareIcon, MinusSquareIcon } from 'satellite-lucide-icons'
 
-import { Message, Group } from '~/types/messaging'
+import { UIMessage, Group } from '~/types/messaging'
 import { getUsernameFromState, getFullUserInfoFromState } from '~/utilities/Messaging'
 
 export default Vue.extend({
@@ -17,7 +17,7 @@ export default Vue.extend({
   },
   props: {
     message: {
-      type: Object as PropType<Message>,
+      type: Object as PropType<UIMessage>,
       default: () => ({
         id: '0',
         at: 1620515543000,

--- a/utilities/Messaging.ts
+++ b/utilities/Messaging.ts
@@ -128,7 +128,20 @@ export function groupMessages(
       const group: Group = groupOrDivider
 
       const newMessages = group.messages
-        ? [...group.messages, { ...currentMessage, replies: [], reactions: [] }]
+        ? [
+            ...group.messages,
+            {
+              ...currentMessage,
+              replies: messageRepliesToUIReplies(
+                currentMessageReplies,
+                currentMessageReactions,
+              ),
+              reactions: getMessageUIReactions(
+                currentMessage,
+                currentMessageReactions,
+              ),
+            },
+          ]
         : [{ ...currentMessage, replies: [], reactions: [] }]
 
       groupedMessages[groupedMessages.length - 1] = {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- render replies for all messages. They were being stored in textile properly. for any 'new message' (at the beginning of a new group based on time or message sender), replies and reactions were being set to []. Now they're set based on info coming from textile.
- Fix type name to reflect past updates

**Which issue(s) this PR fixes** 🔨
AP-271

<!--AP-100-->

**Special notes for reviewers** 🗒️
- responses are still buggy. Replies will have the same responses as their parent messages

**Additional comments** 🎤
