### PR TITLE
fix(Theme): deactivate flair dropdown until selects moonless night

### DIFF
--- a/components/interactables/Select/Select.less
+++ b/components/interactables/Select/Select.less
@@ -88,6 +88,11 @@
   outline: none;
 }
 
-&.disabled {
-  opacity: 0.8;
+.disabled {
+  .custom-select {
+    .selected {
+      box-shadow: 0 5px 14px -5px @gray !important;
+      background: @gray !important;
+    }
+  }
 }

--- a/components/interactables/Select/Select.vue
+++ b/components/interactables/Select/Select.vue
@@ -81,7 +81,7 @@ export default Vue.extend({
      * @example
      */
     selected(newValue, oldValue) {
-      if (!oldValue) {
+      if (oldValue !== newValue) {
         this.$data.selectedValue = newValue
       }
     },

--- a/components/interactables/Switch/Switch.less
+++ b/components/interactables/Switch/Switch.less
@@ -66,10 +66,12 @@
     .switch-button.locked {
       .sw-button {
         border-color: @gray;
-        background: @gray !important;
-        box-shadow: -5px 0px 20px -2px @gray !important;
+        .sw-button {
+          border-color: @gray;
+          background: @gray !important;
+          box-shadow: -5px 0px 20px -2px @gray !important;
+        }
       }
-      border-color: @gray;
     }
     .switch-button-label {
       margin-left: 10px;

--- a/components/interactables/Switch/Switch.less
+++ b/components/interactables/Switch/Switch.less
@@ -63,7 +63,14 @@
         }
       }
     }
-
+    .switch-button.locked {
+      .sw-button {
+        border-color: @gray;
+        background: @gray !important;
+        box-shadow: -5px 0px 20px -2px @gray !important;
+      }
+      border-color: @gray;
+    }
     .switch-button-label {
       margin-left: 10px;
     }

--- a/components/views/settings/pages/personalize/Personalize.html
+++ b/components/views/settings/pages/personalize/Personalize.html
@@ -16,12 +16,7 @@
     <div class="column">
       <TypographyLabel :text="$t('pages.settings.personalize.theme')" />
       <br />
-      <InteractablesSelect
-        v-model="theme"
-        size="small"
-        :options="themes"
-        :selected="ui.theme.base.value"
-      />
+      <InteractablesSelect v-model="theme" size="small" :options="themes" />
     </div>
   </div>
 
@@ -30,11 +25,11 @@
       <TypographyLabel :text="$t('pages.settings.personalize.flair')" />
       <br />
       <InteractablesSelect
+        :disabled="theme===ThemeNames.DEFAULT"
         v-model="flair"
         size="small"
         :options="flairs"
         colorSupport
-        :selected="ui.theme.flair.value"
       />
     </div>
   </div>

--- a/components/views/settings/pages/personalize/Personalize.html
+++ b/components/views/settings/pages/personalize/Personalize.html
@@ -25,7 +25,7 @@
       <TypographyLabel :text="$t('pages.settings.personalize.flair')" />
       <br />
       <InteractablesSelect
-        :disabled="theme===ThemeNames.DEFAULT"
+        :disabled="theme === ThemeNames.DEFAULT"
         v-model="flair"
         size="small"
         :options="flairs"

--- a/components/views/settings/pages/personalize/index.vue
+++ b/components/views/settings/pages/personalize/index.vue
@@ -23,11 +23,13 @@ export default Vue.extend({
         const activeTheme = Themes.find((th) => {
           return th.value === state
         })
-        if (activeTheme.name === ThemeNames.DEFAULT) {
-          this.$store.commit(
-            'ui/updateFlair',
-            Flairs.find((flair) => flair.value === FlairColors.SATELLITE),
+        if (activeTheme?.name === ThemeNames.DEFAULT) {
+          const flairValue = Flairs.find(
+            (flair) => flair.value === FlairColors.SATELLITE,
           )
+          if (flairValue) {
+            this.$store.commit('ui/updateFlair', flairValue)
+          }
         }
         this.$store.commit('ui/updateTheme', activeTheme)
       },

--- a/components/views/settings/pages/personalize/index.vue
+++ b/components/views/settings/pages/personalize/index.vue
@@ -3,7 +3,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import { mapState } from 'vuex'
-import { Themes, Flairs, ThemeNames } from '~/store/ui/types.ts'
+import { Themes, Flairs, FlairColors, ThemeNames } from '~/store/ui/types.ts'
 export default Vue.extend({
   name: 'PersonalizeSettings',
   layout: 'settings',
@@ -23,6 +23,12 @@ export default Vue.extend({
         const activeTheme = Themes.find((th) => {
           return th.value === state
         })
+        if (activeTheme.name === ThemeNames.DEFAULT) {
+          this.$store.commit(
+            'ui/updateFlair',
+            Flairs.find((flair) => flair.value === FlairColors.SATELLITE),
+          )
+        }
         this.$store.commit('ui/updateTheme', activeTheme)
       },
       get() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Themes - the flair dropdown be deactivated until the user selects the moonlight theme

**Which issue(s) this PR fixes** 🔨
deactivate flair dropdown until selects moonless night and set the satellite as default.
<!--AP-X-->
AP-424
**Special notes for reviewers** 🗒️

**Additional comments** 🎤
