### PR TITLE
fix(enhancer): close enhancer(emoji,glyph) after choose

### DIFF
--- a/components/views/chat/enhancers/Enhancers.vue
+++ b/components/views/chat/enhancers/Enhancers.vue
@@ -30,8 +30,8 @@ export default Vue.extend({
   props: {
     sidebar: {
       type: Boolean,
-      default: false
-    }
+      default: false,
+    },
   },
   computed: {
     ...mapState(['ui']),
@@ -96,11 +96,11 @@ export default Vue.extend({
           emoji,
           reactTo: this.ui.settingReaction.messageID,
         })
-        this.toggleEnhancers()
       } else {
         this.$store.commit('ui/chatbarContent', this.ui.chatbarContent + emoji)
       }
       this.$store.commit('ui/updateMostUsedEmoji', { emoji, name: emojiName })
+      this.toggleEnhancers()
     },
     /**
      * @method setRoute DocsTODO

--- a/components/views/chat/enhancers/glyphs/item/Item.vue
+++ b/components/views/chat/enhancers/glyphs/item/Item.vue
@@ -27,15 +27,15 @@ export default Vue.extend({
     },
     sendOnClick: { type: Boolean, default: false, required: false },
   },
-  computed: {
-    getSrc(): string {
-      return this.isLoaded ? this.src : loadImg
-    },
-  },
   data() {
     return {
       isLoaded: false,
     }
+  },
+  computed: {
+    getSrc(): string {
+      return this.isLoaded ? this.src : loadImg
+    },
   },
   methods: {
     mouseOver() {
@@ -67,6 +67,10 @@ export default Vue.extend({
       this.$store.commit('ui/updateRecentGlyphs', {
         pack: this.pack,
         url: this.src,
+      })
+      this.$store.commit('ui/toggleEnhancers', {
+        show: false,
+        floating: !!this.$device.isMobile,
       })
     },
     setLoaded() {


### PR DESCRIPTION
**What this PR does** 📖
Fix Emoji/Glyph menu should close after a user has selected and sent an emoji. (See discord for an example)

**Which issue(s) this PR fixes** 🔨

AP-488

**Special notes for reviewers** 🗒️
For now when send emoji, it does not appear in chatbar and that's what David is currently working.
