### PR TITLE
fix(ui): update locale on settings/profile 

### DIFF
--- a/components/views/settings/profile/card/Card.html
+++ b/components/views/settings/profile/card/Card.html
@@ -34,6 +34,9 @@
           deselectLabel=""
           selectedLabel=""
         >
+          <span slot="noResult"
+            >{{ $t('pages.settings.profile.info.noResult') }}</span
+          >
         </multiselect>
         <div class="mg-half">
           <InteractablesChip
@@ -62,6 +65,9 @@
           deselectLabel=""
           selectedLabel=""
         >
+          <span slot="noResult"
+            >{{ $t('pages.settings.profile.info.noResult') }}</span
+          >
         </multiselect>
         <div class="mg-half">
           <InteractablesChip

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -394,6 +394,7 @@ export default {
           selectLocation: 'Select Location',
           language: 'Language',
           selectLanguage: 'Select Language',
+          noResult: 'No elements found',
         },
         phrase: {
           title: 'Recovery Phrase',


### PR DESCRIPTION
… off

<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
on settings/profile page, search location, and language multi-select dropdown, when no search result, the message is cut off. put custom no result message instead of default one to fix this issue.
**Which issue(s) this PR fixes** 🔨
AP-310
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
