### PR TITLE
fix(storeTextileActions): reset message load state on init

### DIFF
--- a/store/textile/actions.ts
+++ b/store/textile/actions.ts
@@ -118,6 +118,7 @@ export default {
     commit('friends/setActive', friend, { root: true })
 
     commit('setConversationLoading', { loading: false })
+    commit('setMessageLoading', { loading: false })
 
     // TODO: only for testing
     dispatch('subscribeToMailbox')


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Fixes an issue with the message loading state where, when a user sends a message but the message fails to send (for example, when sending a message with a textile account key instead of user group key), that conversation is stuck in a loading state for that user indefinitely.

**Which issue(s) this PR fixes** 🔨
Not sure if this is related to another ticket yet, but will search for one.
For now, this was found while working on [AP-973](https://satellite-im.atlassian.net/browse/AP-973)
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
