### PR TITLE
chore(update): hide mock and tweak section

### DIFF
--- a/components/views/settings/Sidebar.vue
+++ b/components/views/settings/Sidebar.vue
@@ -83,10 +83,10 @@ export default Vue.extend({
         {
           title: 'Developer',
           links: [
-            {
+            /* {
               to: 'developer',
               text: 'Mock & Tweak',
-            },
+            }, */
             {
               to: 'notifications',
               text: 'Notifications',


### PR DESCRIPTION


**What this PR does** 📖

Hides mock and tweak section

before
<img width="380" alt="Captura de ecrã 2022-02-22, às 01 18 13" src="https://user-images.githubusercontent.com/29093946/155045897-9b37c8a8-cf99-46c9-bdf6-659dcdd64dd8.png">


after
<img width="370" alt="Captura de ecrã 2022-02-22, às 01 18 08" src="https://user-images.githubusercontent.com/29093946/155045902-9a21e2e3-025c-497e-ada6-05bf186160ba.png">

