### PR TITLE
fix(mobile): on friends swip hide virtual keyboard

### DIFF
--- a/layouts/friends.vue
+++ b/layouts/friends.vue
@@ -75,6 +75,12 @@ export default Vue.extend({
           slideChange: () => {
             if (this.$refs.swiper && this.$refs.swiper.$swiper) {
               const newShowSidebar = this.$refs.swiper.$swiper.activeIndex === 0
+
+              // force virtual keyboard hide on mobile when swiper slide change
+              if (newShowSidebar) {
+                document.activeElement.blur()
+              }
+
               if (this.showSidebar !== newShowSidebar) {
                 this.$store.commit('ui/showSidebar', newShowSidebar)
               }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
on the friends and chat page, the virtual keyboard is not hiding when the user swipes the sidebar, this PR fix this
**Which issue(s) this PR fixes** 🔨
AP-688
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
