### PR TITLE
test(jest): remove not needed imports + minor lint

### DIFF
--- a/libraries/Solana/FriendsProgram/FriendsProgram.layout.test.ts
+++ b/libraries/Solana/FriendsProgram/FriendsProgram.layout.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as FriendsProgramLayout from '~/libraries/Solana/FriendsProgram/FriendsProgram.layout'
 
 describe('FriendsProgramLayout.encodeInstructionData', () => {

--- a/libraries/Solana/ServerProgram/ServerProgram.layout.test.ts
+++ b/libraries/Solana/ServerProgram/ServerProgram.layout.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as ServerProgramLayout from '~/libraries/Solana/ServerProgram/ServerProgram.layout'
 
 describe.skip('ServerProgramLayout.encodeInstructionData', () => {

--- a/libraries/Solana/Solana.test.ts
+++ b/libraries/Solana/Solana.test.ts
@@ -1,30 +1,29 @@
-import * as Solana from '~/libraries/Solana/Solana'
 import * as web3 from '@solana/web3.js'
-import { expect } from '@jest/globals'
+import * as Solana from '~/libraries/Solana/Solana'
 
 describe('Solana.getClusterFromNetworkConfig', () => {
   test('0', () => {
-    let result: any = Solana.getClusterFromNetworkConfig('mainnet-beta')
+    const result: any = Solana.getClusterFromNetworkConfig('mainnet-beta')
     expect(result).toMatchSnapshot()
   })
 
   test('1', () => {
-    let result: any = Solana.getClusterFromNetworkConfig('testnet')
+    const result: any = Solana.getClusterFromNetworkConfig('testnet')
     expect(result).toMatchSnapshot()
   })
 
   test('2', () => {
-    let result: any = Solana.getClusterFromNetworkConfig('West')
+    const result: any = Solana.getClusterFromNetworkConfig('West')
     expect(result).toMatchSnapshot()
   })
 
   test('3', () => {
-    let result: any = Solana.getClusterFromNetworkConfig('North')
+    const result: any = Solana.getClusterFromNetworkConfig('North')
     expect(result).toMatchSnapshot()
   })
 
   test('4', () => {
-    let result: any = Solana.getClusterFromNetworkConfig('')
+    const result: any = Solana.getClusterFromNetworkConfig('')
     expect(result).toMatchSnapshot()
   })
 })
@@ -32,34 +31,34 @@ describe('Solana.getClusterFromNetworkConfig', () => {
 describe.skip('Solana.publicKeyFromSeeds', () => {
   // AP-330
   test('0', async () => {
-    let inst: any = new Uint8Array([-1, -1, 1, 100, 100])
-    let inst2: any = new Uint8Array([100, 1, 100, 0, 0])
-    let param1: any = [inst, inst2]
-    let param3: any = new web3.PublicKey(10)
+    const inst: any = new Uint8Array([-1, -1, 1, 100, 100])
+    const inst2: any = new Uint8Array([100, 1, 100, 0, 0])
+    const param1: any = [inst, inst2]
+    const param3: any = new web3.PublicKey(10)
     await Solana.publicKeyFromSeeds(param1, 'Foo bar', param3)
   })
 
   test('1', async () => {
-    let inst: any = new Uint8Array([100, -100, 0, 0, -1])
-    let inst2: any = new Uint8Array([-100, -100, 0, -100, 100])
-    let param1: any = [inst, inst2]
-    let param3: any = new web3.PublicKey('Gail Hoppe')
+    const inst: any = new Uint8Array([100, -100, 0, 0, -1])
+    const inst2: any = new Uint8Array([-100, -100, 0, -100, 100])
+    const param1: any = [inst, inst2]
+    const param3: any = new web3.PublicKey('Gail Hoppe')
     await Solana.publicKeyFromSeeds(param1, 'Hello, world!', param3)
   })
 
   test('2', async () => {
-    let inst: any = new Uint8Array([-1, 100, -1, 1, 0])
-    let inst2: any = new Uint8Array([1, 1, 100, 0, 1])
-    let param1: any = [inst, inst2]
-    let param3: any = new web3.PublicKey(1000)
+    const inst: any = new Uint8Array([-1, 100, -1, 1, 0])
+    const inst2: any = new Uint8Array([1, 1, 100, 0, 1])
+    const param1: any = [inst, inst2]
+    const param3: any = new web3.PublicKey(1000)
     await Solana.publicKeyFromSeeds(param1, 'This is a Text', param3)
   })
 
   test('3', async () => {
-    let inst: any = new Uint8Array([-100, -1, -100, 0, 100])
-    let inst2: any = new Uint8Array([-1, 100, 1, 1, 0])
-    let param1: any = [inst, inst2]
-    let param3: any = new web3.PublicKey('Janet Homenick')
+    const inst: any = new Uint8Array([-100, -1, -100, 0, 100])
+    const inst2: any = new Uint8Array([-1, 100, 1, 1, 0])
+    const param1: any = [inst, inst2]
+    const param3: any = new web3.PublicKey('Janet Homenick')
     await Solana.publicKeyFromSeeds(param1, 'foo bar', param3)
   })
 })

--- a/libraries/SoundManager/SolanaManager.test.ts
+++ b/libraries/SoundManager/SolanaManager.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as SolanaManager from '~/libraries/Solana/SolanaManager/SolanaManager'
 
 describe.skip('SolanaManager.default.stringToBuffer', () => {

--- a/libraries/Textile/Utils.test.ts
+++ b/libraries/Textile/Utils.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as utils from '~/libraries/Textile/utils'
 
 describe('utils.stringToTypedBase64', () => {

--- a/libraries/ui/Commands.test.ts
+++ b/libraries/ui/Commands.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as Commands from '~/libraries/ui/Commands'
 
 describe('Commands.parseCommand', () => {

--- a/libraries/ui/Friends.test.ts
+++ b/libraries/ui/Friends.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as Friends from '~/libraries/ui/Friends'
 
 describe('Friends.getAlphaSorted', () => {

--- a/store/audio/actions.test.ts
+++ b/store/audio/actions.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as actions from '~/store/audio/actions'
 
 describe.skip('actions.default.toggleDeafen', () => {

--- a/store/audio/mutations.test.ts
+++ b/store/audio/mutations.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as mutations from '~/store/audio/mutations'
 
 describe('mutations.default.mute', () => {

--- a/store/audio/state.test.ts
+++ b/store/audio/state.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as state from '~/store/audio/state'
 
 describe('state.default', () => {

--- a/store/chat/mutations.test.ts
+++ b/store/chat/mutations.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as mutations from '~/store/chat/mutations'
 
 describe('mutations.default.setChatReply', () => {

--- a/store/chat/state.test.ts
+++ b/store/chat/state.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as state from '~/store/chat/state'
 
 describe('state.default', () => {

--- a/store/dataState/state.test.ts
+++ b/store/dataState/state.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as state from '~/store/dataState/state'
 
 describe('state.default', () => {

--- a/store/files/actions.test.ts
+++ b/store/files/actions.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as actions from '~/store/files/actions'
 
 describe('actions.default.handler', () => {

--- a/store/files/mutations.test.ts
+++ b/store/files/mutations.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as mutations from '~/store/files/mutations'
 
 describe('mutations.default.fetchFiles', () => {

--- a/store/files/state.test.ts
+++ b/store/files/state.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as state from '~/store/files/state'
 
 describe('state.default', () => {

--- a/store/media/actions.test.ts
+++ b/store/media/actions.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as actions from '~/store/media/actions'
 
 describe('actions.default.handler', () => {

--- a/store/prerequisites/getters.test.ts
+++ b/store/prerequisites/getters.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as getters from '~/store/prerequisites/getters'
 
 describe('getters.default.allPrerequisitesReady', () => {

--- a/store/prerequisites/mutations.test.ts
+++ b/store/prerequisites/mutations.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as mutations from '~/store/prerequisites/mutations'
 
 describe('mutations.default.setTextileReady', () => {

--- a/store/prerequisites/state.test.ts
+++ b/store/prerequisites/state.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as state from '~/store/prerequisites/state'
 
 describe('state.default', () => {

--- a/store/search/mutations.test.ts
+++ b/store/search/mutations.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as mutations from '~/store/search/mutations'
 
 describe('mutations.default.setSearchQuery', () => {

--- a/store/search/state.test.ts
+++ b/store/search/state.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as state from '~/store/search/state'
 
 describe('state.default', () => {

--- a/store/settings/mutations.test.ts
+++ b/store/settings/mutations.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as mutations from '~/store/settings/mutations'
 
 describe('mutations.default.echoCancellation', () => {

--- a/store/video/mutations.test.ts
+++ b/store/video/mutations.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as mutations from '~/store/video/mutations'
 
 describe('mutations.default.toggleCamera', () => {

--- a/store/video/state.test.ts
+++ b/store/video/state.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as state from '~/store/video/state'
 
 describe('state.default', () => {

--- a/utilities/ConsoleWarning.test.ts
+++ b/utilities/ConsoleWarning.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as ConsoleWarning from '~/utilities/ConsoleWarning'
 import 'jest-canvas-mock'
 

--- a/utilities/Messaging.test.ts
+++ b/utilities/Messaging.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as Messaging from '~/utilities/Messaging'
 
 describe('Messaging.refreshTimestampInterval', () => {

--- a/utilities/SimpleWrap.test.ts
+++ b/utilities/SimpleWrap.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as SimpleWrap from '~/utilities/SimpleWrap'
 
 describe('SimpleWrap.SimpleWrap', () => {

--- a/utilities/io-ts.test.ts
+++ b/utilities/io-ts.test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals'
 import * as IoTS from '~/utilities/io-ts'
 
 describe('IoTS.fromEnum', () => {


### PR DESCRIPTION

**What this PR does** 📖

- Removes not needed `import { expect } from '@jest/globals'` on Jest tests
- Minor linting