### PR TITLE
add(crypto, jest): functioning utilities and unit test initialization

### DIFF
--- a/libraries/Crypto/Crypto.test.ts
+++ b/libraries/Crypto/Crypto.test.ts
@@ -113,6 +113,8 @@ describe.skip('initializeRecipient', () => {
   })
 
   test('0', async () => {
+    inst.init(web3.Keypair.generate())
+    inst.signMessage(new Uint8Array([]), '')
     const param1: any = new web3.PublicKey(1)
     await inst.initializeRecipient(param1)
   })
@@ -123,11 +125,15 @@ describe.skip('initializeRecipient', () => {
   })
 
   test('2', async () => {
+    inst.init(web3.Keypair.generate())
+    inst.signMessage(new Uint8Array([]), '')
     const param1: any = new web3.PublicKey(1000)
     await inst.initializeRecipient(param1)
   })
 
   test('3', async () => {
+    inst.init(web3.Keypair.generate())
+    inst.signMessage(new Uint8Array([]), '')
     const param1: any = new web3.PublicKey(10)
     await inst.initializeRecipient(param1)
   })
@@ -264,14 +270,21 @@ describe.skip('separateIvFromData', () => {
   })
 })
 
-describe.skip('isInitialized', () => {
+describe('isInitialized', () => {
   let inst: any
 
   beforeEach(() => {
     inst = new Crypto.default()
   })
 
-  test('0', () => {
+  test('is not initialized', () => {
+    const result: any = inst.isInitialized()
+    expect(result).toMatchSnapshot()
+  })
+
+  test('is initialized', () => {
+    inst.init(web3.Keypair.generate())
+    inst.signMessage(new Uint8Array([]), '')
     const result: any = inst.isInitialized()
     expect(result).toMatchSnapshot()
   })
@@ -285,6 +298,8 @@ describe.skip('decryptFrom', () => {
   })
 
   test('0', () => {
+    inst.init(web3.Keypair.generate())
+    inst.signMessage(new Uint8Array([]), '')
     const result: any = inst.decryptFrom(
       '192.168.1.5',
       'data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20version%3D%221.1%22%20baseProfile%3D%22full%22%20width%3D%22undefined%22%20height%3D%22undefined%22%3E%3Crect%20width%3D%22100%25%22%20height%3D%22100%25%22%20fill%3D%22grey%22%2F%3E%3Ctext%20x%3D%22NaN%22%20y%3D%22NaN%22%20font-size%3D%2220%22%20alignment-baseline%3D%22middle%22%20text-anchor%3D%22middle%22%20fill%3D%22white%22%3Eundefinedxundefined%3C%2Ftext%3E%3C%2Fsvg%3E',
@@ -293,6 +308,8 @@ describe.skip('decryptFrom', () => {
   })
 
   test('1', () => {
+    inst.init(web3.Keypair.generate())
+    inst.signMessage(new Uint8Array([]), '')
     const result: any = inst.decryptFrom(
       '0.0.0.0',
       'data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20version%3D%221.1%22%20baseProfile%3D%22full%22%20width%3D%22undefined%22%20height%3D%22undefined%22%3E%3Crect%20width%3D%22100%25%22%20height%3D%22100%25%22%20fill%3D%22grey%22%2F%3E%3Ctext%20x%3D%22NaN%22%20y%3D%22NaN%22%20font-size%3D%2220%22%20alignment-baseline%3D%22middle%22%20text-anchor%3D%22middle%22%20fill%3D%22white%22%3Eundefinedxundefined%3C%2Ftext%3E%3C%2Fsvg%3E',
@@ -301,6 +318,8 @@ describe.skip('decryptFrom', () => {
   })
 
   test('2', () => {
+    inst.init(web3.Keypair.generate())
+    inst.signMessage(new Uint8Array([]), '')
     const result: any = inst.decryptFrom('', '')
     expect(result).toMatchSnapshot()
   })

--- a/libraries/Crypto/Crypto.ts
+++ b/libraries/Crypto/Crypto.ts
@@ -1,3 +1,4 @@
+import { TextEncoder, TextDecoder } from 'util'
 import { Keypair, PublicKey } from '@solana/web3.js'
 import ed2curve from 'ed2curve'
 import { sharedKey, signMessage } from 'curve25519-js'

--- a/libraries/Crypto/__snapshots__/Crypto.test.ts.snap
+++ b/libraries/Crypto/__snapshots__/Crypto.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`isInitialized is initialized 1`] = `true`;
+
+exports[`isInitialized is not initialized 1`] = `false`;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖

Add utilities that resolve the error and the following unit test (`ReferenceError: TextEncoder is not defined`, `Crypto Instance not initialized`)

**Which issue(s) this PR fixes** 🔨

AP-334

> Not fully fixed, but it's AP-334. I suggest writing from scratch the unit test because... it's a bit weird? Some of the non-base58 errors were because the string passed into the function as parameters had `i`, ` ` (spaces), and other characters that weren't valid in base58.

**Special notes for reviewers** 🗒️

This is a draft, I think I would need to spend more time on this; if it is considered worthy to be reworked!

**Additional comments** 🎤
