### PR TITLE
chore(update): hide pin icon on chat

### DIFF
--- a/components/views/chat/message/actions/Actions.html
+++ b/components/views/chat/message/actions/Actions.html
@@ -17,12 +17,13 @@
   >
     <corner-down-right-icon size="1x" :class="'control-icon'" />
   </div>
-  <!--<div
+  <div 
     class="reply-command has-tooltip has-tooltip-primary"
     :data-tooltip="$t('messaging.pin')"
+    v-if="featureReadyToShow"
   >
     <archive-icon size="1x" :class="'control-icon'" />
-  </div>-->
+  </div>
   <div
     class="reply-command has-tooltip has-tooltip-primary"
     :data-tooltip="$t('controls.edit')"

--- a/components/views/chat/message/actions/Actions.html
+++ b/components/views/chat/message/actions/Actions.html
@@ -17,12 +17,12 @@
   >
     <corner-down-right-icon size="1x" :class="'control-icon'" />
   </div>
-  <div
+  <!--<div
     class="reply-command has-tooltip has-tooltip-primary"
     :data-tooltip="$t('messaging.pin')"
   >
     <archive-icon size="1x" :class="'control-icon'" />
-  </div>
+  </div>-->
   <div
     class="reply-command has-tooltip has-tooltip-primary"
     :data-tooltip="$t('controls.edit')"

--- a/components/views/chat/message/actions/Actions.html
+++ b/components/views/chat/message/actions/Actions.html
@@ -17,7 +17,7 @@
   >
     <corner-down-right-icon size="1x" :class="'control-icon'" />
   </div>
-  <div 
+  <div
     class="reply-command has-tooltip has-tooltip-primary"
     :data-tooltip="$t('messaging.pin')"
     v-if="featureReadyToShow"

--- a/components/views/chat/message/actions/Actions.vue
+++ b/components/views/chat/message/actions/Actions.vue
@@ -23,6 +23,7 @@ export default Vue.extend({
   data() {
     return {
       hasMoreSettings: false,
+      featureReadyToShow: false,
     }
   },
   props: {


### PR DESCRIPTION


**What this PR does** 📖

Hides pin icon on chat.

before
<img width="321" alt="Captura de ecrã 2022-02-22, às 01 25 58" src="https://user-images.githubusercontent.com/29093946/155046594-099de090-a715-4b34-915b-7290e970b1cf.png">


after
<img width="217" alt="Captura de ecrã 2022-02-22, às 01 26 24" src="https://user-images.githubusercontent.com/29093946/155046599-816e8e42-b970-4470-a197-05a690db231c.png">

