### PR TITLE
fix(media): fix settings tooltip layered issue AP-412

### DIFF
--- a/components/ui/Chat/Scroll/Scroll.less
+++ b/components/ui/Chat/Scroll/Scroll.less
@@ -51,7 +51,7 @@
   width: calc(@full - @normal-spacing * 1.8);
   margin-left: @normal-spacing;
   border-radius: 0 0 @corner-rounding @corner-rounding;
-  z-index: @base-z-index + 3;
+  z-index: @base-z-index + 11;
   padding: (@light-spacing / 2 ) @light-spacing;
   span {
     float: right;

--- a/components/views/media/Media.less
+++ b/components/views/media/Media.less
@@ -1,6 +1,6 @@
 #mediastream {
   position: absolute;
-  z-index: @base-z-index + 4; // Keep +1 wrt .new-message-alert z-index in ChatScroll.less
+  z-index: @base-z-index + 12; // Keep +1 wrt .new-message-alert z-index in ChatScroll.less
   top: @toolbar-height;
   height: auto;
   max-height: 25.5rem;


### PR DESCRIPTION
**What this PR does** 📖
Fix ' When the user hovers over the Settings icon in the media viewer half of the Settings label will be layered behind the Sidemenu'
**Which issue(s) this PR fixes** 🔨

AP-412
