### PR TITLE
feat(profile): profile modal responsive layout AP-507

### DIFF
--- a/assets/styles/framework/breakpoints.less
+++ b/assets/styles/framework/breakpoints.less
@@ -1,2 +1,3 @@
-@mobile-breakpoint: 768px;
 @mobile-candybar-breakpoint: 360px;
+@mobile-breakpoint: 768px;
+@medium-breakpoint: 1250px;

--- a/components/interactables/Tabs/Tabs.html
+++ b/components/interactables/Tabs/Tabs.html
@@ -1,0 +1,5 @@
+<div id="tabs">
+  <button v-for="tab in tabs" @click="setRoute(tab.route)">{{tab.text}}</button>
+
+  <slot v-if="$slots.default"></slot>
+</div>

--- a/components/interactables/Tabs/Tabs.html
+++ b/components/interactables/Tabs/Tabs.html
@@ -1,5 +1,12 @@
 <div id="tabs">
-  <button v-for="tab in tabs" @click="setRoute(tab.route)">{{tab.text}}</button>
+  <button
+    class="tab"
+    v-for="tab in tabs"
+    @click="setRoute(tab.route)"
+    :class="route===tab.route ? 'active' : ''"
+  >
+    {{tab.text}}
+  </button>
 
   <slot v-if="$slots.default"></slot>
 </div>

--- a/components/interactables/Tabs/Tabs.less
+++ b/components/interactables/Tabs/Tabs.less
@@ -1,4 +1,17 @@
 #tabs {
   display: flex;
   gap: @xlarge-spacing;
+
+  .tab {
+    cursor: pointer;
+    color: @text;
+    background: transparent;
+    padding-bottom: @normal-spacing;
+
+    &.active {
+      color: @secondary-text;
+      border-bottom: 2px solid @primary-color!important;
+      padding-bottom: calc(@normal-spacing - 2px;);
+    }
+  }
 }

--- a/components/interactables/Tabs/Tabs.less
+++ b/components/interactables/Tabs/Tabs.less
@@ -15,3 +15,9 @@
     }
   }
 }
+
+@media only screen and (max-width: @mobile-breakpoint) {
+  #tabs {
+    gap: @normal-spacing;
+  }
+}

--- a/components/interactables/Tabs/Tabs.less
+++ b/components/interactables/Tabs/Tabs.less
@@ -21,3 +21,10 @@
     gap: @normal-spacing;
   }
 }
+
+@media only screen and (max-width: 480px) {
+  #tabs {
+    gap: initial;
+    justify-content: space-between;
+  }
+}

--- a/components/interactables/Tabs/Tabs.less
+++ b/components/interactables/Tabs/Tabs.less
@@ -1,0 +1,4 @@
+#tabs {
+  display: flex;
+  gap: @xlarge-spacing;
+}

--- a/components/interactables/Tabs/Tabs.vue
+++ b/components/interactables/Tabs/Tabs.vue
@@ -1,7 +1,6 @@
 <template src="./Tabs.html"></template>
 <script lang="ts">
 import Vue, { PropType } from 'vue'
-
 import { Tab } from './types.d'
 
 export default Vue.extend({
@@ -14,11 +13,6 @@ export default Vue.extend({
       type: Array as PropType<Array<Tab>>,
       required: true,
     },
-  },
-  data() {
-    return {
-      active: false,
-    }
   },
   methods: {
     setRoute(route: string) {

--- a/components/interactables/Tabs/Tabs.vue
+++ b/components/interactables/Tabs/Tabs.vue
@@ -1,0 +1,30 @@
+<template src="./Tabs.html"></template>
+<script lang="ts">
+import Vue, { PropType } from 'vue'
+
+import { Tab } from './types.d'
+
+export default Vue.extend({
+  props: {
+    route: {
+      type: String,
+      default: '',
+    },
+    tabs: {
+      type: Array as PropType<Array<Tab>>,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      active: false,
+    }
+  },
+  methods: {
+    setRoute(route: string) {
+      this.$emit('setRoute', route)
+    },
+  },
+})
+</script>
+<style scoped lang="less" src="./Tabs.less"></style>

--- a/components/interactables/Tabs/types.d.ts
+++ b/components/interactables/Tabs/types.d.ts
@@ -1,0 +1,4 @@
+export interface Tab {
+  text: string
+  route: string
+}

--- a/components/ui/Global/Global.html
+++ b/components/ui/Global/Global.html
@@ -67,7 +67,6 @@
     :close-modal="() => toggleModal(ModalWindows.USERPROFILE)"
     nopad
     v-click-outside="() => toggleModal(ModalWindows.USERPROFILE)"
-    :small="true"
   >
     <UserProfile :close-modal="() => toggleModal(ModalWindows.USERPROFILE)" />
   </UiModal>

--- a/components/ui/HorizontalRule/HorizontalRule.vue
+++ b/components/ui/HorizontalRule/HorizontalRule.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="horizontal-rule">
-    <hr >
+    <hr />
   </div>
 </template>
 <script lang="ts">

--- a/components/ui/Popups/Error/Error.less
+++ b/components/ui/Popups/Error/Error.less
@@ -68,7 +68,7 @@
   &:extend(.full-width);
 }
 
-@media (max-width: 768px) {
+@media (max-width: @mobile-breakpoint) {
   .create-error-container {
     &:extend(.full-width);
   }

--- a/components/ui/User/State/State.less
+++ b/components/ui/User/State/State.less
@@ -1,69 +1,67 @@
 .user-state {
-    position: relative;
-    display: flex;
-    align-items: center;
-    height: 35px;
-    width: 35px;
-    .status {
-        position: absolute;
-        bottom: -1.5px;
-        right: -2.5px;
-        font-size: @text-size;
-        text-shadow: 0 0 3px #000;
-        display: inline-flex;
-        align-content: center;
+  position: relative;
+  display: flex;
+  align-items: center;
+  .status {
+    position: absolute;
+    bottom: -1.5px;
+    right: -2.5px;
+    font-size: @text-size;
+    text-shadow: 0 0 3px #000;
+    display: inline-flex;
+    align-content: center;
 
-        circle {
-            stroke: @midground;
-            stroke-width: 5;
-            paint-order: stroke;
-        }
-        &.is-online {
-            &:extend(.color-success);
-            fill: @green;
-        }
-        &.is-offline {
-            &:extend(.font-gray);
-            fill: @gray;
-        }
-        &.is-idle {
-            &:extend(.color-warning);
-            fill: @yellow;
-        }
+    circle {
+      stroke: @midground;
+      stroke-width: 5;
+      paint-order: stroke;
     }
-
-    .mobile-status {
-        position: absolute;
-        bottom: -1.5px;
-        right: -2.5px;
-        font-size: @small-icon-size;
-        text-shadow: 0 0 3px #000;
-
-        rect {
-            stroke: @midground;
-            stroke-width: 4;
-            paint-order: stroke;
-            fill: @green;
-        }
-        line {
-            fill: #000;
-            stroke: @midground;
-            stroke-width: 4;
-        }
-        &.is-mobile {
-            &:extend(.color-success);
-        }
+    &.is-online {
+      &:extend(.color-success);
+      fill: @green;
     }
-
-    #typing-badge-container {
-        &:extend(.background-primary);
-        width: 40px;
-        height: 18px;
-        position: absolute;
-        bottom: -1.5px;
-        left: 18px;
-        padding: 5px;
-        border-radius: 10px;
-        border: 3px solid @midground;
+    &.is-offline {
+      &:extend(.font-gray);
+      fill: @gray;
     }
+    &.is-idle {
+      &:extend(.color-warning);
+      fill: @yellow;
+    }
+  }
+
+  .mobile-status {
+    position: absolute;
+    bottom: -1.5px;
+    right: -2.5px;
+    font-size: @small-icon-size;
+    text-shadow: 0 0 3px #000;
+
+    rect {
+      stroke: @midground;
+      stroke-width: 4;
+      paint-order: stroke;
+      fill: @green;
+    }
+    line {
+      fill: #000;
+      stroke: @midground;
+      stroke-width: 4;
+    }
+    &.is-mobile {
+      &:extend(.color-success);
+    }
+  }
+
+  #typing-badge-container {
+    &:extend(.background-primary);
+    width: 40px;
+    height: 18px;
+    position: absolute;
+    bottom: -1.5px;
+    left: 18px;
+    padding: 5px;
+    border-radius: 10px;
+    border: 3px solid @midground;
+  }
 }

--- a/components/ui/User/State/State.vue
+++ b/components/ui/User/State/State.vue
@@ -9,7 +9,7 @@
 
     <circle-icon
       v-if="user.state !== 'mobile' && !isTyping"
-      size="1x"
+      :size="size > 35 ? '1.65x' : '1x'"
       :class="`status is-${user.state}`"
     />
     <smartphone-icon

--- a/components/ui/User/State/State.vue
+++ b/components/ui/User/State/State.vue
@@ -1,11 +1,12 @@
 <template>
-  <div class="user-state">
+  <div class="user-state" :style="`width:${size}px; height:${size}px`">
     <UiCircle
       :type="src ? 'image' : 'random'"
       :seed="user.address"
-      :size="35"
+      :size="size"
       :source="src"
     />
+
     <circle-icon
       v-if="user.state !== 'mobile' && !isTyping"
       size="1x"
@@ -41,6 +42,11 @@ export default Vue.extend({
       required: false,
     },
     src: { type: String, default: '', required: false },
+    size: {
+      type: Number,
+      default: 35,
+      required: false,
+    },
   },
 })
 </script>

--- a/components/views/chat/enhancers/Enhancers.less
+++ b/components/views/chat/enhancers/Enhancers.less
@@ -44,14 +44,13 @@
   overflow: hidden;
   z-index: @base-z-index + 100;
   &:extend(.blur);
-}
 
-#enhancers.side-open {
-  margin-right: calc(@sidebar-size + @servers-size + 1rem);
-}
-
-#enhancers.side-close {
-  margin-right: 1rem;
+  &.side-open {
+    margin-right: calc(@sidebar-size + @servers-size + 1rem);
+  }
+  &.side-close {
+    margin-right: 1rem;
+  }
 }
 
 .emoji-picker {
@@ -107,5 +106,8 @@
   #enhancers {
     width: calc(100vw - @normal-spacing*2);
     min-width: calc(100vw - @normal-spacing*2);
+    &.side-close {
+      margin-right: 0;
+    }
   }
 }

--- a/components/views/servers/create/Create.less
+++ b/components/views/servers/create/Create.less
@@ -68,7 +68,7 @@
   &:extend(.full-width);
 }
 
-@media (max-width: 768px) {
+@media (max-width: @mobile-breakpoint) {
   .create-server-container {
     &:extend(.full-width);
   }
@@ -85,7 +85,6 @@
     margin-top: 0px;
   }
 }
-
 
 @media only screen and (max-width: @mobile-breakpoint) {
   .submit-container {

--- a/components/views/user/create/Create.less
+++ b/components/views/user/create/Create.less
@@ -68,7 +68,7 @@
   &:extend(.full-width);
 }
 
-@media (max-width: 768px) {
+@media (max-width: @mobile-breakpoint) {
   .create-server-container {
     &:extend(.full-width);
   }

--- a/components/views/user/profile/Profile.html
+++ b/components/views/user/profile/Profile.html
@@ -6,19 +6,37 @@
     <div class="details">
       <div class="details-info">
         <img :src="sample.imageUrl" alt="" class="photo-sm" />
-        <!-- todo: add source after AP476 gets merged profilePictureSrc -->
         <UiUserState
           :user="{address: ui.userProfile.address, state: ui.userProfile.state}"
           :size="80"
+          :src="profilePictureSrc"
         />
         <div class="intro">
-          <TypographyTitle :text="ui.userProfile.name" :size="6" />
-          <TypographyText :text="ui.userProfile.status" :size="6" />
-          <div v-if="ui.userProfile.badges" class="badges"></div>
+          <div>
+            <TypographyTitle :text="ui.userProfile.name" :size="6" />
+            <TypographyText :text="ui.userProfile.status" :size="6" />
+          </div>
+          <!-- todo: add real badges and conditional -->
+          <div class="badges">
+            <award-icon
+              v-for="n in 3"
+              :key="n"
+              size="1.2x"
+              :style="`color:${badgeColors[n]}`"
+            />
+          </div>
         </div>
       </div>
+      <div class="buttons mobile">
+        <InteractablesButton type="primary">
+          <user-plus-icon size="1.25x" />
+        </InteractablesButton>
+        <InteractablesButton type="primary">
+          <more-vertical-icon size="1.25x" />
+        </InteractablesButton>
+      </div>
       <InteractablesTabs :tabs="tabs" @setRoute="setRoute" :route="route">
-        <div class="buttons">
+        <div class="buttons desktop">
           <InteractablesButton type="primary" size="small">
             <user-plus-icon size="1.25x" />
           </InteractablesButton>
@@ -30,16 +48,22 @@
       <UiHorizontalRule style="margin-top: 0" />
       <div v-if="route==='about'" class="about">
         <div>
-          <TypographyTitle text="About Me" :size="6" />
+          <TypographyTitle :text="$t('modal.profile.about.me')" :size="6" />
           <TypographyText text="Lorem ipsum dolor" />
         </div>
         <div>
-          <TypographyTitle text="Location" :size="6" />
+          <TypographyTitle
+            :text="$t('modal.profile.about.location')"
+            :size="6"
+          />
           <TypographyText text="Lorem ipsum dolor" />
         </div>
         <div>
-          <TypographyTitle text="Add Note" :size="6" />
-          <TypographyText text="Click to add note" />
+          <TypographyTitle
+            :text="$t('modal.profile.about.add_note')"
+            :size="6"
+          />
+          <TypographyText :text="$t('modal.profile.about.click_note')" />
         </div>
       </div>
       <div v-if="route==='accounts'">accounts</div>

--- a/components/views/user/profile/Profile.html
+++ b/components/views/user/profile/Profile.html
@@ -5,6 +5,7 @@
     <img :src="sample.imageUrl" alt="" class="photo" />
     <div class="details">
       <div class="details-info">
+        <img :src="sample.imageUrl" alt="" class="photo-sm" />
         <!-- todo: add source after AP476 gets merged profilePictureSrc -->
         <UiUserState
           :user="{address: ui.userProfile.address, state: ui.userProfile.state}"

--- a/components/views/user/profile/Profile.html
+++ b/components/views/user/profile/Profile.html
@@ -2,10 +2,10 @@
   <InteractablesClose :action="closeProfileModal" />
   <img :src="sample.imageUrl" alt="" class="banner" />
   <div class="profile-body">
-    <img :src="sample.imageUrl" alt="" class="picture" />
-    <div class="details-container">
-      <div class="details">
-        <!-- add source after rebase profilePictureSrc -->
+    <img :src="sample.imageUrl" alt="" class="photo" />
+    <div class="details">
+      <div class="details-info">
+        <!-- todo: add source after AP476 gets merged profilePictureSrc -->
         <UiUserState
           :user="{address: ui.userProfile.address, state: ui.userProfile.state}"
           :size="80"
@@ -16,7 +16,7 @@
           <div v-if="ui.userProfile.badges" class="badges"></div>
         </div>
       </div>
-      <InteractablesTabs :tabs="tabs" @setRoute="setRoute">
+      <InteractablesTabs :tabs="tabs" @setRoute="setRoute" :route="route">
         <div class="buttons">
           <InteractablesButton type="primary" size="small">
             <user-plus-icon size="1.25x" />
@@ -26,16 +26,24 @@
           </InteractablesButton>
         </div>
       </InteractablesTabs>
-      <UiHorizontalRule />
-      <UiScroll
-        v-if="route==='about'"
-        verticalScroll
-        scrollbarVisibility="scroll"
-        enableWrap
-        noPadding
-      >
-        test
-      </UiScroll>
+      <UiHorizontalRule style="margin-top: 0" />
+      <div v-if="route==='about'" class="about">
+        <div>
+          <TypographyTitle text="About Me" :size="6" />
+          <TypographyText text="Lorem ipsum dolor" />
+        </div>
+        <div>
+          <TypographyTitle text="Location" :size="6" />
+          <TypographyText text="Lorem ipsum dolor" />
+        </div>
+        <div>
+          <TypographyTitle text="Add Note" :size="6" />
+          <TypographyText text="Click to add note" />
+        </div>
+      </div>
+      <div v-if="route==='accounts'">accounts</div>
+      <div v-if="route==='activity'">activity</div>
+      <div v-if="route==='mutual'">mutual</div>
     </div>
   </div>
 </div>

--- a/components/views/user/profile/Profile.html
+++ b/components/views/user/profile/Profile.html
@@ -1,13 +1,41 @@
-<div class="user-profile" v-click-outside="closeProfileModal">
-  <div class="body-panel">
-    <div class="top-bar">
-      <div class="action">
-        <InteractablesClose :action="closeProfileModal" />
+<div id="profile" v-click-outside="closeProfileModal">
+  <InteractablesClose :action="closeProfileModal" />
+  <img :src="sample.imageUrl" alt="" class="banner" />
+  <div class="profile-body">
+    <img :src="sample.imageUrl" alt="" class="picture" />
+    <div class="details-container">
+      <div class="details">
+        <!-- add source after rebase profilePictureSrc -->
+        <UiUserState
+          :user="{address: ui.userProfile.address, state: ui.userProfile.state}"
+          :size="80"
+        />
+        <div class="intro">
+          <TypographyTitle :text="ui.userProfile.name" :size="6" />
+          <TypographyText :text="ui.userProfile.status" :size="6" />
+          <div v-if="ui.userProfile.badges" class="badges"></div>
+        </div>
       </div>
+      <InteractablesTabs :tabs="tabs" @setRoute="setRoute">
+        <div class="buttons">
+          <InteractablesButton type="primary" size="small">
+            <user-plus-icon size="1.25x" />
+          </InteractablesButton>
+          <InteractablesButton type="primary" size="small">
+            <more-vertical-icon size="1.25x" />
+          </InteractablesButton>
+        </div>
+      </InteractablesTabs>
+      <UiHorizontalRule />
+      <UiScroll
+        v-if="route==='about'"
+        verticalScroll
+        scrollbarVisibility="scroll"
+        enableWrap
+        noPadding
+      >
+        test
+      </UiScroll>
     </div>
-
-    <UiScroll verticalScroll scrollbarVisibility="scroll" enableWrap noPadding>
-      <div>{{this.ui.userProfile.name}}</div>
-    </UiScroll>
   </div>
 </div>

--- a/components/views/user/profile/Profile.less
+++ b/components/views/user/profile/Profile.less
@@ -2,13 +2,12 @@
   display: flex;
   flex-direction: column;
   width: 964px;
-  height: 540px;
+  height: @full;
 
   .banner {
     height: 120px;
     object-fit: cover;
   }
-
   .photo {
     max-height: 424px;
     margin-top: -88px;
@@ -16,7 +15,6 @@
   .photo-sm {
     display: none;
   }
-
   .profile-body {
     display: flex;
     gap: @large-spacing;
@@ -27,7 +25,6 @@
       display: flex;
       flex-direction: column;
     }
-
     .details-info {
       display: flex;
       flex-direction: row;
@@ -38,16 +35,35 @@
       .intro {
         display: flex;
         flex-direction: column;
+        gap: 0.5rem;
+
+        .badges {
+          display: flex;
+          gap: 0.4rem;
+        }
       }
     }
     .buttons {
       padding-bottom: @normal-spacing;
       margin-left: auto;
+
+      &.mobile {
+        display: none;
+      }
     }
     .about {
       display: flex;
       flex-direction: column;
       gap: @normal-spacing;
+
+      // temp font fixes until we refactor headings
+      .title.is-6 {
+        font-size: 12px;
+        margin-bottom: 0.5rem;
+      }
+      p {
+        font-size: 12px;
+      }
     }
   }
 }
@@ -83,6 +99,22 @@
     }
     .photo-sm {
       display: none;
+    }
+  }
+}
+@media only screen and (max-width: 480px) {
+  #profile {
+    .profile-body {
+      .buttons {
+        margin-left: initial;
+        padding: initial;
+        &.desktop {
+          display: none;
+        }
+        &.mobile {
+          display: flex;
+        }
+      }
     }
   }
 }

--- a/components/views/user/profile/Profile.less
+++ b/components/views/user/profile/Profile.less
@@ -1,10 +1,8 @@
 #profile {
   display: flex;
   flex-direction: column;
-  height: 540px;
   width: 964px;
-  max-height: @full;
-  max-width: @full;
+  height: 540px;
 
   .banner {
     height: 120px;
@@ -13,7 +11,10 @@
 
   .photo {
     max-height: 424px;
-    margin-top: -120px;
+    margin-top: -88px;
+  }
+  .photo-sm {
+    display: none;
   }
 
   .profile-body {
@@ -47,6 +48,41 @@
       display: flex;
       flex-direction: column;
       gap: @normal-spacing;
+    }
+  }
+}
+
+@media only screen and (max-width: @medium-breakpoint) {
+  #profile {
+    display: flex;
+    flex-direction: column;
+    width: 600px;
+    height: 546px;
+
+    .photo {
+      display: none;
+    }
+    .photo-sm {
+      display: block;
+      max-height: 212px;
+      margin: -88px 8px 0 0;
+    }
+    .profile-body {
+      padding-top: 0;
+    }
+  }
+}
+
+@media only screen and (max-width: @mobile-breakpoint) {
+  #profile {
+    width: @full;
+    height: @full;
+
+    .profile-body {
+      padding: @large-spacing;
+    }
+    .photo-sm {
+      display: none;
     }
   }
 }

--- a/components/views/user/profile/Profile.less
+++ b/components/views/user/profile/Profile.less
@@ -1,19 +1,43 @@
-.user-profile {
+#profile {
   display: flex;
+  flex-direction: column;
   height: @full;
-  max-height: @full;
   overflow: hidden;
+  width: 964px;
 
-  .body-panel {
-    width: 784px;
-    padding: 32px;
-    .top-bar {
-      height: 25px;
+  .banner {
+    height: 120px;
+    object-fit: cover;
+  }
+
+  .picture {
+    max-height: 424px;
+    margin-top: -120px;
+  }
+
+  .profile-body {
+    display: flex;
+    gap: @large-spacing;
+    padding: @xlarge-spacing;
+
+    .details-container {
+      width: @full;
+    }
+
+    .details {
       display: flex;
+      flex-direction: row;
       align-items: center;
-      .action {
-        flex-shrink: 0;
+      gap: @normal-spacing;
+      margin-bottom: @large-spacing;
+
+      .intro {
+        display: flex;
+        flex-direction: column;
       }
+    }
+    .buttons {
+      margin-left: auto;
     }
   }
 }

--- a/components/views/user/profile/Profile.less
+++ b/components/views/user/profile/Profile.less
@@ -1,16 +1,17 @@
 #profile {
   display: flex;
   flex-direction: column;
-  height: @full;
-  overflow: hidden;
+  height: 540px;
   width: 964px;
+  max-height: @full;
+  max-width: @full;
 
   .banner {
     height: 120px;
     object-fit: cover;
   }
 
-  .picture {
+  .photo {
     max-height: 424px;
     margin-top: -120px;
   }
@@ -20,11 +21,13 @@
     gap: @large-spacing;
     padding: @xlarge-spacing;
 
-    .details-container {
+    .details {
       width: @full;
+      display: flex;
+      flex-direction: column;
     }
 
-    .details {
+    .details-info {
       display: flex;
       flex-direction: row;
       align-items: center;
@@ -37,7 +40,13 @@
       }
     }
     .buttons {
+      padding-bottom: @normal-spacing;
       margin-left: auto;
+    }
+    .about {
+      display: flex;
+      flex-direction: column;
+      gap: @normal-spacing;
     }
   }
 }

--- a/components/views/user/profile/Profile.vue
+++ b/components/views/user/profile/Profile.vue
@@ -63,9 +63,8 @@ export default Vue.extend({
       this.closeModal()
       this.$store.commit('ui/setUserProfile', {})
     },
-    setRoute(destination: string) {
-      console.log(destination)
-      this.route = destination
+    setRoute(route: string) {
+      this.route = route
     },
   },
 })

--- a/components/views/user/profile/Profile.vue
+++ b/components/views/user/profile/Profile.vue
@@ -4,7 +4,11 @@
 import Vue from 'vue'
 import { mapState } from 'vuex'
 
-import { UserPlusIcon, MoreVerticalIcon } from 'satellite-lucide-icons'
+import {
+  UserPlusIcon,
+  MoreVerticalIcon,
+  AwardIcon,
+} from 'satellite-lucide-icons'
 import { sampleProfileInfo } from '~/mock/profile'
 
 declare module 'vue/types/vue' {
@@ -18,6 +22,7 @@ export default Vue.extend({
   components: {
     UserPlusIcon,
     MoreVerticalIcon,
+    AwardIcon,
   },
   props: {
     closeModal: {
@@ -30,19 +35,19 @@ export default Vue.extend({
       route: 'about',
       tabs: [
         {
-          text: 'About',
+          text: this.$t('modal.profile.about.tab'),
           route: 'about',
         },
         {
-          text: 'Accounts',
+          text: this.$t('modal.profile.accounts'),
           route: 'accounts',
         },
         {
-          text: 'Activity',
+          text: this.$t('modal.profile.activity.tab'),
           route: 'activity',
         },
         {
-          text: 'Mutual',
+          text: this.$t('modal.profile.mutual.tab'),
           route: 'mutual',
         },
       ],
@@ -56,6 +61,10 @@ export default Vue.extend({
     profilePictureSrc() {
       const hash = this.ui.userProfile.profilePicture
       return hash ? `${this.$Config.textile.browser}/ipfs/${hash}` : ''
+    },
+    // temp until we get real badges
+    badgeColors() {
+      return ['', '#F6CC6B', '#61CEA4', '#DA716F']
     },
   },
   methods: {

--- a/components/views/user/profile/Profile.vue
+++ b/components/views/user/profile/Profile.vue
@@ -4,20 +4,68 @@
 import Vue from 'vue'
 import { mapState } from 'vuex'
 
+import { UserPlusIcon, MoreVerticalIcon } from 'satellite-lucide-icons'
+import { sampleProfileInfo } from '~/mock/profile'
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    closeModal: () => void
+    route: string
+  }
+}
+
 export default Vue.extend({
+  components: {
+    UserPlusIcon,
+    MoreVerticalIcon,
+  },
   props: {
     closeModal: {
       type: Function,
       default: () => {},
     },
   },
+  data() {
+    return {
+      route: 'about',
+      tabs: [
+        {
+          text: 'About',
+          route: 'about',
+        },
+        {
+          text: 'Accounts',
+          route: 'accounts',
+        },
+        {
+          text: 'Activity',
+          route: 'activity',
+        },
+        {
+          text: 'Mutual',
+          route: 'mutual',
+        },
+      ],
+    }
+  },
   computed: {
     ...mapState(['ui']),
+    sample() {
+      return sampleProfileInfo
+    },
+    profilePictureSrc() {
+      const hash = this.ui.userProfile.profilePicture
+      return hash ? `${this.$Config.textile.browser}/ipfs/${hash}` : ''
+    },
   },
   methods: {
     closeProfileModal() {
       this.closeModal()
       this.$store.commit('ui/setUserProfile', {})
+    },
+    setRoute(destination: string) {
+      console.log(destination)
+      this.route = destination
     },
   },
 })


### PR DESCRIPTION
**What this PR does** 📖
- backbone of the profile modal (fully responsive) with..
  - mock profile images (pull real data after it's added to store)
  - real user name, status, and picture
  - generic tab component (can be reused elsewhere)
- refactor UserState size so I can use large version on profile
- fix unrelated margin bug for enhancers mobile
- adjust a few css files to use breakpoint variables rather than hard coded pixel values

**Which issue(s) this PR fixes** 🔨
AP-507

**Special notes for reviewers** 🗒️
**Additional comments** 🎤
