### PR TITLE
feat(profile): basic functionality for profile pictures AP-476

### DIFF
--- a/components/interactables/QuickProfile/QuickProfile.html
+++ b/components/interactables/QuickProfile/QuickProfile.html
@@ -12,7 +12,7 @@
       :type="user.profilePicture ? 'image' : 'random'"
       :seed="user.address"
       :size="45"
-      :source="user.profilePicture"
+      :source="src"
     />
   </div>
   <TypographyTitle :text="user.name" :size="6" />

--- a/components/interactables/QuickProfile/QuickProfile.html
+++ b/components/interactables/QuickProfile/QuickProfile.html
@@ -8,7 +8,12 @@
     <InteractablesClose :action="close" />
   </div>
   <div class="header">
-    <UiCircle type="random" :seed="user.address" :size="45" />
+    <UiCircle
+      :type="user.profilePicture ? 'image' : 'random'"
+      :seed="user.address"
+      :size="45"
+      :source="user.profilePicture"
+    />
   </div>
   <TypographyTitle :text="user.name" :size="6" />
   <TypographyText

--- a/components/interactables/QuickProfile/QuickProfile.html
+++ b/components/interactables/QuickProfile/QuickProfile.html
@@ -9,7 +9,7 @@
   </div>
   <div class="header">
     <UiCircle
-      :type="user.profilePicture ? 'image' : 'random'"
+      :type="src ? 'image' : 'random'"
       :seed="user.address"
       :size="45"
       :source="src"

--- a/components/interactables/QuickProfile/QuickProfile.html
+++ b/components/interactables/QuickProfile/QuickProfile.html
@@ -22,7 +22,7 @@
     class="address"
   />
   <TypographyText :text="user.status" :size="6" />
-  <template v-if="!isMe()">
+  <template v-if="!isMe">
     <UiHorizontalRule />
     <InteractablesInputGroup
       type="primary"

--- a/components/interactables/QuickProfile/QuickProfile.vue
+++ b/components/interactables/QuickProfile/QuickProfile.vue
@@ -35,6 +35,9 @@ export default Vue.extend({
     isMe(): boolean {
       return this.accounts.details.textilePubkey === this.user?.textilePubkey
     },
+    src(): string {
+      return `${this.$Config.textile.browser}/ipfs/${this.user?.profilePicture}`
+    },
   },
   mounted() {
     this.handleOverflow()

--- a/components/interactables/QuickProfile/QuickProfile.vue
+++ b/components/interactables/QuickProfile/QuickProfile.vue
@@ -36,7 +36,8 @@ export default Vue.extend({
       return this.accounts.details.textilePubkey === this.user?.textilePubkey
     },
     src(): string {
-      return `${this.$Config.textile.browser}/ipfs/${this.user?.profilePicture}`
+      const hash = this.user?.profilePicture
+      return hash ? `${this.$Config.textile.browser}/ipfs/${hash}` : ''
     },
   },
   mounted() {

--- a/components/interactables/QuickProfile/QuickProfile.vue
+++ b/components/interactables/QuickProfile/QuickProfile.vue
@@ -5,6 +5,15 @@ import { mapState } from 'vuex'
 import { ArrowRightIcon } from 'satellite-lucide-icons'
 import { User } from '~/types/ui/user'
 
+declare module 'vue/types/vue' {
+  interface Vue {
+    text: string
+    maxChars: number
+    close: () => void
+    handleOverflow: () => void
+  }
+}
+
 export default Vue.extend({
   components: {
     ArrowRightIcon,
@@ -23,6 +32,9 @@ export default Vue.extend({
   },
   computed: {
     ...mapState(['ui', 'accounts']),
+    isMe(): boolean {
+      return this.accounts.details.textilePubkey === this.user?.textilePubkey
+    },
   },
   mounted() {
     this.handleOverflow()
@@ -74,12 +86,6 @@ export default Vue.extend({
         text: this.text,
       })
       this.close()
-    },
-    isMe() {
-      return (
-        this.accounts.details &&
-        this.accounts.details.textilePubkey === this.user?.textilePubkey
-      )
     },
   },
 })

--- a/components/interactables/QuickProfile/QuickProfile.vue
+++ b/components/interactables/QuickProfile/QuickProfile.vue
@@ -2,8 +2,8 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue'
 import { mapState } from 'vuex'
-import { User } from '~/types/ui/user'
 import { ArrowRightIcon } from 'satellite-lucide-icons'
+import { User } from '~/types/ui/user'
 
 export default Vue.extend({
   components: {

--- a/components/ui/Circle/Circle.html
+++ b/components/ui/Circle/Circle.html
@@ -4,7 +4,7 @@
   @click="() => {$emit('click')}"
 >
   <img
-    :src="source"
+    :src="fetchSource"
     v-if="type === 'image' && source"
     alt="Circle Image"
     :class="`${square ? 'is-square' : 'is-rounded'} image`"

--- a/components/ui/Circle/Circle.html
+++ b/components/ui/Circle/Circle.html
@@ -1,21 +1,19 @@
-<div 
+<div
   :class="`${square ? 'is-square' : 'is-rounded'} ${type === 'icon' ? 'circle-flex' : 'circle'}`"
   :style="`font-size: ${size * 0.55}px; height: ${size}px; width: ${size}px; background: ${color};`"
   @click="() => {$emit('click')}"
-  >
+>
   <img
     :src="source"
     v-if="type === 'image' && source"
-    alt="Cirlce Image"
-    :class="`${square ? 'is-square' : 'is-rounded'} image`">
-  <UiSatelliteCircle 
+    alt="Circle Image"
+    :class="`${square ? 'is-square' : 'is-rounded'} image`"
+  />
+  <UiSatelliteCircle
     v-else-if="type === 'random'"
     :address="seed"
     :name="name"
   />
-  <UiDynamicIcon
-    size="1x"
-    :icon="icon"
-    v-else-if="icon" />
+  <UiDynamicIcon size="1x" :icon="icon" v-else-if="icon" />
   <slot></slot>
 </div>

--- a/components/ui/Circle/Circle.html
+++ b/components/ui/Circle/Circle.html
@@ -4,7 +4,7 @@
   @click="() => {$emit('click')}"
 >
   <img
-    :src="fetchSource"
+    :src="source"
     v-if="type === 'image' && source"
     alt="Circle Image"
     :class="`${square ? 'is-square' : 'is-rounded'} image`"

--- a/components/ui/Circle/Circle.vue
+++ b/components/ui/Circle/Circle.vue
@@ -1,6 +1,5 @@
 <template src="./Circle.html"></template>
 <script lang="ts">
-// @ts-ignore - Missing Types
 import Vue, { PropType } from 'vue'
 import { CircleType } from './types'
 

--- a/components/ui/Circle/Circle.vue
+++ b/components/ui/Circle/Circle.vue
@@ -69,6 +69,11 @@ export default Vue.extend({
       default: '',
     },
   },
+  computed: {
+    fetchSource() {
+      return `${this.$Config.textile.browser}/ipfs/${this.source}`
+    },
+  },
 })
 </script>
 <style scoped lang="less" src="./Circle.less"></style>

--- a/components/ui/Circle/Circle.vue
+++ b/components/ui/Circle/Circle.vue
@@ -69,11 +69,6 @@ export default Vue.extend({
       default: '',
     },
   },
-  computed: {
-    fetchSource() {
-      return `${this.$Config.textile.browser}/ipfs/${this.source}`
-    },
-  },
 })
 </script>
 <style scoped lang="less" src="./Circle.less"></style>

--- a/components/ui/User/State/State.vue
+++ b/components/ui/User/State/State.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="user-state">
-    <UiCircle v-if="src" type="image" :source="src" :size="35" />
-    <UiCircle v-else type="random" :seed="user.address" :size="35" />
+    <UiCircle
+      :type="src ? 'image' : 'random'"
+      :seed="user.address"
+      :size="35"
+      :source="src"
+    />
     <circle-icon
       v-if="user.state !== 'mobile' && !isTyping"
       size="1x"

--- a/components/ui/User/State/State.vue
+++ b/components/ui/User/State/State.vue
@@ -1,14 +1,15 @@
 <template>
   <div class="user-state">
-    <UiCircle type="random" :seed="user.address" :size="35" />
+    <UiCircle v-if="src" type="image" :source="src" :size="35" />
+    <UiCircle v-else type="random" :seed="user.address" :size="35" />
     <circle-icon
-      size="1x"
       v-if="user.state !== 'mobile' && !isTyping"
+      size="1x"
       :class="`status is-${user.state}`"
     />
     <smartphone-icon
-      size="1x"
       v-else-if="user.state === 'mobile'"
+      size="1x"
       :class="`mobile-status is-${user.state}`"
     />
     <UiChatTypingIndicator v-else />
@@ -17,8 +18,8 @@
 
 <script lang="ts">
 import Vue, { PropType } from 'vue'
-import { User } from '~/types/ui/user'
 import { SmartphoneIcon, CircleIcon } from 'satellite-lucide-icons'
+import { User } from '~/types/ui/user'
 
 export default Vue.extend({
   components: {
@@ -35,6 +36,7 @@ export default Vue.extend({
       default: false,
       required: false,
     },
+    src: { type: String, default: '', required: false },
   },
 })
 </script>

--- a/components/views/chat/conversation/Conversation.vue
+++ b/components/views/chat/conversation/Conversation.vue
@@ -18,7 +18,7 @@ export default Vue.extend({
   },
   computed: {
     ...mapState(['ui', 'textile']),
-  }
+  },
 })
 </script>
 <style scoped lang="less" src="./Conversation.less"></style>

--- a/components/views/chat/group/Group.html
+++ b/components/views/chat/group/Group.html
@@ -1,7 +1,7 @@
 <div class="is-group">
   <span v-on:click="showQuickProfile">
     <UiCircle
-      :type="src? 'image' :'random'"
+      :type="src ? 'image' :'random'"
       :seed="address"
       :size="35"
       :source="src"

--- a/components/views/chat/group/Group.html
+++ b/components/views/chat/group/Group.html
@@ -1,6 +1,11 @@
 <div class="is-group">
   <span v-on:click="showQuickProfile">
-    <UiCircle type="random" :seed="address" :size="35" />
+    <UiCircle
+      :type="src? 'image' :'random'"
+      :seed="address"
+      :size="35"
+      :source="src"
+    />
   </span>
   <div class="group-body">
     <div class="group-heading">

--- a/components/views/chat/group/Group.vue
+++ b/components/views/chat/group/Group.vue
@@ -40,9 +40,15 @@ export default Vue.extend({
     src() {
       // if sender is you
       if (this.address === 'unknown') {
-        return this.accounts.details.profilePicture
+        const myHash = this.accounts.details.profilePicture
+        return myHash ? `${this.$Config.textile.browser}/ipfs/${myHash}` : ''
       }
-      return this.friends.all.find((e: Friend) => e.activeChat).profilePicture
+
+      const hash = this.friends.all.find(
+        (e: Friend) => e.activeChat,
+      ).profilePicture
+
+      return hash ? `${this.$Config.textile.browser}/ipfs/${hash}` : ''
     },
   },
   created() {

--- a/components/views/chat/group/Group.vue
+++ b/components/views/chat/group/Group.vue
@@ -37,7 +37,7 @@ export default Vue.extend({
       // $mock.users.filter(u => u.address === group.from)[0].badge
       return ''
     },
-    src() {
+    src(): string {
       // if sender is you
       if (this.address === 'unknown') {
         const myHash = this.accounts.details.profilePicture

--- a/components/views/chat/group/Group.vue
+++ b/components/views/chat/group/Group.vue
@@ -1,11 +1,10 @@
 <template src="./Group.html"></template>
 <script lang="ts">
 import Vue, { PropType } from 'vue'
-
+import { mapState } from 'vuex'
 import { Config } from '~/config'
-
 import { Group } from '~/types/messaging'
-import { User } from '~/types/ui/user'
+import { Friend } from '~/types/ui/friends'
 import {
   getUsernameFromState,
   getAddressFromState,
@@ -27,6 +26,7 @@ export default Vue.extend({
     }
   },
   computed: {
+    ...mapState(['friends', 'accounts']),
     address() {
       return getAddressFromState(this.group.from, this.$store.state)
     },
@@ -37,19 +37,12 @@ export default Vue.extend({
       // $mock.users.filter(u => u.address === group.from)[0].badge
       return ''
     },
-  },
-  methods: {
-    /**
-     * @method showQuickProfile
-     * @description Shows quickprofile component for user by setting quickProfile to true in state and setQuickProfilePosition
-     * to the current group components click event data
-     * @param e Event object from group component click
-     * @example v-on:click="showQuickProfile"
-     */
-    showQuickProfile(e: Event) {
-      const selectedUser = getFullUserInfoFromState(this.group.from, this.$store.state)
-      this.$store.commit('ui/setQuickProfilePosition', e)
-      this.$store.commit('ui/quickProfile', selectedUser)
+    src() {
+      // if sender is you
+      if (this.address === 'unknown') {
+        return this.accounts.details.profilePicture
+      }
+      return this.friends.all.find((e: Friend) => e.activeChat).profilePicture
     },
   },
   created() {
@@ -60,11 +53,28 @@ export default Vue.extend({
     this.$data.timestampRefreshInterval = refreshTimestampInterval(
       this.group.at,
       setTimestamp,
-      Config.chat.timestampUpdateInterval
+      Config.chat.timestampUpdateInterval,
     )
   },
   beforeDestroy() {
     clearInterval(this.$data.refreshTimestampEveryMinute)
+  },
+  methods: {
+    /**
+     * @method showQuickProfile
+     * @description Shows quickprofile component for user by setting quickProfile to true in state and setQuickProfilePosition
+     * to the current group components click event data
+     * @param e Event object from group component click
+     * @example v-on:click="showQuickProfile"
+     */
+    showQuickProfile(e: Event) {
+      const selectedUser = getFullUserInfoFromState(
+        this.group.from,
+        this.$store.state,
+      )
+      this.$store.commit('ui/setQuickProfilePosition', e)
+      this.$store.commit('ui/quickProfile', selectedUser)
+    },
   },
 })
 </script>

--- a/components/views/files/controls/Controls.html
+++ b/components/views/files/controls/Controls.html
@@ -17,9 +17,9 @@
       size="small"
       :action="()=>{show('newfolder')}"
     >
-    <folder-plus-icon size="1x" />
-  </InteractablesButton>
-    <FilesUpload editable="true" type="button" />
+      <folder-plus-icon size="1x" />
+    </InteractablesButton>
+    <FilesUpload :editable="true" type="button" />
   </div>
   <div>
     <FilesViewSwitcher :changeView="changeView" />

--- a/components/views/files/upload/Upload.vue
+++ b/components/views/files/upload/Upload.vue
@@ -1,4 +1,4 @@
-<template src='./Upload.html'></template>
+<template src="./Upload.html"></template>
 
 <script lang="ts">
 import { FilePlusIcon, PlusIcon, XIcon } from 'satellite-lucide-icons'
@@ -15,6 +15,7 @@ declare module 'vue/types/vue' {
     cancelUpload: () => void
     finishUploads: () => void
     dispatchFile: (file: UploadDropItemType) => void
+    alertNsfwFile: () => void
   }
 }
 
@@ -51,7 +52,7 @@ export default Vue.extend({
       aiScanning: false,
       fileAmount: 0,
       containsNsfw: false,
-      alertNsfw: false
+      alertNsfw: false,
     }
   },
   computed: {
@@ -118,7 +119,7 @@ export default Vue.extend({
     loadPicture(item: UploadDropItemType) {
       if (!item.file) return
       const reader = new FileReader()
-      reader.onload = function(e: Event | any) {
+      reader.onload = function (e: Event | any) {
         if (e.target) item.url = e.target.result
       }
       reader.readAsDataURL(item.file)
@@ -166,7 +167,6 @@ export default Vue.extend({
           document.body.style.cursor = PropCommonEnum.DEFAULT
           this.$store.dispatch('textile/clearUploadStatus')
         }
-
       }
     },
     alertNsfwFile() {
@@ -184,15 +184,17 @@ export default Vue.extend({
      * @description Sends a singular file to textile.
      */
     async dispatchFile(file: FileType) {
-      await this.$store.dispatch('textile/sendFileMessage', {
-        to: this.recipient.textilePubkey,
-        file: file,
-      }).then(() => {
-        this.finishUploads()
-      })
+      await this.$store
+        .dispatch('textile/sendFileMessage', {
+          to: this.recipient.textilePubkey,
+          file,
+        })
+        .then(() => {
+          this.finishUploads()
+        })
         .catch((error) => {
           if (error) {
-            new Error(error)
+            this.$Logger.log('file send error', error)
             document.body.style.cursor = PropCommonEnum.DEFAULT
             this.$store.dispatch('textile/clearUploadStatus')
           }
@@ -214,7 +216,7 @@ export default Vue.extend({
           }
         }
       })
-      nsfwCheck.map((file: UploadDropItemType) => {
+      nsfwCheck.forEach((file: UploadDropItemType) => {
         this.$data.fileAmount = nsfwCheck.length
         this.dispatchFile(file)
       })
@@ -223,4 +225,4 @@ export default Vue.extend({
 })
 </script>
 
-<style scoped lang='less' src='./Upload.less'></style>
+<style scoped lang="less" src="./Upload.less"></style>

--- a/components/views/files/upload/Upload.vue
+++ b/components/views/files/upload/Upload.vue
@@ -203,6 +203,7 @@ export default Vue.extend({
     /**
      * @method sendMessage
      * @description Sends action to Upload the file to textile.
+     * eslint is expecting return. may need refactoring
      */
     async sendMessage() {
       const nsfwCheck = this.$data.files.filter((file: UploadDropItemType) => {

--- a/components/views/friends/add/Add.vue
+++ b/components/views/friends/add/Add.vue
@@ -8,11 +8,11 @@ import QrcodeVue from 'qrcode.vue'
 import { UserPlusIcon } from 'satellite-lucide-icons'
 
 import Vue from 'vue'
-import ServerProgram from '~/libraries/Solana/ServerProgram/ServerProgram'
-import { Friend } from '~/types/ui/friends'
 
+import { debounce } from 'lodash'
+import { Friend } from '~/types/ui/friends'
+import ServerProgram from '~/libraries/Solana/ServerProgram/ServerProgram'
 import SolanaManager from '~/libraries/Solana/SolanaManager/SolanaManager'
-import _, { debounce } from 'lodash'
 
 export default Vue.extend({
   components: {
@@ -30,7 +30,7 @@ export default Vue.extend({
     }
   },
   methods: {
-    _searchFriend: _.debounce(async function(this:any) {
+    _searchFriend: debounce(async function (this: any) {
       if (this.accountID.length >= 40) {
         return await this.searchFriend()
       }
@@ -45,10 +45,10 @@ export default Vue.extend({
         this.error = this.$t('friends.self_add') as string
         return
       }
-      
+
       if (
         this.$store.state.friends.all.filter(
-          (f: Friend) => f.account.accountId === accountID
+          (f: Friend) => f.account.accountId === accountID,
         ).length === 1
       ) {
         this.error = this.$t('friends.already_friend') as string

--- a/components/views/friends/add/Add.vue
+++ b/components/views/friends/add/Add.vue
@@ -1,6 +1,5 @@
 <template src="./Add.html"></template>
 <script lang="ts">
-// @ts-ignore
 import { PublicKey } from '@solana/web3.js'
 // @ts-ignore
 import QrcodeVue from 'qrcode.vue'

--- a/components/views/friends/friend/Friend.html
+++ b/components/views/friends/friend/Friend.html
@@ -1,5 +1,5 @@
 <div class="friend">
-  <UiUserState :user="friend" />
+  <UiUserState :user="friend" :src="src" />
   <div class="description">
     <TypographySubtitle :size="6" :text="friend.name" />
     <TypographyText :text="friend.status" />
@@ -14,7 +14,7 @@
       :data-tooltip="$t('friends.accept')"
       :loading="loading === 'accept'"
       :action="acceptFriendRequest"
-      >
+    >
       <check-icon size="1x" />
     </InteractablesButton>
     <InteractablesButton
@@ -24,8 +24,9 @@
       class="has-tooltip has-tooltip-primary has-tooltip-bottom has-tooltip-desktop-only"
       :data-tooltip="$t('friends.decline')"
       :loading="loading === 'decline'"
-      :action="declineFriendRequest">
-      <x-icon size="1x"/>
+      :action="declineFriendRequest"
+    >
+      <x-icon size="1x" />
     </InteractablesButton>
   </div>
   <div class="controls" v-else-if="blocked">
@@ -34,7 +35,8 @@
       size="small"
       class="has-tooltip has-tooltip-primary has-tooltip-bottom has-tooltip-desktop-only"
       :data-tooltip="$t('friends.unblock')"
-      :action="() => {}">
+      :action="() => {}"
+    >
       <x-icon size="1x" />
     </InteractablesButton>
   </div>
@@ -45,7 +47,8 @@
       class="has-tooltip has-tooltip-primary has-tooltip-bottom has-tooltip-desktop-only"
       :data-tooltip="$t('friends.send')"
       :loading="loading === 'sending'"
-      :action="createFriendRequest">
+      :action="createFriendRequest"
+    >
       <check-icon size="1x" />
     </InteractablesButton>
   </div>
@@ -56,7 +59,8 @@
       size="small"
       class="has-tooltip has-tooltip-primary has-tooltip-bottom has-tooltip-desktop-only"
       :data-tooltip="$t('friends.message')"
-      :action="sendMessageRequest">
+      :action="sendMessageRequest"
+    >
       <message-square-icon size="1x" />
     </InteractablesButton>
     <InteractablesButton
@@ -65,7 +69,8 @@
       class="has-tooltip has-tooltip-primary has-tooltip-bottom has-tooltip-desktop-only"
       :data-tooltip="$t('friends.options')"
       :loading="loading === 'options'"
-      :action="contextMenu">
+      :action="contextMenu"
+    >
       <more-vertical-icon size="1x" />
     </InteractablesButton>
   </div>

--- a/components/views/friends/friend/Friend.vue
+++ b/components/views/friends/friend/Friend.vue
@@ -57,16 +57,12 @@ export default Vue.extend({
   },
   computed: {
     src() {
-      if (this.friend?.profilePicture) {
-        return `${this.$Config.textile.browser}/ipfs/${this.friend.profilePicture}`
-      }
-      if (this.friend?.photoHash) {
-        return `${this.$Config.textile.browser}/ipfs/${this.friend.photoHash}`
-      }
-      if (this.friend?.request?.userInfo?.photoHash) {
-        return `${this.$Config.textile.browser}/ipfs/${this.friend.request.userInfo.photoHash}`
-      }
-      return ''
+      return (
+        this.friend?.photoHash ||
+        this.friend?.profilePicture ||
+        this.friend?.request?.userInfo?.photoHash ||
+        ''
+      )
     },
   },
   methods: {

--- a/components/views/friends/friend/Friend.vue
+++ b/components/views/friends/friend/Friend.vue
@@ -55,6 +55,20 @@ export default Vue.extend({
       contextMenuValues: [{ text: 'Remove Friend', func: this.removeFriend }],
     }
   },
+  computed: {
+    src() {
+      if (this.friend?.profilePicture) {
+        return `${this.$Config.textile.browser}/ipfs/${this.friend.profilePicture}`
+      }
+      if (this.friend?.photoHash) {
+        return `${this.$Config.textile.browser}/ipfs/${this.friend.photoHash}`
+      }
+      if (this.friend?.request?.userInfo?.photoHash) {
+        return `${this.$Config.textile.browser}/ipfs/${this.friend.request.userInfo.photoHash}`
+      }
+      return ''
+    },
+  },
   methods: {
     async createFriendRequest() {
       this.loading = 'sending'

--- a/components/views/friends/friend/Friend.vue
+++ b/components/views/friends/friend/Friend.vue
@@ -18,6 +18,7 @@ import { ContextMenu } from '~/components/mixins/UI/ContextMenu'
 declare module 'vue/types/vue' {
   interface Vue {
     removeFriend: () => void
+    loading: string
   }
 }
 
@@ -56,13 +57,12 @@ export default Vue.extend({
     }
   },
   computed: {
-    src() {
-      return (
+    src(): string {
+      const hash =
         this.friend?.photoHash ||
         this.friend?.profilePicture ||
-        this.friend?.request?.userInfo?.photoHash ||
-        ''
-      )
+        this.friend?.request?.userInfo?.photoHash
+      return hash ? `${this.$Config.textile.browser}/ipfs/${hash}` : ''
     },
   },
   methods: {

--- a/components/views/navigation/sidebar/status/Status.html
+++ b/components/views/navigation/sidebar/status/Status.html
@@ -1,15 +1,18 @@
 <div id="status">
-  <UiUserState :user="{address: accounts.active, state: accounts.details.state}" />
+  <UiUserState
+    :user="{address: accounts.active, state: accounts.details.state}"
+    :src="src"
+  />
   <div
     class="user-info has-tooltip has-tooltip-top has-tooltip-primary"
     v-on:click="$toast.show($t('ui.copied'))"
     :data-tooltip="$t('controls.copy_id')"
     v-clipboard:copy="accounts.active"
   >
-    <TypographyTitle 
-      :text="accounts.details.name" 
+    <TypographyTitle :text="accounts.details.name" :size="6" />
+    <TypographySubtitle
+      :text="accounts.details.status || 'No status set.'"
       :size="6"
-      />
-    <TypographySubtitle :text="accounts.details.status || 'No status set.'" :size="6"/>
+    />
   </div>
 </div>

--- a/components/views/navigation/sidebar/status/Status.html
+++ b/components/views/navigation/sidebar/status/Status.html
@@ -11,7 +11,7 @@
   >
     <TypographyTitle :text="accounts.details.name" :size="6" />
     <TypographySubtitle
-      :text="accounts.details.status || 'No status set.'"
+      :text="accounts.details.status || $t('pages.settings.accounts.no_status')"
       :size="6"
     />
   </div>

--- a/components/views/navigation/sidebar/status/Status.vue
+++ b/components/views/navigation/sidebar/status/Status.vue
@@ -8,10 +8,7 @@ export default Vue.extend({
   computed: {
     ...mapState(['accounts']),
     src() {
-      if (this.accounts?.details?.profilePicture) {
-        return `${this.$Config.textile.browser}/ipfs/${this.accounts.details.profilePicture}`
-      }
-      return ''
+      return this.accounts.details.profilePicture
     },
   },
 })

--- a/components/views/navigation/sidebar/status/Status.vue
+++ b/components/views/navigation/sidebar/status/Status.vue
@@ -7,6 +7,12 @@ import { mapState } from 'vuex'
 export default Vue.extend({
   computed: {
     ...mapState(['accounts']),
+    src() {
+      if (this.accounts?.details?.profilePicture) {
+        return `${this.$Config.textile.browser}/ipfs/${this.accounts.details.profilePicture}`
+      }
+      return ''
+    },
   },
 })
 </script>

--- a/components/views/navigation/sidebar/status/Status.vue
+++ b/components/views/navigation/sidebar/status/Status.vue
@@ -7,7 +7,7 @@ import { mapState } from 'vuex'
 export default Vue.extend({
   computed: {
     ...mapState(['accounts']),
-    src() {
+    src(): string {
       const hash = this.accounts.details.profilePicture
       return hash ? `${this.$Config.textile.browser}/ipfs/${hash}` : ''
     },

--- a/components/views/navigation/sidebar/status/Status.vue
+++ b/components/views/navigation/sidebar/status/Status.vue
@@ -8,7 +8,8 @@ export default Vue.extend({
   computed: {
     ...mapState(['accounts']),
     src() {
-      return this.accounts.details.profilePicture
+      const hash = this.accounts.details.profilePicture
+      return hash ? `${this.$Config.textile.browser}/ipfs/${hash}` : ''
     },
   },
 })

--- a/components/views/navigation/toolbar/Toolbar.html
+++ b/components/views/navigation/toolbar/Toolbar.html
@@ -2,9 +2,10 @@
   <div class="circle-container" v-if="!$device.isMobile">
     <UiUserState :user="user" v-if="!server" />
     <UiCircle
-      type="random"
+      :type="src ? 'image' : 'random'"
       :seed="`${server ? server.address : '0xdf9eb223bafbe5c5271415c75aecd68c21fe3d7f'}`"
       :size="35"
+      :source="src"
       v-else
     />
   </div>

--- a/components/views/navigation/toolbar/Toolbar.vue
+++ b/components/views/navigation/toolbar/Toolbar.vue
@@ -83,10 +83,7 @@ export default Vue.extend({
     },
     ModalWindows: () => ModalWindows,
     src() {
-      if (this.server?.profilePicture) {
-        return `${this.$Config.textile.browser}/ipfs/${this.server.profilePicture}`
-      }
-      return ''
+      return this.server?.profilePicture ?? ''
     },
   },
   methods: {

--- a/components/views/navigation/toolbar/Toolbar.vue
+++ b/components/views/navigation/toolbar/Toolbar.vue
@@ -82,8 +82,10 @@ export default Vue.extend({
       },
     },
     ModalWindows: () => ModalWindows,
-    src() {
-      return this.server?.profilePicture ?? ''
+    src(): string {
+      // @ts-ignore curently reading user as type Server. Will likely be reworked with server update
+      const hash = this.server?.profilePicture
+      return hash ? `${this.$Config.textile.browser}/ipfs/${hash}` : ''
     },
   },
   methods: {

--- a/components/views/navigation/toolbar/Toolbar.vue
+++ b/components/views/navigation/toolbar/Toolbar.vue
@@ -1,4 +1,4 @@
-<template src="./Toolbar.html" />
+<template src="./Toolbar.html"></template>
 
 <script lang="ts">
 import Vue, { PropType } from 'vue'
@@ -82,6 +82,12 @@ export default Vue.extend({
       },
     },
     ModalWindows: () => ModalWindows,
+    src() {
+      if (this.server?.profilePicture) {
+        return `${this.$Config.textile.browser}/ipfs/${this.server.profilePicture}`
+      }
+      return ''
+    },
   },
   methods: {
     /**

--- a/components/views/settings/pages/profile/Profile.html
+++ b/components/views/settings/pages/profile/Profile.html
@@ -28,7 +28,7 @@
           <div class="column profile-photo-column">
             <div class="profile-photo">
               <input ref="file" class="input-file" type="file" @change="selectProfileImage" accept="image/*"></input>
-              <UiCircle :type="croppedImage? 'image' : 'random' " :source="croppedImage" seed="0x0000000000000000000000000000000000000000" :size="isSmallScreen ? 55 : 75"/>
+              <UiCircle :type="croppedImage || accounts.details.profilePicture ? 'image' : 'random' " :source="src" seed="0x0000000000000000000000000000000000000000" :size="isSmallScreen ? 55 : 75"/>
               <UiCircle 
                 type="icon" 
                 @click="openFileDialog"

--- a/components/views/settings/pages/profile/index.vue
+++ b/components/views/settings/pages/profile/index.vue
@@ -5,13 +5,12 @@ import Vue from 'vue'
 import { mapState } from 'vuex'
 
 import { ClipboardIcon } from 'satellite-lucide-icons'
-
-
 import { sampleProfileInfo } from '~/mock/profile'
+import { AccountsState } from '~/store/accounts/types'
 
 declare module 'vue/types/vue' {
   interface Vue {
-    accounts: any
+    accounts: AccountsState
   }
 }
 export default Vue.extend({
@@ -38,6 +37,13 @@ export default Vue.extend({
       if (this.$mq === 'sm' || (this.ui.settingsSideBar && this.$mq === 'md'))
         return true
       return false
+    },
+    src(): string {
+      if (this.croppedImage) {
+        return this.croppedImage
+      }
+      const hash = this.accounts.details.profilePicture
+      return hash ? `${this.$Config.textile.browser}/ipfs/${hash}` : ''
     },
   },
   methods: {

--- a/components/views/user/User.html
+++ b/components/views/user/User.html
@@ -1,8 +1,12 @@
 <div class="user" @contextmenu="contextMenu" v-on:click="navigateToUser">
-  <UiUserState :user="user" :isTyping="isTyping" />
+  <UiUserState :user="user" :isTyping="isTyping" :src="src" />
   <div class="user-info">
     <TypographyTitle :size="6" :text="user.name" />
-    <TypographySubtitle v-if="user.last_message && user.last_message.length > 0" :size="6" :text="user.last_message" />
+    <TypographySubtitle
+      v-if="user.last_message && user.last_message.length > 0"
+      :size="6"
+      :text="user.last_message"
+    />
     <TypographySubtitle v-else :size="6" :text="user.status" />
   </div>
   <div class="user-chat-details">

--- a/components/views/user/User.vue
+++ b/components/views/user/User.vue
@@ -47,6 +47,14 @@ export default Vue.extend({
       ],
     }
   },
+  computed: {
+    src() {
+      if (this.user?.profilePicture) {
+        return `${this.$Config.textile.browser}/ipfs/${this.user?.profilePicture}`
+      }
+      return ''
+    },
+  },
   methods: {
     testFunc() {
       this.$Logger.log('User Context', 'Test func')

--- a/components/views/user/User.vue
+++ b/components/views/user/User.vue
@@ -48,7 +48,7 @@ export default Vue.extend({
     }
   },
   computed: {
-    src() {
+    src(): string {
       const hash = this.user?.profilePicture
       return hash ? `${this.$Config.textile.browser}/ipfs/${hash}` : ''
     },

--- a/components/views/user/User.vue
+++ b/components/views/user/User.vue
@@ -49,7 +49,8 @@ export default Vue.extend({
   },
   computed: {
     src() {
-      return this.user?.profilePicture ?? ''
+      const hash = this.user?.profilePicture
+      return hash ? `${this.$Config.textile.browser}/ipfs/${hash}` : ''
     },
   },
   methods: {

--- a/components/views/user/User.vue
+++ b/components/views/user/User.vue
@@ -49,10 +49,7 @@ export default Vue.extend({
   },
   computed: {
     src() {
-      if (this.user?.profilePicture) {
-        return `${this.$Config.textile.browser}/ipfs/${this.user?.profilePicture}`
-      }
-      return ''
+      return this.user?.profilePicture ?? ''
     },
   },
   methods: {

--- a/components/views/user/create/Create.vue
+++ b/components/views/user/create/Create.vue
@@ -88,7 +88,7 @@ export default Vue.extend({
 
       this.onConfirm({
         username: this.name,
-        imageURI: this.croppedImage,
+        photoHash: this.croppedImage,
         status: this.status,
       })
       return true

--- a/layouts/server.vue
+++ b/layouts/server.vue
@@ -29,13 +29,15 @@
           />
           <Enhancers />
         </swiper-slide>
-        <swiper-slide :class="`dynamic-content ${ui.fullscreen ? 'fullscreen-media' : ''}`">
+        <swiper-slide
+          :class="`dynamic-content ${ui.fullscreen ? 'fullscreen-media' : ''}`"
+        >
           <menu-icon
             class="toggle--sidebar"
-            v-on:click="toggleMenu"
             size="1.2x"
             full-width
             :style="`${!sidebar ? 'display: block' : 'display: none'}`"
+            @click="toggleMenu"
           />
           <Toolbar
             id="toolbar"
@@ -75,36 +77,33 @@
 <script lang="ts">
 import Vue from 'vue'
 import { mapState } from 'vuex'
+import { MenuIcon } from 'satellite-lucide-icons'
 import { Touch } from '~/components/mixins/Touch'
 import Layout from '~/components/mixins/Layouts/Layout'
 
-import {
-  MenuIcon,
-} from 'satellite-lucide-icons'
-
 export default Vue.extend({
   name: 'ServerLayout',
-  mixins: [Touch, Layout],
-  middleware: 'authenticated',
   components: {
     MenuIcon,
   },
+  mixins: [Touch, Layout],
+  middleware: 'authenticated',
   data() {
     return {
-      sidebar: this.$device.isMobile ? false : true,
+      sidebar: !this.$device.isMobile,
       swiperOption: {
         initialSlide: this.$device.isMobile ? 1 : 0,
         resistanceRatio: 0,
         slidesPerView: 'auto',
-        noSwiping: this.$device.isMobile ? false : true,
-        allowTouchMove: this.$device.isMobile ? true : false,
+        noSwiping: !this.$device.isMobile,
+        allowTouchMove: this.$device.isMobile,
         on: {
           slideChange: () => {
             if (this.$refs.swiper && this.$refs.swiper.$swiper) {
               this.$data.sidebar = this.$refs.swiper.$swiper.activeIndex === 0
             }
-          }
-        }
+          },
+        },
       },
     }
   },
@@ -121,7 +120,7 @@ export default Vue.extend({
           ? this.$refs.swiper.$swiper.slideNext()
           : this.$refs.swiper.$swiper.slidePrev()
       }
-    }
+    },
   },
 })
 </script>

--- a/libraries/Solana/ServerProgram/ServerProgram.ts
+++ b/libraries/Solana/ServerProgram/ServerProgram.ts
@@ -1,5 +1,4 @@
 import {
-  // eslint-disable-next-line import/named
   ConfirmOptions,
   Connection,
   Keypair,
@@ -11,6 +10,12 @@ import {
   TransactionInstruction,
 } from '@solana/web3.js'
 import base58 from 'micro-base58'
+import {
+  dwellerAccountLayout,
+  encodeInstructionData,
+} from './ServerProgram.layout'
+import { CreateDerivedAccountParams } from './ServerProgram.types'
+import { RawUser } from '~/types/ui/user'
 import { Config } from '~/config'
 import {
   Seeds,
@@ -18,12 +23,6 @@ import {
   stringToBuffer,
 } from '~/libraries/Solana/Solana'
 import Solana from '~/libraries/Solana/SolanaManager/SolanaManager'
-import { RawUser } from '~/types/ui/user'
-import {
-  dwellerAccountLayout,
-  encodeInstructionData,
-} from './ServerProgram.layout'
-import { CreateDerivedAccountParams } from './ServerProgram.types'
 
 const SERVER_PROGRAM_ID = new PublicKey(Config.solana.serverProgramId)
 

--- a/libraries/Textile/BucketManager.ts
+++ b/libraries/Textile/BucketManager.ts
@@ -1,32 +1,29 @@
-import {
-  Buckets,
-  Identity,
-  PushPathResult,
-  Root,
-} from '@textile/hub';
-// @ts-ignore
+import { Buckets, Identity, PushPathResult, Root } from '@textile/hub'
 import { Config } from '~/config'
-import {TextileInitializationData} from "~/types/textile/manager";
+import { TextileInitializationData } from '~/types/textile/manager'
 
 // TODO: Buckets are not yet secure - AP-402
 // encrypt storage and allow the recipent to decrypt with
 // their priv key.
 export default class BucketManager {
-  buckets: Buckets | null;
-  bucketKey: Root["key"] | null;
+  buckets: Buckets | null
+  bucketKey: Root['key'] | null
   textile: TextileInitializationData
-  identity: Identity;
-  bucketName: string;
-  prefix: string;
+  identity: Identity
+  bucketName: string
+  prefix: string
 
-  constructor(textile: TextileInitializationData, identity: Identity, prefix: string) {
-
-    this.identity = identity;
-    this.textile = textile;
-    this.buckets = null;
-    this.bucketKey = null;
-    this.bucketName = 'v74files';
-    this.prefix = prefix;
+  constructor(
+    textile: TextileInitializationData,
+    identity: Identity,
+    prefix: string,
+  ) {
+    this.identity = identity
+    this.textile = textile
+    this.buckets = null
+    this.bucketKey = null
+    this.bucketName = 'v74files'
+    this.prefix = prefix
   }
 
   /**
@@ -37,62 +34,63 @@ export default class BucketManager {
    * @example progressParse(returnedNumber, file.size)
    */
   private progressParse(uploaded: number, total: number) {
-    return uploaded / total * 100;
+    return (uploaded / total) * 100
   }
 
   async init() {
     if (!Config.textile.key) {
       throw new Error('Textile key not found')
     }
-    this.buckets = await Buckets.withKeyInfo({key: Config.textile.key});
+    this.buckets = await Buckets.withKeyInfo({ key: Config.textile.key })
     await this.buckets.getToken(this.identity)
-    const result = await this.buckets.getOrCreate(`hub.textile.io/ipfs/${this.identity}/${this.prefix}`);
-    if (!result.root) throw new Error('failed to open buckets');
-    this.bucketKey = result.root.key;
-    await this.ensureIndex();
-
+    const result = await this.buckets.getOrCreate(
+      `hub.textile.io/ipfs/${this.identity}/${this.prefix}`,
+    )
+    if (!result.root) throw new Error('failed to open buckets')
+    this.bucketKey = result.root.key
+    await this.ensureIndex()
   }
 
   async removeFromIndex(file: File) {
-    const path = `${this.prefix}/index.json`;
-    if (!this.buckets || !this.bucketKey) return;
-    const bytesStream = await this.buckets?.pullPath(this.bucketKey, path);
-    let array: any[] = [];
+    const path = `${this.prefix}/index.json`
+    if (!this.buckets || !this.bucketKey) return
+    const bytesStream = await this.buckets?.pullPath(this.bucketKey, path)
+    let array: any[] = []
     if (bytesStream) {
-      const next = await bytesStream.next();
-      const value = next.value;
-      const oldIndex = JSON.parse(Buffer.from(value).toString());
-      array = [...oldIndex.paths];
+      const next = await bytesStream.next()
+      const value = next.value
+      const oldIndex = JSON.parse(Buffer.from(value).toString())
+      array = [...oldIndex.paths]
     }
 
-    const filtered = array.filter(item => {
+    const filtered = array.filter((item) => {
       // @ts-ignore
-      return item.file.name !== file.file.name;
-    });
+      return item.file.name !== file.file.name
+    })
 
     const index = {
-      date: (new Date()).getTime(),
+      date: new Date().getTime(),
       meta: {},
       paths: filtered,
-    };
+    }
     // Store the index in the Bucket (or in the Thread later)
-    const buf = Buffer.from(JSON.stringify(index, null, 2));
-    await this.buckets.pushPath(this.bucketKey, path, buf);
+    const buf = Buffer.from(JSON.stringify(index, null, 2))
+    await this.buckets.pushPath(this.bucketKey, path, buf)
   }
 
   async addToIndex(file: File, root: string | undefined, remotePath: string) {
-    const path = `${this.prefix}/index.json`;
-    if (!this.buckets || !this.bucketKey) return;
-    const bytesStream = await this.buckets?.pullPath(this.bucketKey, path);
-    let array: any[] = [];
+    const path = `${this.prefix}/index.json`
+    if (!this.buckets || !this.bucketKey) return
+    const bytesStream = await this.buckets?.pullPath(this.bucketKey, path)
+    let array: any[] = []
     if (bytesStream) {
-      const next = await bytesStream.next();
-      const value = next.value;
-      const oldIndex = JSON.parse(Buffer.from(value).toString());
-      array = [...oldIndex.paths];
+      const next = await bytesStream.next()
+      const value = next.value
+      const oldIndex = JSON.parse(Buffer.from(value).toString())
+      array = [...oldIndex.paths]
     }
     const index = {
-      date: (new Date()).getTime(),
+      date: new Date().getTime(),
       meta: {},
       paths: [
         ...array,
@@ -108,79 +106,87 @@ export default class BucketManager {
           remote: encodeURI(`${Config.textile.browser}${root}${remotePath}`),
         },
       ],
-    };
+    }
     // Store the index in the Bucket (or in the Thread later)
-    const buf = Buffer.from(JSON.stringify(index, null, 1));
-    await this.buckets.pushPath(this.bucketKey, path, buf);
+    const buf = Buffer.from(JSON.stringify(index, null, 1))
+    await this.buckets.pushPath(this.bucketKey, path, buf)
   }
 
-  async ensureIndex() : Promise<boolean> {
-    const path = `${this.prefix}/index.json`;
-    return new Promise(async resolve => {
-      if (!this.buckets || !this.bucketKey) return null;
-      this.buckets.listPath(this.bucketKey, path)
+  async ensureIndex(): Promise<boolean> {
+    const path = `${this.prefix}/index.json`
+    return new Promise((resolve) => {
+      if (!this.buckets || !this.bucketKey) return null
+      this.buckets
+        .listPath(this.bucketKey, path)
         .then(() => {
-          resolve(true);
+          resolve(true)
         })
-        .catch(async e => {
+        .catch(async (e) => {
           const index = {
-            date: (new Date()).getTime(),
+            date: new Date().getTime(),
             meta: {},
             paths: [],
-          };
+          }
           // Store the index in the Bucket (or in the Thread later)
-          const buf = Buffer.from(JSON.stringify(index, null, 2));
-          if (!this.buckets || !this.bucketKey) return null;
-          await this.buckets.pushPath(this.bucketKey, path, buf);
-          resolve(false);
-        });
-    });
+          const buf = Buffer.from(JSON.stringify(index, null, 2))
+          if (!this.buckets || !this.bucketKey) return null
+          await this.buckets.pushPath(this.bucketKey, path, buf)
+          resolve(false)
+        })
+    })
   }
 
-  async fetchIndex() : Promise<object> {
-    const path = `${this.prefix}/index.json`;
-    if (!this.buckets || !this.bucketKey) return {};
-    const bytesStream = await this.buckets?.pullPath(this.bucketKey, path);
-    const next = await bytesStream.next();
-    const value = next.value;
-    const index = JSON.parse(Buffer.from(value).toString());
-    return index;
+  async fetchIndex(): Promise<object> {
+    const path = `${this.prefix}/index.json`
+    if (!this.buckets || !this.bucketKey) return {}
+    const bytesStream = await this.buckets?.pullPath(this.bucketKey, path)
+    const next = await bytesStream.next()
+    const value = next.value
+    const index = JSON.parse(Buffer.from(value).toString())
+    return index
   }
 
-  async pushFile(file: File, path: string, progress: CallableFunction) : Promise<PushPathResult> {
+  async pushFile(
+    file: File,
+    path: string,
+    progress: CallableFunction,
+  ): Promise<PushPathResult> {
     return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onabort = () => reject('file reading was aborted');
-      reader.onerror = () => reject('file reading has failed');
+      const reader = new FileReader()
+      reader.onabort = () => reject(new Error('file reading was aborted'))
+      reader.onerror = () => reject(new Error('file reading has failed'))
       reader.onload = () => {
         if (!this.buckets || !this.bucketKey) {
-          reject(new Error('Please init first'));
-          return;
+          reject(new Error('Please init first'))
+          return
         }
-        const binaryStr = reader.result;
-        this.buckets.pushPath(this.bucketKey, `${path}`, binaryStr, {
-          progress: (num) => {
-            if (progress && num) progress(this.progressParse(num, file.size))
-          },
-        }).then((raw) => {
-          resolve(raw);
-        }).catch(error => {
-          new Error(error);
-        });
-      };
-      reader.readAsArrayBuffer(file);
-    });
+        const binaryStr = reader.result
+        this.buckets
+          .pushPath(this.bucketKey, `${path}`, binaryStr, {
+            progress: (num) => {
+              if (progress && num) progress(this.progressParse(num, file.size))
+            },
+          })
+          .then((raw) => {
+            resolve(raw)
+          })
+          .catch((error) => {
+            throw error
+          })
+      }
+      reader.readAsArrayBuffer(file)
+    })
   }
 
-  async getBucket() : Promise<Root | undefined>{
-    if (!this.buckets) return undefined;
-    const roots = await this.buckets.list();
-    return roots.find((bucket) => bucket.name === this.bucketName);
+  async getBucket(): Promise<Root | undefined> {
+    if (!this.buckets) return undefined
+    const roots = await this.buckets.list()
+    return roots.find((bucket) => bucket.name === this.bucketName)
   }
 
-  async getLinks() : Promise<any> {
-    if (!this.buckets || !this.bucketKey) return undefined;
-    const links = await this.buckets.links(this.bucketKey);
-    return links;
+  async getLinks(): Promise<any> {
+    if (!this.buckets || !this.bucketKey) return undefined
+    const links = await this.buckets.links(this.bucketKey)
+    return links
   }
 }

--- a/libraries/Textile/BucketManager.ts
+++ b/libraries/Textile/BucketManager.ts
@@ -149,7 +149,7 @@ export default class BucketManager {
   async pushFile(
     file: File,
     path: string,
-    progress: CallableFunction,
+    progress?: CallableFunction,
   ): Promise<PushPathResult> {
     return new Promise((resolve, reject) => {
       const reader = new FileReader()

--- a/libraries/Textile/TextileManager.ts
+++ b/libraries/Textile/TextileManager.ts
@@ -5,7 +5,7 @@ import {
   TextileConfig,
   TextileInitializationData,
 } from '~/types/textile/manager'
-import BucketManager from "~/libraries/Textile/BucketManager";
+import BucketManager from '~/libraries/Textile/BucketManager'
 
 export default class TextileManager {
   creds?: Creds
@@ -46,7 +46,11 @@ export default class TextileManager {
     }
 
     this.mailboxManager = new MailboxManager(textile, wallet.address)
-    this.bucketManager = new BucketManager(textile, identity, textile.wallet.address)
+    this.bucketManager = new BucketManager(
+      textile,
+      identity,
+      textile.wallet.address,
+    )
     await this.bucketManager.init().catch((e) => console.log(e))
     return this.mailboxManager.init()
   }
@@ -60,7 +64,7 @@ export default class TextileManager {
   async authenticate(
     id: string,
     pass: string,
-    textile: TextileInitializationData
+    textile: TextileInitializationData,
   ) {
     this.creds = {
       id,
@@ -69,7 +73,11 @@ export default class TextileManager {
 
     this.mailboxManager = new MailboxManager(textile, textile.wallet.address)
     await this.mailboxManager.init()
-    this.bucketManager = new BucketManager(textile, textile.identity,textile.wallet.address)
+    this.bucketManager = new BucketManager(
+      textile,
+      textile.identity,
+      textile.wallet.address,
+    )
     await this.bucketManager.init().catch((e) => console.log(e))
   }
 

--- a/mock/users.ts
+++ b/mock/users.ts
@@ -7,8 +7,7 @@ export const Users = [
     unreads: 4,
     last_message:
       'Ship of the imagination consciousness across the centuries network of wormholes finite but unbounded inconspicuous motes of rock and gas.',
-    profilePicture:
-      'https://st2.depositphotos.com/1009634/7235/v/600/depositphotos_72350117-stock-illustration-no-user-profile-picture-hand.jpg',
+    profilePicture: '',
   },
   {
     name: 'Ariel Larissa',
@@ -18,8 +17,7 @@ export const Users = [
     unreads: 1,
     last_message:
       'Network of wormholes science citizens of distant epochs tingling of the spine cosmic ocean brain is the seed of intelligence. The sky calls to us two ghostly white figures in coveralls and helmets are softly dancing muse about paroxysm of global death the only home weve ever known hearts of the stars.',
-    profilePicture:
-      'https://st2.depositphotos.com/1009634/7235/v/600/depositphotos_72350117-stock-illustration-no-user-profile-picture-hand.jpg',
+    profilePicture: '',
   },
   {
     name: 'Taurus Nix',
@@ -53,8 +51,7 @@ export const Users = [
     state: 'mobile',
     last_message:
       'To be the first to enter the cosmos, to engage, single-handed, in an unprecedented duel with nature—could one dream of anything more?',
-    profilePicture:
-      'https://st2.depositphotos.com/1009634/7235/v/600/depositphotos_72350117-stock-illustration-no-user-profile-picture-hand.jpg',
+    profilePicture: '',
   },
   {
     name: 'James Lightspeed',
@@ -79,8 +76,7 @@ export const Users = [
     state: 'mobile',
     last_message:
       'To be the first to enter the cosmos, to engage, single-handed, in an unprecedented duel with nature—could one dream of anything more?',
-    profilePicture:
-      'https://st2.depositphotos.com/1009634/7235/v/600/depositphotos_72350117-stock-illustration-no-user-profile-picture-hand.jpg',
+    profilePicture: '',
   },
 ]
 

--- a/pages/auth/register/index.vue
+++ b/pages/auth/register/index.vue
@@ -42,10 +42,9 @@ export default Vue.extend({
   mounted() {},
   methods: {
     async confirm(userData: UserRegistrationData) {
-      // TODO: upload picture to pinata first - AP-395
       await this.$store.dispatch('accounts/registerUser', {
         name: userData.username,
-        photoHash: '',
+        image: userData.photoHash,
         status: userData.status,
       })
 

--- a/pages/auth/register/index.vue
+++ b/pages/auth/register/index.vue
@@ -29,7 +29,7 @@ export default Vue.extend({
           return this.$i18n.t('user.registration.reg_status.funding_account')
         case RegistrationStatus.SENDING_TRANSACTION:
           return this.$i18n.t(
-            'user.registration.reg_status.sending_transaction'
+            'user.registration.reg_status.sending_transaction',
           )
         default:
           return this.$i18n.t('user.registration.reg_status.registered')

--- a/pages/setup/phrase/index.vue
+++ b/pages/setup/phrase/index.vue
@@ -3,9 +3,11 @@
 <script lang="ts">
 import Vue from 'vue'
 import { mapState } from 'vuex'
+import { AccountsState } from '~/store/accounts/types'
+
 declare module 'vue/types/vue' {
   interface Vue {
-    accounts: any
+    accounts: AccountsState
   }
 }
 export default Vue.extend({

--- a/store/accounts/actions.ts
+++ b/store/accounts/actions.ts
@@ -282,13 +282,12 @@ export default {
 }
 
 /**
- * @method uploadPicture helper function to upload image to textile if needed
- * @description
- * @param userAccount
- * @example
+ * @method uploadPicture
+ * @description helper function to upload image to textile if needed
+ * @param image data string of uploaded image
+ * @returns textile hash of image, or '' if no image is present
  */
 async function uploadPicture(image: string) {
-  // immediately return empty string if there's no image
   if (!image) {
     return ''
   }

--- a/store/accounts/actions.ts
+++ b/store/accounts/actions.ts
@@ -236,7 +236,11 @@ export default {
 
     commit('setRegistrationStatus', RegistrationStatus.SENDING_TRANSACTION)
 
-    await serverProgram.createUser(userData.name, '', userData.status)
+    await serverProgram.createUser(
+      userData.name,
+      userData.photoHash,
+      userData.status,
+    )
 
     commit('setRegistrationStatus', RegistrationStatus.REGISTERED)
 
@@ -247,7 +251,7 @@ export default {
     commit('setUserDetails', {
       username: userData.name,
       status: userData.status,
-      photoHash: userData.photoHash,
+      imageURI: userData.photoHash,
       address: userAccount.publicKey.toBase58(),
     })
   },

--- a/store/accounts/mutations.ts
+++ b/store/accounts/mutations.ts
@@ -54,13 +54,13 @@ const mutations = {
   },
   setRegistrationStatus(
     state: AccountsState,
-    registrationStates: RegistrationStatus
+    registrationStates: RegistrationStatus,
   ) {
     state.registrationStatus = registrationStates
   },
   setLastVisited(state: AccountsState, lastVisited: string) {
     state.lastVisited = lastVisited
-  }
+  },
 }
 
 export default mutations

--- a/store/accounts/mutations.ts
+++ b/store/accounts/mutations.ts
@@ -31,7 +31,7 @@ const mutations = {
     state.details = {
       name: details.username,
       status: details.status,
-      profilePicture: details.imageURI,
+      profilePicture: details.photoHash,
       address: state.active,
       state: 'online',
     }

--- a/store/accounts/types.ts
+++ b/store/accounts/types.ts
@@ -38,6 +38,6 @@ export enum AccountsError {
 
 export interface UserRegistrationPayload {
   name: string
-  photoHash: string
+  image: string
   status: string
 }

--- a/types/ui/friends.d.ts
+++ b/types/ui/friends.d.ts
@@ -5,16 +5,6 @@ export interface EncryptedFriend extends User {
   encryptedTextilePubkey: string
 }
 
-export interface Friend extends EncryptedFriend {
-  publicKey: string
-  typingState: 'TYPING' | 'NOT_TYPING'
-  textilePubkey: string
-  item: any // TODO remove unnecessary properties AP-393
-  pending: Boolean
-  activeChat: Boolean
-  account: FriendAccount
-}
-
 export interface FriendRequest {
   requestId: string
   account: FriendAccount
@@ -25,6 +15,19 @@ export interface IncomingRequest extends FriendRequest {
   from: string
   userInfo: RawUser | null
   account: FriendAccount
+}
+
+export interface Friend extends EncryptedFriend {
+  publicKey: string
+  typingState: 'TYPING' | 'NOT_TYPING'
+  textilePubkey: string
+  item: any // TODO remove unnecessary properties AP-393
+  pending: Boolean
+  activeChat: Boolean
+  account: FriendAccount
+  // possibly break these out into different type. These optional fields come up in the friends list, add, request area
+  request?: IncomingRequest
+  photoHash?: string
 }
 
 export interface OutgoingRequest extends FriendRequest {

--- a/types/ui/user.d.ts
+++ b/types/ui/user.d.ts
@@ -17,7 +17,7 @@ export type User = {
 
 export interface UserRegistrationData {
   username: string
-  imageURI: string
+  photoHash: string
   status: string
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- upload picture to textile on account creation, set hash in Solana and state
- render picture in various places
  - chat
  - quick profile
  - adding friend
  - friends list
  - status
  - profile settings
- general refactoring/formatting across files

**Which issue(s) this PR fixes** 🔨
AP-476

**Special notes for reviewers** 🗒️
- I believe textile is initialized twice during initial registration. There's a comment about moving this to a startup action
  - The pre-existing location (loadAccount in store/accounts/actions.ts)
  - In order to add image to bucket before solana picture registration (registerUser in store/accounts/actions.ts)
- You can only add a picture on account creation right now

**Additional comments** 🎤
