### PR TITLE
feat(privacySettings): create privacy settings tab

### DIFF
--- a/components/views/settings/Sidebar.vue
+++ b/components/views/settings/Sidebar.vue
@@ -57,6 +57,10 @@ export default Vue.extend({
               to: 'accounts',
               text: 'Accounts & Devices',
             },
+            {
+              to: 'privacy',
+              text: 'Privacy',
+            },
           ] as Array<SidebarLink>,
         } as SidebarGrouping,
         {

--- a/components/views/settings/modal/Modal.html
+++ b/components/views/settings/modal/Modal.html
@@ -36,6 +36,7 @@
           <SettingsPagesStorage v-if="page === 'storage'" />
           <SettingsPagesNetwork v-if="page === 'network'" />
           <SettingsPagesRealms v-if="page === 'realms'" />
+          <SettingsPagesPrivacy v-if="page === 'privacy'" />
         </UiScroll>
       </swiper-slide>
     </swiper>

--- a/components/views/settings/pages/privacy/Privacy.html
+++ b/components/views/settings/pages/privacy/Privacy.html
@@ -1,0 +1,38 @@
+<div id="privacy-settings">
+  <div class="columns is-desktop">
+    <div class="column">
+      <TypographyTitle :size="6" :text="$t('pages.privacy.title')" />
+      <TypographySubtitle :size="6" :text="$t('pages.privacy.subtitle')" />
+    </div>
+  </div>
+  <UiScroll verticalScroll enableWrap scrollbarVisibility="scroll">
+    <div class="columns is-desktop">
+      <SettingsUnit
+        :title="$t('pages.privacy.register.title')"
+        :text="$t('pages.privacy.register.subtitle')"
+      >
+        <InteractablesSwitch :isEnabled="true" />
+      </SettingsUnit>
+      <SettingsUnit
+        :title="$t('pages.privacy.pin.title')"
+        :text="$t('pages.privacy.pin.subtitle')"
+      >
+        <InteractablesSwitch v-model="storePin" />
+      </SettingsUnit>
+    </div>
+    <div class="columns is-desktop">
+      <SettingsUnit
+        :title="$t('pages.privacy.embeds.title')"
+        :text="$t('pages.privacy.embeds.subtitle')"
+      >
+        <InteractablesSwitch v-model="embeddedLinks" />
+      </SettingsUnit>
+      <SettingsUnit
+        :title="$t('pages.privacy.activity.title')"
+        :text="$t('pages.privacy.activity.subtitle')"
+      >
+        <InteractablesSwitch v-model="displayCurrentActivity" />
+      </SettingsUnit>
+    </div>
+  </UiScroll>
+</div>

--- a/components/views/settings/pages/privacy/index.vue
+++ b/components/views/settings/pages/privacy/index.vue
@@ -1,0 +1,43 @@
+<template src="./Privacy.html" />
+
+<script lang="ts">
+import Vue from 'vue'
+import { mapState } from 'vuex'
+import { Themes, Flairs, ThemeNames } from '~/store/ui/types.ts'
+export default Vue.extend({
+  name: 'PrivacySettings',
+  layout: 'settings',
+  data() {
+    return {
+      registry: true,
+    }
+  },
+  computed: {
+    ...mapState(['ui', 'accounts', 'settings']),
+    storePin: {
+      set(state) {
+        this.$store.commit('accounts/setStorePin', state)
+      },
+      get() {
+        return !this.accounts ? false : this.accounts.storePin
+      },
+    },
+    embeddedLinks: {
+      set(state) {
+        this.$store.commit('settings/embeddedLinks', state)
+      },
+      get() {
+        return this.settings.embeddedLinks
+      },
+    },
+    displayCurrentActivity: {
+      set(state) {
+        this.$store.commit('settings/displayCurrentActivity', state)
+      },
+      get() {
+        return this.settings.displayCurrentActivity
+      },
+    },
+  },
+})
+</script>


### PR DESCRIPTION
What this PR does 📖

  Create privacy settings tab like below screen
  ![image](https://user-images.githubusercontent.com/81814644/150454778-704f29d6-4e1f-4f68-98e7-dde04df5938c.png)
  
  The embeds option is currently available in ‘Network’ in settings, and needs to be relocated, the others are not and need to be added.
  Disable the ‘register username’ toggle

Which issue(s) this PR fixes 🔨
AP-485
