### PR TITLE
fix(files): svg preview

### DIFF
--- a/components/views/files/file/File.html
+++ b/components/views/files/file/File.html
@@ -21,12 +21,11 @@
       @mouseleave="heartHover=false"
     />
   </div>
-  <img v-if="isSvg" class="image-preview" :src="svgSrc" />
   <!-- todo- only showing images under a certain size because large images slow it down a LOT. maybe add thumbnail to index  -->
   <img
-    v-else-if="isImage && item.size < $Config.uploadByteLimit"
+    v-if="isImage && item.size < $Config.uploadByteLimit"
     class="image-preview"
-    :src="path"
+    :src="isSvg ? svgSrc : path"
   />
   <div v-else class="icon-container">
     <folder-icon v-if="item.content" size="4x" class="file-type-icon" />

--- a/components/views/files/file/File.html
+++ b/components/views/files/file/File.html
@@ -21,9 +21,10 @@
       @mouseleave="heartHover=false"
     />
   </div>
+  <img v-if="isSvg" class="image-preview" :src="svgSrc" />
   <!-- todo- only showing images under a certain size because large images slow it down a LOT. maybe add thumbnail to index  -->
   <img
-    v-if="isImage && item.size < $Config.uploadByteLimit"
+    v-else-if="isImage && item.size < $Config.uploadByteLimit"
     class="image-preview"
     :src="path"
   />

--- a/components/views/files/file/File.less
+++ b/components/views/files/file/File.less
@@ -44,8 +44,8 @@
   }
 
   .image-preview {
-    height: 162px;
     object-fit: cover;
+    height: 162px;
     filter: brightness(0.75);
   }
 

--- a/components/views/files/file/File.vue
+++ b/components/views/files/file/File.vue
@@ -15,6 +15,7 @@ import { ContextMenu } from '~/components/mixins/UI/ContextMenu'
 import { Item } from '~/libraries/Files/abstracts/Item.abstract'
 import { Directory } from '~/libraries/Files/Directory'
 import { Fil } from '~/libraries/Files/Fil'
+import encode from '~/utilities/EncodeSvg'
 
 declare module 'vue/types/vue' {
   interface Vue {
@@ -51,11 +52,10 @@ export default Vue.extend({
   },
   data() {
     return {
-      fileUrl: String,
-      fileSize: '',
       fileHover: false,
       linkHover: false,
       heartHover: false,
+      svgSrc: '',
       contextMenuValues: [
         { text: 'Favorite', func: this.like },
         { text: 'Share', func: this.share },
@@ -80,6 +80,9 @@ export default Vue.extend({
     isArchive(): boolean {
       return Boolean(this.item.name.match(this.$Config.regex.archive))
     },
+    isSvg(): boolean {
+      return Boolean(this.item.name.match(this.$Config.regex.svg))
+    },
     /**
      * @returns path inside textile bucket
      */
@@ -88,6 +91,11 @@ export default Vue.extend({
         ? this.$Config.textile.browser + this.item.hash
         : ''
     },
+  },
+  mounted() {
+    if (this.isSvg) {
+      this.encodeSvg()
+    }
   },
   methods: {
     /**
@@ -159,6 +167,13 @@ export default Vue.extend({
       await this.$TextileManager.bucket?.updateIndex(this.$FileSystem.export)
       this.$store.commit('ui/setIsLoadingFileIndex', false)
       this.$emit('forceRender')
+    },
+    /**
+     * @method encodeSvg
+     * @description converts svg at path to usable data string
+     */
+    async encodeSvg() {
+      this.svgSrc = await encode(this.path)
     },
   },
 })

--- a/components/views/files/view/View.html
+++ b/components/views/files/view/View.html
@@ -39,11 +39,10 @@
       </div>
     </div>
   </div>
-  <img v-if="isSvg" class="file-image" :src="svgSrc" />
   <img
-    v-else-if="isImage && file.size < $Config.uploadByteLimit"
+    v-if="isImage && file.size < $Config.uploadByteLimit"
     class="file-image"
-    :src="path"
+    :src="isSvg ? svgSrc : path"
   />
   <div v-else class="no-preview">
     <a

--- a/components/views/files/view/View.html
+++ b/components/views/files/view/View.html
@@ -39,8 +39,9 @@
       </div>
     </div>
   </div>
+  <img v-if="isSvg" class="file-image" :src="svgSrc" />
   <img
-    v-if="isImage && file.size < $Config.uploadByteLimit"
+    v-else-if="isImage && file.size < $Config.uploadByteLimit"
     class="file-image"
     :src="path"
   />

--- a/components/views/files/view/View.vue
+++ b/components/views/files/view/View.vue
@@ -11,6 +11,7 @@ import {
   LinkIcon,
 } from 'satellite-lucide-icons'
 import { Fil } from '~/libraries/Files/Fil'
+import encode from '~/utilities/EncodeSvg'
 
 export default Vue.extend({
   components: {
@@ -27,6 +28,11 @@ export default Vue.extend({
       required: true,
     },
   },
+  data() {
+    return {
+      svgSrc: '' as string,
+    }
+  },
   computed: {
     ...mapState(['ui']),
     path(): string {
@@ -35,6 +41,14 @@ export default Vue.extend({
     isImage(): boolean {
       return Boolean(this.file.name.match(this.$Config.regex.image))
     },
+    isSvg(): boolean {
+      return Boolean(this.file.name.match(this.$Config.regex.svg))
+    },
+  },
+  mounted() {
+    if (this.isSvg) {
+      this.encodeSvg()
+    }
   },
   methods: {
     /**
@@ -52,6 +66,13 @@ export default Vue.extend({
         this.$toast.show(this.$t('pages.files.link_copied') as string)
       })
       this.$emit('forceRender')
+    },
+    /**
+     * @method encodeSvg
+     * @description converts svg at path to usable data string
+     */
+    async encodeSvg() {
+      this.svgSrc = await encode(this.path)
     },
   },
 })

--- a/config.ts
+++ b/config.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/named
 import { Commitment } from '@solana/web3.js'
 
 export const Config = {
@@ -105,6 +104,8 @@ export const Config = {
   regex: {
     // Regex to identify if a filetype is an image we support
     image: '^.*.(apng|avif|gif|jpg|jpeg|jfif|pjpeg|pjp|png|svg|webp)$',
+    // check if file is svg
+    svg: '^.*.(svg)$',
     // determine if filetype is archive
     archive: '^.*.(zip|vnd.rar|x-7z-compressed)$',
     // Regex to check if string contains only emoji's.

--- a/utilities/EncodeSvg.ts
+++ b/utilities/EncodeSvg.ts
@@ -1,0 +1,26 @@
+/**
+ * @function encode
+ * @description fetches svg from textile and converts to a data string
+ */
+export default async function encode(url: string): Promise<string> {
+  const svg = await fetch(url).then((res) => res.text())
+
+  return (
+    'data:image/svg+xml,' +
+    svg
+      .replace(
+        '<svg',
+        ~svg.indexOf('xmlns')
+          ? '<svg'
+          : '<svg xmlns="http://www.w3.org/2000/svg"',
+      )
+      .replace(/"/g, "'")
+      .replace(/%/g, '%25')
+      .replace(/#/g, '%23')
+      .replace(/{/g, '%7B')
+      .replace(/}/g, '%7D')
+      .replace(/</g, '%3C')
+      .replace(/>/g, '%3E')
+      .replace(/\s+/g, ' ')
+  )
+}

--- a/utilities/EncodeSvg.ts
+++ b/utilities/EncodeSvg.ts
@@ -5,22 +5,5 @@
 export default async function encode(url: string): Promise<string> {
   const svg = await fetch(url).then((res) => res.text())
 
-  return (
-    'data:image/svg+xml,' +
-    svg
-      .replace(
-        '<svg',
-        ~svg.indexOf('xmlns')
-          ? '<svg'
-          : '<svg xmlns="http://www.w3.org/2000/svg"',
-      )
-      .replace(/"/g, "'")
-      .replace(/%/g, '%25')
-      .replace(/#/g, '%23')
-      .replace(/{/g, '%7B')
-      .replace(/}/g, '%7D')
-      .replace(/</g, '%3C')
-      .replace(/>/g, '%3E')
-      .replace(/\s+/g, ' ')
-  )
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- svg preview in grid view and full screen file view
- added utility function to convert a textile svg url to a usable data string

**Which issue(s) this PR fixes** 🔨
AP-970
<!--AP-X-->

**Special notes for reviewers** 🗒️
this was more complicated than expected.. the more 'anonymous' url for an svg upload to a bucket looks like this
https://hub.textile.io/ipfs/bafkreifzm3k7qg3trv3qyfsxvyli5engm42if3vrezhr36oicxberyv4oa

This link can't be used as an `<img>` src, I needed to fetch the svg then run some string replacement so it could be used as a data string for src.

We don't run into this issue in chat. Those urls maintain their file extension (textile.io/.../test.svg), but you lose anonymity. Anyone with that link can backtrack and see all the files in the bucket

I also experimented using the link as a data attribute for `<object>`, but the styling was painful and would be super hacky to fix (like direct DOM manipulation)

**Additional comments** 🎤
