### PR TITLE
add(jest): 100% coverage for SoundManager unit test

### DIFF
--- a/libraries/SoundManager/SoundManager.test.ts
+++ b/libraries/SoundManager/SoundManager.test.ts
@@ -1,0 +1,90 @@
+import { Howl } from 'howler'
+
+import { Sounds } from './SoundManager'
+import SoundManager from './SoundManager'
+
+describe('init', () => {
+    it('should pass',() => {
+        expect(Sounds).toMatchSnapshot(`
+    Object {
+    "CALL": "call",
+    "CONNECTED": "connected",
+    "DEAFEN": "deafen",
+    "HANGUP": "hangup",
+    "MUTE": "mute",
+    "NEW_MESSAGE": "newMessage",
+    "UNDEAFEN": "undeafen",
+    "UNMUTE": "unmute",
+    "UPLOAD": "upload",
+    }
+        `)
+    })
+})
+
+describe('Manage sounds', () => {
+    let inst: any
+    let volume: number = 1.0
+
+    beforeEach(() => {
+        inst = new SoundManager(volume)
+    })
+
+    test('sound exists', () => {
+        let result: any = inst.existsSound(Sounds.CALL)
+        expect(result).toMatchSnapshot()
+    })
+    
+    test('sound doesn\'t exists', () => {
+        try {
+            inst.existsSound(null)
+        } catch (error) {
+            expect(error).toBeInstanceOf(Error);
+            expect(error).toHaveProperty('message', 'Sound not found');
+        }
+    })
+    
+    test('sound plays', () => {
+        const spy = jest.spyOn(inst.sounds[Sounds.CALL], 'play')
+        let result: any = inst.playSound(Sounds.CALL)
+
+        // Some sort of lead for the `Error: Not implemented: HTMLMediaElement.prototype.play` error, also `prototype.pause`
+        //
+        // const playStub = jest
+        //         .spyOn(window.HTMLMediaElement.prototype, 'play')
+        //         .mockImplementation(() => new Promise<void>((resolve, reject) => {
+        //             return {}
+        //         }))
+        // const loadStub = jest
+        //         .spyOn(window.HTMLMediaElement.prototype, 'load')
+        //         .mockImplementation(() => {})
+        // expect(playStub).not.toHaveBeenCalled();
+        // expect(loadStub).not.toHaveBeenCalled();
+
+        expect(spy).toHaveBeenCalled();
+        expect(result).toMatchSnapshot()
+    })
+    
+    test('sound stops', () => {
+        const spy = jest.spyOn(inst.sounds[Sounds.CALL], 'stop')
+        let result: any = inst.stopSound(Sounds.CALL)
+
+        expect(spy).toHaveBeenCalled();
+        expect(result).toMatchSnapshot()
+    })
+    
+    test('sound is playing', () => {
+        const spy = jest.spyOn(inst.sounds[Sounds.CALL], 'playing')
+        let result: any = inst.isPlaying(Sounds.CALL)
+
+        expect(spy).toHaveBeenCalled();
+        expect(result).toMatchSnapshot()
+    })
+    
+    test('change volume level of sound', () => {
+        const spy = jest.spyOn(inst.sounds[Sounds.CALL], 'volume')
+        let result: any = inst.changeLevels(volume)
+
+        expect(spy).toHaveBeenCalled();
+        expect(result).toMatchSnapshot()
+    })
+})

--- a/libraries/SoundManager/SoundManager.test.ts
+++ b/libraries/SoundManager/SoundManager.test.ts
@@ -1,11 +1,23 @@
 import { Howl } from 'howler'
 
-import { Sounds } from './SoundManager'
-import SoundManager from './SoundManager'
+import SoundManager, { Sounds } from './SoundManager'
+
+window.HTMLMediaElement.prototype.load = () => {
+  /* do nothing */
+}
+window.HTMLMediaElement.prototype.play = () => {
+  /* do nothing */
+}
+window.HTMLMediaElement.prototype.pause = () => {
+  /* do nothing */
+}
+window.HTMLMediaElement.prototype.addTextTrack = () => {
+  /* do nothing */
+}
 
 describe('init', () => {
-    it('should pass',() => {
-        expect(Sounds).toMatchSnapshot(`
+  it('should pass', () => {
+    expect(Sounds).toMatchSnapshot(`
     Object {
     "CALL": "call",
     "CONNECTED": "connected",
@@ -18,73 +30,73 @@ describe('init', () => {
     "UPLOAD": "upload",
     }
         `)
-    })
+  })
 })
 
 describe('Manage sounds', () => {
-    let inst: any
-    let volume: number = 1.0
+  let inst: any
+  const volume: number = 1.0
 
-    beforeEach(() => {
-        inst = new SoundManager(volume)
-    })
+  beforeEach(() => {
+    inst = new SoundManager(volume)
+  })
 
-    test('sound exists', () => {
-        let result: any = inst.existsSound(Sounds.CALL)
-        expect(result).toMatchSnapshot()
-    })
-    
-    test('sound doesn\'t exists', () => {
-        try {
-            inst.existsSound(null)
-        } catch (error) {
-            expect(error).toBeInstanceOf(Error);
-            expect(error).toHaveProperty('message', 'Sound not found');
-        }
-    })
-    
-    test('sound plays', () => {
-        const spy = jest.spyOn(inst.sounds[Sounds.CALL], 'play')
-        let result: any = inst.playSound(Sounds.CALL)
+  test('sound exists', () => {
+    const result: any = inst.existsSound(Sounds.CALL)
+    expect(result).toMatchSnapshot()
+  })
 
-        // Some sort of lead for the `Error: Not implemented: HTMLMediaElement.prototype.play` error, also `prototype.pause`
-        //
-        // const playStub = jest
-        //         .spyOn(window.HTMLMediaElement.prototype, 'play')
-        //         .mockImplementation(() => new Promise<void>((resolve, reject) => {
-        //             return {}
-        //         }))
-        // const loadStub = jest
-        //         .spyOn(window.HTMLMediaElement.prototype, 'load')
-        //         .mockImplementation(() => {})
-        // expect(playStub).not.toHaveBeenCalled();
-        // expect(loadStub).not.toHaveBeenCalled();
+  test("sound doesn't exists", () => {
+    try {
+      inst.existsSound(null)
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error)
+      expect(error).toHaveProperty('message', 'Sound not found')
+    }
+  })
 
-        expect(spy).toHaveBeenCalled();
-        expect(result).toMatchSnapshot()
-    })
-    
-    test('sound stops', () => {
-        const spy = jest.spyOn(inst.sounds[Sounds.CALL], 'stop')
-        let result: any = inst.stopSound(Sounds.CALL)
+  test('sound plays', () => {
+    const spy = jest.spyOn(inst.sounds[Sounds.CALL], 'play')
+    const result: any = inst.playSound(Sounds.CALL)
 
-        expect(spy).toHaveBeenCalled();
-        expect(result).toMatchSnapshot()
-    })
-    
-    test('sound is playing', () => {
-        const spy = jest.spyOn(inst.sounds[Sounds.CALL], 'playing')
-        let result: any = inst.isPlaying(Sounds.CALL)
+    // Some sort of lead for the `Error: Not implemented: HTMLMediaElement.prototype.play` error, also `prototype.pause`
+    //
+    // const playStub = jest
+    //         .spyOn(window.HTMLMediaElement.prototype, 'play')
+    //         .mockImplementation(() => new Promise<void>((resolve, reject) => {
+    //             return {}
+    //         }))
+    // const loadStub = jest
+    //         .spyOn(window.HTMLMediaElement.prototype, 'load')
+    //         .mockImplementation(() => {})
+    // expect(playStub).not.toHaveBeenCalled();
+    // expect(loadStub).not.toHaveBeenCalled();
 
-        expect(spy).toHaveBeenCalled();
-        expect(result).toMatchSnapshot()
-    })
-    
-    test('change volume level of sound', () => {
-        const spy = jest.spyOn(inst.sounds[Sounds.CALL], 'volume')
-        let result: any = inst.changeLevels(volume)
+    expect(spy).toHaveBeenCalled()
+    expect(result).toMatchSnapshot()
+  })
 
-        expect(spy).toHaveBeenCalled();
-        expect(result).toMatchSnapshot()
-    })
+  test('sound stops', () => {
+    const spy = jest.spyOn(inst.sounds[Sounds.CALL], 'stop')
+    const result: any = inst.stopSound(Sounds.CALL)
+
+    expect(spy).toHaveBeenCalled()
+    expect(result).toMatchSnapshot()
+  })
+
+  test('sound is playing', () => {
+    const spy = jest.spyOn(inst.sounds[Sounds.CALL], 'playing')
+    const result: any = inst.isPlaying(Sounds.CALL)
+
+    expect(spy).toHaveBeenCalled()
+    expect(result).toMatchSnapshot()
+  })
+
+  test('change volume level of sound', () => {
+    const spy = jest.spyOn(inst.sounds[Sounds.CALL], 'volume')
+    const result: any = inst.changeLevels(volume)
+
+    expect(spy).toHaveBeenCalled()
+    expect(result).toMatchSnapshot()
+  })
 })

--- a/libraries/SoundManager/SoundManager.test.ts
+++ b/libraries/SoundManager/SoundManager.test.ts
@@ -1,5 +1,3 @@
-import { Howl } from 'howler'
-
 import SoundManager, { Sounds } from './SoundManager'
 
 describe('init', () => {

--- a/libraries/SoundManager/SoundManager.test.ts
+++ b/libraries/SoundManager/SoundManager.test.ts
@@ -2,19 +2,6 @@ import { Howl } from 'howler'
 
 import SoundManager, { Sounds } from './SoundManager'
 
-window.HTMLMediaElement.prototype.load = () => {
-  /* do nothing */
-}
-window.HTMLMediaElement.prototype.play = () => {
-  /* do nothing */
-}
-window.HTMLMediaElement.prototype.pause = () => {
-  /* do nothing */
-}
-window.HTMLMediaElement.prototype.addTextTrack = () => {
-  /* do nothing */
-}
-
 describe('init', () => {
   it('should pass', () => {
     expect(Sounds).toMatchSnapshot(`
@@ -56,21 +43,17 @@ describe('Manage sounds', () => {
   })
 
   test('sound plays', () => {
+    window.HTMLMediaElement.prototype.load = () => {
+      return Promise.resolve()
+    }
+    window.HTMLMediaElement.prototype.play = () => {
+      return Promise.resolve()
+    }
+    window.HTMLMediaElement.prototype.pause = () => {
+      return Promise.resolve()
+    }
     const spy = jest.spyOn(inst.sounds[Sounds.CALL], 'play')
     const result: any = inst.playSound(Sounds.CALL)
-
-    // Some sort of lead for the `Error: Not implemented: HTMLMediaElement.prototype.play` error, also `prototype.pause`
-    //
-    // const playStub = jest
-    //         .spyOn(window.HTMLMediaElement.prototype, 'play')
-    //         .mockImplementation(() => new Promise<void>((resolve, reject) => {
-    //             return {}
-    //         }))
-    // const loadStub = jest
-    //         .spyOn(window.HTMLMediaElement.prototype, 'load')
-    //         .mockImplementation(() => {})
-    // expect(playStub).not.toHaveBeenCalled();
-    // expect(loadStub).not.toHaveBeenCalled();
 
     expect(spy).toHaveBeenCalled()
     expect(result).toMatchSnapshot()

--- a/libraries/SoundManager/__snapshots__/SoundManager.test.ts.snap
+++ b/libraries/SoundManager/__snapshots__/SoundManager.test.ts.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Manage sounds change volume level of sound 1`] = `undefined`;
+
+exports[`Manage sounds sound exists 1`] = `undefined`;
+
+exports[`Manage sounds sound is playing 1`] = `false`;
+
+exports[`Manage sounds sound plays 1`] = `undefined`;
+
+exports[`Manage sounds sound stops 1`] = `undefined`;
+
+exports[`init should pass: 
+    Object {
+    "CALL": "call",
+    "CONNECTED": "connected",
+    "DEAFEN": "deafen",
+    "HANGUP": "hangup",
+    "MUTE": "mute",
+    "NEW_MESSAGE": "newMessage",
+    "UNDEAFEN": "undeafen",
+    "UNMUTE": "unmute",
+    "UPLOAD": "upload",
+    }
+         1`] = `
+Object {
+  "CALL": "call",
+  "CONNECTED": "connected",
+  "DEAFEN": "deafen",
+  "HANGUP": "hangup",
+  "MUTE": "mute",
+  "NEW_MESSAGE": "newMessage",
+  "UNDEAFEN": "undeafen",
+  "UNMUTE": "unmute",
+  "UPLOAD": "upload",
+}
+`;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖

Add unit tests (100% coverage) for the SoundManager unit test.

**Which issue(s) this PR fixes** 🔨

AP-139

<!--AP-X-->

**Special notes for reviewers** 🗒️

The `this.sounds[sound].play()` returns two weird `console.error`:

![image](https://user-images.githubusercontent.com/34530026/150844410-bf732163-626c-4a74-bb25-83ea320ea340.png)

I did some googling and came across [this](https://stackoverflow.com/questions/51829319/how-to-mock-video-pause-function-using-jest/51831366), to which I tried to add to the code but it didn't work so I just commented it out for further debugging!

![image](https://user-images.githubusercontent.com/34530026/150844497-95539333-b447-4a5b-b7fe-84af2d06ee6b.png)

I think it's a particular problem to` .play()` because other units in the test suite are written identically and yet only `.play()` have those two console errors:

![image](https://user-images.githubusercontent.com/34530026/150844627-c1198f75-c536-4af1-9a86-af9ecdbe5f88.png)



**Additional comments** 🎤
