### PR TITLE
add(jest): 100% coverage for libraries/ui/Alerts.ts unit test

### DIFF
--- a/libraries/ui/Alerts.test.ts
+++ b/libraries/ui/Alerts.test.ts
@@ -1,0 +1,58 @@
+import * as _ from 'lodash'
+import * as Alerts from './Alerts'
+
+describe('test alert methods', () => {
+  const AlertsConstructor = new Alerts.Alerts()
+  const inst = AlertsConstructor
+  const state = inst.all
+
+  test('get all active alerts', () => {
+    const result: any = inst.all
+    expect(result).toEqual(state)
+  })
+  test('make alert', () => {
+    const dummyData = {
+      type: Alerts.AlertType.DEV,
+      content: {
+        title: 'Title',
+        description: 'Description',
+      },
+    }
+    const result: any = inst.make(dummyData)
+
+    // Because an Alert type have `Date.now()` and the `uuidv4()` function, we cannot check it
+    // because it's value that's generated there will be different with the ones generated here.
+
+    expect(result.type).toBe(dummyData.type)
+    expect(result.content.title).toBe(dummyData.content.title)
+    expect(result.content.description).toBe(dummyData.content.description)
+  })
+  test('mark alert', () => {
+    const alertToBeMarked = state.find(
+      (e) => e.state === Alerts.AlertState.UNREAD,
+    ) // Select a message that has not been read
+
+    const result: any = inst.mark(Alerts.AlertState.READ, alertToBeMarked!.id!)
+    const updatedPublicStore = inst.all
+    const markedAlert = updatedPublicStore.find((alert) => {
+      return alert.id === alertToBeMarked!.id
+    })
+
+    expect(result.state).toBe(markedAlert!.state)
+  })
+  test('delete alert', () => {
+    const alertToBeDeleted = inst.all.at(-1) // Select the last message to be deleted, though it can be any message
+
+    const result: any = inst.delete(alertToBeDeleted!.id!)
+    const updatedPublicStore = inst.all
+    const deletedAlert = updatedPublicStore.find((alert) => {
+      return alert.id === alertToBeDeleted!.id
+    }) // The find() method returns the value of the first element in the provided array that satisfies the provided
+    // testing function. If no values satisfy the testing function, undefined is returned.
+
+    // Because the selected alert has been deleted, we will expect it to return undefined
+
+    expect(deletedAlert).toBe(undefined)
+    expect(result).toEqual(inst.all) // We expect that the result from the mutated array to equal the latest public story
+  })
+})

--- a/libraries/ui/Alerts.test.ts
+++ b/libraries/ui/Alerts.test.ts
@@ -1,4 +1,3 @@
-import * as _ from 'lodash'
 import * as Alerts from './Alerts'
 
 describe('test alert methods', () => {

--- a/libraries/ui/Alerts.ts
+++ b/libraries/ui/Alerts.ts
@@ -11,28 +11,28 @@ export enum AlertType {
 
 export enum AlertState {
   READ = 'READ',
-  UNREAD = 'UNREAD'
+  UNREAD = 'UNREAD',
 }
 
 export type Alert = {
-  at?: number,
-  id?: string,
-  state?: AlertState,
-  type: AlertType,
+  at?: number
+  id?: string
+  state?: AlertState
+  type: AlertType
   content: {
-    title: string,
-    description: string,
+    title: string
+    description: string
     image?: string
-  },
+  }
 }
 
 export type AlertTemplate = {
-  type: AlertType,
+  type: AlertType
   content: {
-    title: string,
-    description: string,
+    title: string
+    description: string
     image?: string
-  },
+  }
 }
 
 export class Alerts {
@@ -44,9 +44,11 @@ export class Alerts {
       type: AlertType.DEV,
       content: {
         title: 'ATTN:// Cortana',
-        description: "This is a test message to use for building alerts, it's meaningless and just for demo purposes.",
-        image: 'http://forums.windowscentral.com/attachments/cortana/61269d1396509365t-cortana.jpg'
-      }
+        description:
+          "This is a test message to use for building alerts, it's meaningless and just for demo purposes.",
+        image:
+          'http://forums.windowscentral.com/attachments/cortana/61269d1396509365t-cortana.jpg',
+      },
     },
     {
       at: Date.now(),
@@ -55,13 +57,13 @@ export class Alerts {
       type: AlertType.DEV,
       content: {
         title: 'TX:// Guilty Spark',
-        description: "This is a another meaningless test alert message. Ignore me please.",
-        image: 'https://www.giantbomb.com/a/uploads/square_small/0/5150/340231-46172909_343gs.jpg'
-      }
-    }
+        description:
+          'This is a another meaningless test alert message. Ignore me please.',
+        image:
+          'https://www.giantbomb.com/a/uploads/square_small/0/5150/340231-46172909_343gs.jpg',
+      },
+    },
   ]
-
-  constructor() {}
 
   /**
    * @getter all
@@ -108,12 +110,12 @@ export class Alerts {
    * @param id Alert id to mutate
    */
   mark(state: AlertState, id: string): Alert | undefined {
-    const idx = this.all.findIndex((a => a.id === id))
+    const idx = this.all.findIndex((a) => a.id === id)
     this._alerts[idx] = {
       ...this._alerts[idx],
-      state
+      state,
     }
-    return this.all.find(a => a.id === id)
+    return this.all.find((a) => a.id === id)
   }
 
   /**
@@ -122,7 +124,7 @@ export class Alerts {
    * @param id Alert id to delete
    */
   delete(id: string): Alert[] {
-    this._alerts = this._alerts.filter(a => a.id !== id)
+    this._alerts = this._alerts.filter((a) => a.id !== id)
     return this.all
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖

- lint ui/Alerts
- remove useless constructor, 
- and 100% coverage for libraries/ui/Alerts.ts unit test

**Which issue(s) this PR fixes** 🔨

AP-565
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
