### PR TITLE
fix(mobile): minimize keyboard when swipe sidebar

### DIFF
--- a/layouts/chat.vue
+++ b/layouts/chat.vue
@@ -129,6 +129,12 @@ export default Vue.extend({
           slideChange: () => {
             if (this.$refs.swiper && this.$refs.swiper.$swiper) {
               const newShowSidebar = this.$refs.swiper.$swiper.activeIndex === 0
+
+              // force virtual keyboard hide on mobile when swiper slide change
+              if (newShowSidebar) {
+                document.activeElement.blur()
+              }
+
               if (this.showSidebar !== newShowSidebar) {
                 this.$store.commit('ui/showSidebar', newShowSidebar)
               }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
If a user is in chat and swipes over to the Sidebar, the keyboard was not minimized. This PR fixes this by blurring active element 

**Which issue(s) this PR fixes** 🔨
AP-688
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
