### PR TITLE
fix(webrtc): replace setConnectedTime with updateCreatedAt

### DIFF
--- a/store/webrtc/actions.ts
+++ b/store/webrtc/actions.ts
@@ -5,7 +5,6 @@ import Crypto from '~/libraries/Crypto/Crypto'
 
 import { ActionsArguments } from '~/types/store/store'
 import WebRTC from '~/libraries/WebRTC/WebRTC'
-import StreamManager from '~/libraries/WebRTC/StreamManager'
 import Logger from '~/utilities/Logger'
 import { TracksManager } from '~/libraries/WebRTC/TracksManager'
 

--- a/store/webrtc/actions.ts
+++ b/store/webrtc/actions.ts
@@ -96,13 +96,13 @@ export default {
     peer?.call.on('CONNECTED', (data) => {
       commit('setIncomingCall', '')
       commit('setActiveCall', data.peerId)
-      commit('setConnectedTime', Date.now())
+      commit('updateCreatedAt', Date.now())
     })
 
     peer?.call.on('HANG_UP', (data) => {
       commit('setIncomingCall', '')
       commit('setActiveCall', '')
-      commit('setConnectedTime', 0)
+      commit('updateCreatedAt', 0)
       commit('updateLocalTracks', {
         audio: {},
         video: {},

--- a/store/webrtc/mutations.test.ts
+++ b/store/webrtc/mutations.test.ts
@@ -324,8 +324,10 @@ describe('Mutate WebRTC by updating', () => {
   })
 
   it('should update time of creation', () => {
-    // This particular test suite somehow has an error: TypeError: Cannot set properties of undefined (setting 'createdAt')
-    // How we bypassed it is by passing `state.webrtc` instead of just plainly `state` like in the other unit test
+    /*
+     * This particular test suite somehow has an error: TypeError: Cannot set properties of undefined (setting 'createdAt')
+     * How we bypassed it is by passing `state.webrtc` instead of just plainly `state` like in the other unit test
+     */
 
     const localStateForUnitTest = { ...state }
     const dummyDate = Date.now()

--- a/store/webrtc/mutations.test.ts
+++ b/store/webrtc/mutations.test.ts
@@ -132,22 +132,6 @@ describe('Mutate WebRTC by setting', () => {
     })
   })
 
-  it('should update time of creation', () => {
-    // Identical to the updateCreatedAt unit test
-    // This particular test suite somehow has an error: TypeError: Cannot set properties of undefined (setting 'createdAt')
-    // How we bypassed it is by passing `state.webrtc` instead of just plainly `state` like in the other unit test
-
-    const localStateForUnitTest = { ...state }
-    const dummyDate = Date.now()
-    inst.setConnectedTime(localStateForUnitTest.webrtc, dummyDate)
-
-    expect(localStateForUnitTest.webrtc).toMatchObject({
-      activeStream: {
-        createdAt: dummyDate,
-      },
-    })
-  })
-
   it('should set connected peer', () => {
     const localStateForUnitTest = { ...state }
     inst.setConnectedPeer(localStateForUnitTest, '0x0')
@@ -340,7 +324,6 @@ describe('Mutate WebRTC by updating', () => {
   })
 
   it('should update time of creation', () => {
-    // Identical to the setConnectedTime unit test
     // This particular test suite somehow has an error: TypeError: Cannot set properties of undefined (setting 'createdAt')
     // How we bypassed it is by passing `state.webrtc` instead of just plainly `state` like in the other unit test
 

--- a/store/webrtc/mutations.ts
+++ b/store/webrtc/mutations.ts
@@ -10,9 +10,6 @@ const mutations = {
   setActiveCall(state: WebRTCState, id: string) {
     state.activeCall = id
   },
-  setConnectedTime(state: WebRTCState, timestamp: number) {
-    state.activeStream.createdAt = timestamp
-  },
   setConnectedPeer(state: WebRTCState, id: string) {
     state.connectedPeer = id
   },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖

Omitted the redundant `setConnectedTime` with `updateCreatedAt` does the exact same thing, as per the discussion on #1152 

**Which issue(s) this PR fixes** 🔨

AP-606
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
