### PR TITLE
fix(ui): fix padding issue on importAccount page

### DIFF
--- a/components/typography/NumberedWord/NumberedWord.less
+++ b/components/typography/NumberedWord/NumberedWord.less
@@ -23,6 +23,6 @@
     position: absolute;
     cursor: pointer;
     top: 0;
-    right: @light-spacing;
+    right: @xlight-spacing;
   }
 }

--- a/pages/setup/ImportAccount/ImportAccount.less
+++ b/pages/setup/ImportAccount/ImportAccount.less
@@ -45,7 +45,12 @@
         width: unset;
         min-width: @full;
       }
+
+      .columns {
+        width: 18rem;
+      }
       margin: 0;
+      padding-top: 10vh;
       width: 100%;
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
on most of mobile devices, top padding of import account page is very narrow, this PR adds more to padding of import account page. and yes, close button of word phrase lacks a bit padding, so add more gap.
**Which issue(s) this PR fixes** 🔨
AP-281
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
