### PR TITLE
fix(ui): fix mobile bottom padding cut off on settings modal

### DIFF
--- a/components/views/settings/modal/Modal.less
+++ b/components/views/settings/modal/Modal.less
@@ -108,6 +108,7 @@ p {
 
     .ps {
       padding-top: @normal-spacing * 3;
+      padding-bottom: @normal-spacing * 4;
       width: 100%;
     }
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
on Samsung A71, bottom part of settings modal is cut off, this PR just adds more bottom padding on settings modal
**Which issue(s) this PR fixes** 🔨
AP-677
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
