### PR TITLE
fix(embeddedVideo): fix parsing youtube video url

### DIFF
--- a/components/ui/Chat/Embeds/EmbeddedLinkContent/EmbeddedLinkContent.vue
+++ b/components/ui/Chat/Embeds/EmbeddedLinkContent/EmbeddedLinkContent.vue
@@ -46,12 +46,12 @@ export default Vue.extend({
             link.match(this.$Config.regex.youtubeShort)
           ) {
             let youtubeOutSource: string = ''
-            if (link.includes('youtube')) {
+            if (link.includes('youtube.com/')) {
               youtubeOutSource = `https://www.youtube.com/embed/${
                 link.split('v=')[1].split('&')[0]
               }?origin=https://plyr.io&amp;iv_load_policy=3&amp;modestbranding=1&amp;playsinline=1&amp;showinfo=0&amp;rel=0&amp;enablejsapi=1`
             }
-            if (link.includes('youtu.be')) {
+            if (link.includes('youtu.be/')) {
               youtubeOutSource = `https://www.youtube.com/embed/${
                 link.split('.be/')[1].split('/')[0]
               }?origin=https://plyr.io&amp;iv_load_policy=3&amp;modestbranding=1&amp;playsinline=1&amp;showinfo=0&amp;rel=0&amp;enablejsapi=1`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Embedded videos would crash on this URL: https://www.youtube.com/watch?t=81&v=AdtHPZUkKWs&feature=youtu.be because of the way we were parsing youtube.com and youtube.be

On dev currently you will see this video does not embed, and gives an error message that crashes on local dev

**Which issue(s) this PR fixes** 🔨
No ticket

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
