### PR TITLE
fix(contextMenu): fix contextMenu error when clicking out of bounds

### DIFF
--- a/components/interactables/ContextMenu/ContextMenu.vue
+++ b/components/interactables/ContextMenu/ContextMenu.vue
@@ -56,6 +56,7 @@ export default Vue.extend({
      */
     handleOverflow() {
       const contextMenu = this.$refs.contextMenu as HTMLElement
+      if (!contextMenu) return
       const position = this.ui.contextMenuPosition
       let clickX = position.x
       let clickY = position.y


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Fixes an error with the context menu when clicking outside of the viewport

**Which issue(s) this PR fixes** 🔨
Not sure if there is a specific issue for this, but I fixed this while testing [AP-973](https://satellite-im.atlassian.net/browse/AP-973)
<!--AP-X-->

**Special notes for reviewers** 🗒️
I was seeing an error in the console when clicking on dev tools or clicking back into my code editor and this change resolved it
**Additional comments** 🎤
