### PR TITLE
chore(update): hide export storage button

### DIFF
--- a/components/views/settings/pages/storage/Storage.html
+++ b/components/views/settings/pages/storage/Storage.html
@@ -9,7 +9,7 @@
     </div>
   </div>
 
-  <!--<div class="columns is-desktop">
+  <div class="columns is-desktop" v-if="featureReadyToShow">
     <div class="column">
       <TypographyTitle
         :size="6"
@@ -26,7 +26,7 @@
         :text="$t('pages.settings.storage.export.button')"
       />
     </div>
-  </div>-->
+  </div>
 
   <div class="columns is-desktop">
     <div class="column">

--- a/components/views/settings/pages/storage/Storage.html
+++ b/components/views/settings/pages/storage/Storage.html
@@ -9,7 +9,7 @@
     </div>
   </div>
 
-  <div class="columns is-desktop">
+  <!--<div class="columns is-desktop">
     <div class="column">
       <TypographyTitle
         :size="6"
@@ -26,7 +26,7 @@
         :text="$t('pages.settings.storage.export.button')"
       />
     </div>
-  </div>
+  </div>-->
 
   <div class="columns is-desktop">
     <div class="column">

--- a/components/views/settings/pages/storage/index.vue
+++ b/components/views/settings/pages/storage/index.vue
@@ -10,6 +10,7 @@ export default Vue.extend({
     return {
       isLoading: false,
       deleteVerify: false,
+      featureReadyToShow: false,
     }
   },
   methods: {


### PR DESCRIPTION

**What this PR does** 📖

Hides export storage button.

before
<img width="1292" alt="Captura de ecrã 2022-02-22, às 01 14 51" src="https://user-images.githubusercontent.com/29093946/155045644-0b8deb2d-ec4a-474f-b3c9-7050aa108732.png">


after
<img width="1300" alt="Captura de ecrã 2022-02-22, às 01 15 04" src="https://user-images.githubusercontent.com/29093946/155045650-8896111a-576a-415b-bbfd-84426662539d.png">

