### PR TITLE
feat(chatImageUpload): have images persist in each chat

### DIFF
--- a/components/views/files/upload/Upload.vue
+++ b/components/views/files/upload/Upload.vue
@@ -96,7 +96,7 @@ export default Vue.extend({
       if (this.editable) {
         const files: File[] = [...event.target.files]
         this.$parent.$data.showFilePreview = files.length > 0
-        if (files.length > 8) {
+        if (files.length + this.$data.files.length > 8) {
           this.$data.count_error = true
           return
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
https://satellite-im.atlassian.net/browse/AP-113
**Which issue(s) this PR fixes** 🔨
Upload modal changes when switching between chats and preserves pending uploads. No longer uses store due to store size limitations
<!--AP-X-->

**Special notes for reviewers** 🗒️
changed the way uploads work so that pressing the upload button again with pending uploads will add to the list instead of replacing the list of pending uploads. However, line 99 of Upload.vue checks if over 8 files have been selected and throws an error if this is the case, and I'm not sure if this should be updated to check the count of files already in the list as well.
**Additional comments** 🎤
