### PR TITLE
fix(filesUpgrade): dull the storage space upgrade button

### DIFF
--- a/components/views/files/aside/Aside.html
+++ b/components/views/files/aside/Aside.html
@@ -4,8 +4,9 @@
     <InteractablesButton
       :text="$t('pages.files.aside.upgrade')"
       size="small"
-      type="success"
       :action="() => {}"
+      class="has-tooltip has-tooltip-bottom has-tooltip-primary has-tooltip-hidden-touch upgrade"
+      :data-tooltip="$t('pages.files.aside.coming_soon')"
     />
   </div>
   <UiProgress :progress="80" />

--- a/components/views/files/aside/Aside.less
+++ b/components/views/files/aside/Aside.less
@@ -3,11 +3,8 @@
     .is-text {
       &:extend(.full-width);
     }
-    .upgrade-text {
-      align-self: flex-end;
-      text-align: right;
-      &:extend(.color-success);
-      text-transform: uppercase;
+    .upgrade {
+      background-color: @gray!important;
     }
     .button {
       height: 1.4rem;

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -141,6 +141,7 @@ export default {
         upgrade: 'Upgrade',
         quick_access: 'Quick Access',
         shared_items: 'Shared Items',
+        coming_soon: 'Coming soon',
       },
       upload: {
         close: 'Close',


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- change button color to gray
- add tooltip

**Which issue(s) this PR fixes** 🔨

AP-911
<!--AP-X-->

**Special notes for reviewers** 🗒️
- I didn't set button to disabled because it makes the tooltip very difficult to read

**Additional comments** 🎤
