### PR TITLE
fix(reaction): fixes emoji reacts for reply messages of inner messages

### DIFF
--- a/utilities/Messaging.ts
+++ b/utilities/Messaging.ts
@@ -17,7 +17,9 @@ function messageRepliesToUIReplies(
   replies: ReplyMessage[],
   reactions: ReactionsTracker,
 ) {
-  return replies.map((reply) => replyMessageToUIReply(reply, reactions[reply.id]))
+  return replies.map((reply) =>
+    replyMessageToUIReply(reply, reactions[reply.id]),
+  )
 }
 
 function getMessageUIReactions(message: Message, reactions: ReactionMessage[]) {
@@ -113,7 +115,7 @@ export function groupMessages(
             ...currentMessage,
             replies: messageRepliesToUIReplies(
               currentMessageReplies,
-              reactions
+              reactions,
             ),
             reactions: getMessageUIReactions(
               currentMessage,
@@ -135,7 +137,7 @@ export function groupMessages(
               ...currentMessage,
               replies: messageRepliesToUIReplies(
                 currentMessageReplies,
-                currentMessageReactions,
+                reactions,
               ),
               reactions: getMessageUIReactions(
                 currentMessage,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Pretty specific use case, but I noticed something was still buggy after mine and David's fixes earlier.

Emoji reacts to a reply of a message which _is not_ the first message of a group were still not working.

With this, two reactions for 'reply test' will now appear

![image](https://user-images.githubusercontent.com/33670767/148890581-f005b5c0-89b1-4401-bca2-13af966a8056.png)

