### PR TITLE
feat(profilePic): block nsfw profile picture uploads AP-503

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -102,9 +102,9 @@ export const Config = {
     // Regex to check if string is only blank space
     blankSpace: '^[\\s|&nbsp;]*$',
     // Regex to check if string contains only emoji's. Note: doesn't yet support emoji modifiers
-    isEmoji: /\w*[{Emoji_Presentation}\u200d]+/gu,
+    isEmoji: /\w*[{Emoji_Presentation}\u200D]+/gu,
     // Regex to wrap emoji's in spans. Note: Doesn't yet support emoji modifiers
-    emojiWrapper: /[\p{Emoji_Presentation}\u200d]+/gu,
+    emojiWrapper: /[\p{Emoji_Presentation}\u200D]+/gu,
     // check for link
     link: /(\b(https?):\/\/[-A-Z0-9+&@#/%?=~_|!:,.;]*[-A-Z0-9+&@#/%=~_|])/gi,
     youtube: /^https?:\/\/([a-z0-9-]+[.])*youtube.com?/g,


### PR DESCRIPTION
**What this PR does** 📖
- block nsfw profile pictures on account registration
- block pictures that are too large to be NSFW scanned. I think hogan said we may ultimately break the nsfw check off to a separate service to allow for larger files to be scanned. Although, profile pic ultimately gets cropped and scaled down quite a bit anyway, so allowing larger files here doesn't seem mission critical.
- fix minor linter suggestion on config file

**Which issue(s) this PR fixes** 🔨
AP-503

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
