### PR TITLE
fix(call): fix ui issue when user hang up / deny call

### DIFF
--- a/components/ui/Global/Global.vue
+++ b/components/ui/Global/Global.vue
@@ -85,8 +85,8 @@ export default Vue.extend({
 
       peer?.call.deny()
 
-      // peer?.send('SIGNAL', { type: 'CALL_DENIED' })
-      // this.$store.dispatch('webrtc/denyCall')
+      peer?.send('SIGNAL', { type: 'CALL_DENIED' })
+      this.$store.dispatch('webrtc/denyCall')
     },
   },
 })

--- a/store/webrtc/actions.ts
+++ b/store/webrtc/actions.ts
@@ -74,12 +74,12 @@ export default {
       )
     })
 
-    // peer?.communicationBus.on('RAW_DATA', (message) => {
-    //   if (message.data.type === 'CALL_DENIED') {
-    //     peer?.call.hangUp()
-    //     dispatch('hangUp')
-    //   }
-    // })
+    peer?.communicationBus.on('RAW_DATA', (message) => {
+      if (message.data.type === 'CALL_DENIED') {
+        peer?.call.hangUp()
+        dispatch('hangUp')
+      }
+    })
 
     peer?.call.on('INCOMING_CALL', (data) => {
       // if incoming call is activer call return before toggling incoming call


### PR DESCRIPTION
**What this PR does** 📖

Right now if a user disconnects/deny call, the other user doesn’t get any feedback via sound or ui update. The call should end/ui should exit the call instead of leaving it open

**Which issue(s) this PR fixes** 🔨

AP-524
