### PR TITLE
feat(files): file type support for common image, archive types

### DIFF
--- a/libraries/Files/FilSystem.ts
+++ b/libraries/Files/FilSystem.ts
@@ -166,13 +166,13 @@ export class FilSystem {
    * @description recursively adds files and directories from JSON export
    */
   public importChildren(item: ExportItem) {
-    if (item.type in FILE_TYPE) {
+    if ((Object.values(FILE_TYPE) as string[]).includes(item.type)) {
       const { name, hash, size, liked, shared, description } =
         item as ExportFile
       const type = item.type as FILE_TYPE
       this.createFile({ name, hash, size, liked, shared, description, type })
     }
-    if (item.type in DIRECTORY_TYPE) {
+    if ((Object.values(DIRECTORY_TYPE) as string[]).includes(item.type)) {
       const { name, liked, shared, children } = item as ExportDirectory
       const type = item.type as DIRECTORY_TYPE
       this.createDirectory({ name, liked, shared, type })

--- a/libraries/Files/TextileFileSystem.ts
+++ b/libraries/Files/TextileFileSystem.ts
@@ -1,6 +1,9 @@
 import { PushPathResult } from '@textile/hub'
 import Vue from 'vue'
 import { FilSystem } from './FilSystem'
+import { Bucket } from './remote/textile/Bucket'
+import { FILE_TYPE } from './types/file'
+
 export class TextileFileSystem extends FilSystem {
   /**
    * @getter bucket
@@ -21,6 +24,9 @@ export class TextileFileSystem extends FilSystem {
       name: file.name,
       hash: result.path.path,
       size: file.size,
+      type: (Object.values(FILE_TYPE) as string[]).includes(file.type)
+        ? (file.type as FILE_TYPE)
+        : FILE_TYPE.GENERIC,
     })
   }
 

--- a/libraries/Files/types/file.ts
+++ b/libraries/Files/types/file.ts
@@ -1,10 +1,24 @@
 /* Describes all supported filetypes
  * this will be useful for applying icons to the tree later on
  * if we don't have a filetype supported, we can just default to generic.
+ * todo AP-931 - fill this out following ticket instructions
  */
 export enum FILE_TYPE {
   GENERIC = 'generic',
-  // images
+
+  // application - todo
+  ARC = 'application/x-freearc',
+  BZ = 'application/x-bzip',
+  BZTWO = 'application/x-bzip2',
+  GZIP = 'application/gzip',
+  JAR = 'application/java-archive',
+  PDF = 'application/pdf',
+  RAR = 'application/vnd.rar',
+  TAR = 'application/x-tar',
+  ZIP = 'application/zip',
+  SEVENZIP = 'application/x-7z-compressed',
+
+  // image - embeddable
   APNG = 'image/apng',
   AVIF = 'image/avif',
   GIF = 'image/gif',
@@ -12,8 +26,10 @@ export enum FILE_TYPE {
   PNG = 'image/png',
   SVG = 'image/svg+xml',
   WEBP = 'image/webp',
-  // archives
-  ZIP = 'application/zip',
-  RAR = 'application/vnd.rar',
-  SEVENZIP = 'application/x-7z-compressed',
+
+  // image - non-embeddable
+  BMP = 'image/bmp',
+  HEIC = 'image/heic',
+  ICO = 'image/vnd.microsoft.icon',
+  TIFF = 'image/tiff',
 }

--- a/libraries/Files/types/file.ts
+++ b/libraries/Files/types/file.ts
@@ -3,7 +3,17 @@
  * if we don't have a filetype supported, we can just default to generic.
  */
 export enum FILE_TYPE {
-  GENERIC = 'GENERIC',
-  IMAGE_PNG = 'IMG/PNG',
-  ARCHIVE = 'ARCHIVE/ZIP',
+  GENERIC = 'generic',
+  // images
+  APNG = 'image/apng',
+  AVIF = 'image/avif',
+  GIF = 'image/gif',
+  JPG = 'image/jpeg',
+  PNG = 'image/png',
+  SVG = 'image/svg+xml',
+  WEBP = 'image/webp',
+  // archives
+  ZIP = 'application/zip',
+  RAR = 'application/vnd.rar',
+  SEVENZIP = 'application/x-7z-compressed',
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

🔴 **this will remove any current filesystem data since import is based on a valid type**

**What this PR does** 📖
- type support for common file types
- switch type check on import to support more dynamic enums
  - previous check was only checking the key, rather than value. not scalable due to MIME types structure
- add basic file types to enum

**Which issue(s) this PR fixes** 🔨
AP-906

<!--AP-X-->

**Special notes for reviewers** 🗒️
- this will NOT work retroactively. type is registered upon upload

**Additional comments** 🎤
