### PR TITLE
fix(upload): upload same file twice second preview not showing

### DIFF
--- a/components/views/files/upload/Upload.html
+++ b/components/views/files/upload/Upload.html
@@ -38,6 +38,8 @@
   <input
     :type="editable ? `file` : `hidden`"
     id="quick-upload"
+    ref="quickUpload"
+    @click="resetFileUpload"
     @change="handleFile"
     multiple
   />

--- a/components/views/files/upload/Upload.vue
+++ b/components/views/files/upload/Upload.vue
@@ -66,6 +66,15 @@ export default Vue.extend({
   },
   methods: {
     /**
+     * @method resetFileUpload
+     * @description Clear the value of file input so trigger the handleFile for the same file.
+     * @example <input @onclick="resetFileUpload" />
+     */
+    async resetFileUpload() {
+      if (this.$refs.quickUpload)
+        (this.$refs.quickUpload as HTMLFormElement).value = ''
+    },
+    /**
      * @method handleFile
      * @description Handles file in event object by NSFW checking and then loading it. Triggered when a file is changed on the input.
      * @param event Input event object


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
If you try to upload the same file twice from the chatbar, the first time works fine but then if you remove the preview and try to re-upload it the preview won't show, and this PR fix this.
**Which issue(s) this PR fixes** 🔨
AP-649
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
