### PR TITLE
fix(imageUpload): fixes uploaded images being added to the wrong chat when changing during NSFW check

### DIFF
--- a/components/views/files/upload/Upload.vue
+++ b/components/views/files/upload/Upload.vue
@@ -74,6 +74,7 @@ export default Vue.extend({
     },
   },
   mounted() {
+    console.log('test')
     this.files = cloneDeep(this.chat.files?.[this.recipient.address]) ?? []
   },
   methods: {
@@ -101,6 +102,7 @@ export default Vue.extend({
           this.$data.count_error = true
           return
         }
+        const address = this.recipient.address
         this.$data.count_error = false
         for (let i = 0; i < files.length; i++) {
           /* checking .heic file needs file array buffer because sometimes its file type return empty string */
@@ -145,6 +147,10 @@ export default Vue.extend({
             }
             uploadFile.nsfw.checking = false
           }
+          this.$store.commit('chat/addFile', {
+            file: uploadFile,
+            address,
+          })
           this.loadPicture(uploadFile)
         })
         this.files.push(...newFiles)
@@ -167,10 +173,6 @@ export default Vue.extend({
         if (e.target) item.url = e.target.result
       }
       reader.readAsDataURL(item.file)
-      this.$store.commit('chat/addFile', {
-        file: item,
-        address: this.recipient.address,
-      })
     },
     /**
      * @method cancelUpload

--- a/components/views/files/upload/Upload.vue
+++ b/components/views/files/upload/Upload.vue
@@ -74,7 +74,6 @@ export default Vue.extend({
     },
   },
   mounted() {
-    console.log('test')
     this.files = cloneDeep(this.chat.files?.[this.recipient.address]) ?? []
   },
   methods: {

--- a/components/views/files/upload/Upload.vue
+++ b/components/views/files/upload/Upload.vue
@@ -71,6 +71,7 @@ export default Vue.extend({
   watch: {
     recipient() {
       this.files = cloneDeep(this.chat.files?.[this.recipient.address]) ?? []
+      this.$parent.$data.showFilePreview = this.files.length > 0
     },
   },
   mounted() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
assigns the address in the store for uploaded images to be the one from the time the upload is initiated, not the one at the time the file has finished processing.
**Which issue(s) this PR fixes** 🔨
Previously, changing chats while an image is in the NSFW check phase would cause it to get added to the wrong chat's files array. This fixes this.
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
the store solution @josephmcg used for upload persists is a nice one that solves some problems I couldn't figure out how to work around, and investigating how his solution worked is what led me to finding this bug that would've affected both our solutions