### PR TITLE
fix(upload): loading pop up appear and persist despite file upload is canceled

### DIFF
--- a/components/views/files/upload/Upload.vue
+++ b/components/views/files/upload/Upload.vue
@@ -63,7 +63,7 @@ export default Vue.extend({
     }
   },
   computed: {
-    ...mapState(['ui', 'friends', 'chat']),
+    ...mapState(['ui', 'friends', 'chat', 'textile']),
     activeFriend() {
       return this.$Hounddog.getActiveFriend(this.$store.state.friends)
     },
@@ -203,6 +203,9 @@ export default Vue.extend({
         this.count_error = false
         this.$parent.$data.showFilePreview = false
         this.$store.commit('chat/deleteFiles', this.recipient.address)
+        this.$store.dispatch('textile/clearUploadStatus')
+        if (this.textile.messageLoading)
+          this.$store.commit('textile/setMessageLoading', { loading: false })
         return
       }
       this.$store.commit('chat/setFiles', {

--- a/store/textile/actions.ts
+++ b/store/textile/actions.ts
@@ -257,6 +257,8 @@ export default {
         })
       },
     )
+    /* If already canceled */
+    if (!rootState.textile.messageLoading) return
     const fileURL = `${Config.textile.browser}${result?.root}${path}`
     const friend = rootState.friends.all.find((fr) => fr.textilePubkey === to)
 


### PR DESCRIPTION
**What this PR does** 📖
If user cancels sending a file/photo/video before it finished sending, the loading pop up will appear and persist through the rest of your conversations

**Which issue(s) this PR fixes** 🔨
AP-923