### PR TITLE
chore(cypress): add netfly plugin

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[[plugins]]
+  package = "netlify-plugin-cypress"

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "jest": "^26.6.3",
     "jest-canvas-mock": "^2.3.1",
     "lint-staged": ">=10",
+    "netlify-plugin-cypress": "^2.2.0",
     "prettier": "^2.2.1",
     "simple-peer": "^9.11.0",
     "ts-jest": "^27.0.7",

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "babel-jest": "^27.3.1",
     "cypress": "9.5.0",
     "cypress-file-upload": "^5.0.8",
+    "cypress-localstorage-commands": "^1.7.0",
     "dotenv-cli": "^4.0.0",
     "electron": "^13.2.1",
     "encoding": "^0.1.13",


### PR DESCRIPTION
**What this PR does** 📖

- Adds netlify Cypress plugin that Luis added on the Cypress submodule in order to add the Cypress tests on CI
- Adds missing plugin that's needed on the main repo in order for netlify to properly build that
- Adds `netlify.toml` file for CI on netlify