### PR TITLE
chore(media): when a track is found, called one stops blinking

### DIFF
--- a/components/views/media/Media.html
+++ b/components/views/media/Media.html
@@ -20,7 +20,7 @@
       :videoStream="remoteVideoStream"
       :audioStream="remoteAudioStream"
       :audioMuted="remoteAudioMuted"
-      :calling="remoteTracks"
+      :calling="!remoteTracks"
     />
 
     <div

--- a/components/views/media/Media.html
+++ b/components/views/media/Media.html
@@ -20,6 +20,7 @@
       :videoStream="remoteVideoStream"
       :audioStream="remoteAudioStream"
       :audioMuted="remoteAudioMuted"
+      :calling="remoteTracks"
     />
 
     <div

--- a/components/views/media/Media.vue
+++ b/components/views/media/Media.vue
@@ -99,6 +99,29 @@ export default Vue.extend({
 
       return remoteAudioTrack ? new MediaStream([remoteAudioTrack]) : null
     },
+    remoteTracks() {
+      const { activeCall } = this.webrtc
+      const videoId = this.webrtc.remoteTracks.video.id
+      const videoMuted = this.webrtc.remoteTracks.video.muted
+
+      const audioId = this.webrtc.remoteTracks.audio.id
+      const audioMuted = this.webrtc.remoteTracks.audio.muted
+
+      const peer = this.$WebRTC.getPeer(activeCall)
+
+      const remoteVideoTrack = peer?.call.getTrackById(videoId)
+      const remoteAudioTrack = peer?.call.getTrackById(audioId)
+
+      const anyTrack = !!(
+        remoteVideoTrack ||
+        remoteAudioTrack ||
+        videoMuted ||
+        audioMuted
+      )
+
+      return !anyTrack
+    },
+
     recipient() {
       const isMe = this.$route.params.address === this.accounts.active
       const recipient = isMe

--- a/components/views/media/Media.vue
+++ b/components/views/media/Media.vue
@@ -100,28 +100,10 @@ export default Vue.extend({
       return remoteAudioTrack ? new MediaStream([remoteAudioTrack]) : null
     },
     remoteTracks() {
-      const { activeCall } = this.webrtc
-      const videoId = this.webrtc.remoteTracks.video.id
-      const videoMuted = this.webrtc.remoteTracks.video.muted
+      const { id, muted } = this.webrtc.remoteTracks.audio
 
-      const audioId = this.webrtc.remoteTracks.audio.id
-      const audioMuted = this.webrtc.remoteTracks.audio.muted
-
-      const peer = this.$WebRTC.getPeer(activeCall)
-
-      const remoteVideoTrack = peer?.call.getTrackById(videoId)
-      const remoteAudioTrack = peer?.call.getTrackById(audioId)
-
-      const anyTrack = !!(
-        remoteVideoTrack ||
-        remoteAudioTrack ||
-        videoMuted ||
-        audioMuted
-      )
-
-      return !anyTrack
+      return Boolean(id || muted)
     },
-
     recipient() {
       const isMe = this.$route.params.address === this.accounts.active
       const recipient = isMe

--- a/layouts/Layout.less
+++ b/layouts/Layout.less
@@ -150,7 +150,8 @@
 .desktop .dynamic-content.swiper-slide-next {
   padding-right: calc(@sidebar-size + @servers-size);
   #mediastream {
-    width: calc(100% - @sidebar-size - @servers-size);
+    width: calc(@full - (@normal-spacing * 2));
+    margin: 0 1rem;
   }
 }
 
@@ -191,7 +192,8 @@
   .dynamic-content.swiper-slide-next {
     padding-right: 0;
     #mediastream {
-      width: 100%;
+      width: calc(@full - (@normal-spacing * 2));
+      margin: 0 1rem;
     }
   }
   .sidebar-container {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Adds back again the "connecting animation", whenever a user got connected it stops the animation.
Fixed media width (now it's fullwidth)

**Which issue(s) this PR fixes** 🔨
AP-794
<!--AP-X-->

**Special notes for reviewers** 🗒️
I know for sure there's a cleaner code... If someone has any idea, let me know that i change my code! 👍 
By fixing media width, i found out the blink was still on after the other user joined the call, so i removed that too. (my bad i didn't open a new ticket for that)
**Additional comments** 🎤
