### PR TITLE
chore(jest): improve jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -24,6 +24,11 @@ module.exports = {
     '<rootDir>/cypress',
     '<rootDir>/coverage',
     '<rootDir>/plugins',
+    '<rootDir>/electron',
+    '<rootDir>/libraries/Enums',
+    '<rootDir>/libraries/Files/errors',
+    '<rootDir>/libraries/Files/types',
+    '<rootDir>/types',
   ],
   testEnvironment: 'jsdom',
   transform: {


### PR DESCRIPTION


**What this PR does** 📖

Adds ignored folders on jest.config.js to avoid spam when running the jest coverage command

before

<img width="1039" alt="Captura de ecrã 2022-02-03, às 18 18 44" src="https://user-images.githubusercontent.com/29093946/152404598-9a33543d-af02-4383-816c-a29d21bd134a.png">

after

<img width="1039" alt="Captura de ecrã 2022-02-03, às 18 21 28" src="https://user-images.githubusercontent.com/29093946/152404636-b4d8f9fd-a8f3-4005-820a-f8541582942e.png">

