### PR TITLE
chore(update): hide capture mouse section

### DIFF
--- a/components/views/settings/pages/audio/Audio.html
+++ b/components/views/settings/pages/audio/Audio.html
@@ -171,14 +171,15 @@
     </SettingsUnit>
   </div>
 
-  <!-- Screen Share 
+  <!-- Screen Share -->
   <TypographyHorizontalRuleText
     plaintext
     :value="$t('pages.settings.screen.title')"
-  /> -->
+    v-if="featureReadyToShow"
+  />
 
-  <!-- Capture Mouse 
-  <div class="columns is-desktop">
+  <!-- Capture Mouse -->
+  <div class="columns is-desktop" v-if="featureReadyToShow">
     <SettingsUnit
       :title="$t('pages.settings.screen.captureMouse.title')"
       :text="$t('pages.settings.screen.captureMouse.subtitle')"
@@ -189,7 +190,7 @@
         size="small"
       />
     </SettingsUnit>
-  </div> -->
+  </div>
 
   <!-- Notification Sounds -->
   <TypographyHorizontalRuleText

--- a/components/views/settings/pages/audio/Audio.html
+++ b/components/views/settings/pages/audio/Audio.html
@@ -171,13 +171,13 @@
     </SettingsUnit>
   </div>
 
-  <!-- Screen Share -->
+  <!-- Screen Share 
   <TypographyHorizontalRuleText
     plaintext
     :value="$t('pages.settings.screen.title')"
-  />
+  /> -->
 
-  <!-- Capture Mouse -->
+  <!-- Capture Mouse 
   <div class="columns is-desktop">
     <SettingsUnit
       :title="$t('pages.settings.screen.captureMouse.title')"
@@ -189,7 +189,7 @@
         size="small"
       />
     </SettingsUnit>
-  </div>
+  </div> -->
 
   <!-- Notification Sounds -->
   <TypographyHorizontalRuleText

--- a/components/views/settings/pages/audio/index.vue
+++ b/components/views/settings/pages/audio/index.vue
@@ -46,6 +46,7 @@ export default Vue.extend({
       browserAllowsAudioOut: true,
       micLevel: 0,
       stream: null,
+      featureReadyToShow: false,
       updateInterval: null,
       captureMouses: [
         {


### PR DESCRIPTION

**What this PR does** 📖

Hides capture mouse section

before
<img width="1292" alt="Captura de ecrã 2022-02-22, às 01 02 49" src="https://user-images.githubusercontent.com/29093946/155044805-a01a70c7-241d-49e9-9f52-3b710062b914.png">


after
<img width="1284" alt="Captura de ecrã 2022-02-22, às 01 02 35" src="https://user-images.githubusercontent.com/29093946/155044810-7501513a-4e4c-455a-ab34-cc7507887726.png">

