### PR TITLE
fix(files): reduce max height of fullscreen file view

### DIFF
--- a/components/views/files/filepath/Filepath.less
+++ b/components/views/files/filepath/Filepath.less
@@ -3,7 +3,7 @@
     align-items: center;
   }
   a {
-    display: block; // elipsis only works on block elements
+    display: block; // ellipsis only works on block elements
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;

--- a/components/views/files/view/View.less
+++ b/components/views/files/view/View.less
@@ -9,7 +9,7 @@
     display: flex;
     margin: auto;
     max-width: 80vw;
-    max-height: 80vh;
+    max-height: 60vh;
     &:extend(.round-corners);
   }
   .file-icon {
@@ -36,8 +36,12 @@
     margin: @normal-spacing;
 
     .file-info {
+      max-width: 50vw;
       .title {
         &:extend(.font-secondary);
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
       }
     }
 

--- a/components/views/files/view/View.less
+++ b/components/views/files/view/View.less
@@ -46,18 +46,16 @@
     }
 
     .controls {
+      display: flex;
+      height: fit-content;
       margin-left: auto;
-      margin-right: @normal-spacing;
+      margin-right: @large-spacing;
+      gap: @normal-spacing;
 
       .control {
-        display: inline-flex;
+        display: flex;
         font-size: @icon-size;
-        margin: @normal-spacing @light-spacing;
         &:extend(.font-secondary);
-
-        &:nth-child(4) {
-          margin-right: @normal-spacing;
-        }
         &.disabled {
           cursor: not-allowed;
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- fix mobile issue where text would overlap image
- limit width of file info so buttons don't wrap

**Which issue(s) this PR fixes** 🔨
AP-962
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
