### PR TITLE
fix(connectedPeers): fix issue showing connected peers

### DIFF
--- a/components/interactables/Search/Result/Result.vue
+++ b/components/interactables/Search/Result/Result.vue
@@ -2,7 +2,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
-// @ts-ignorex
+// @ts-ignore
 import VuejsPaginate from 'vuejs-paginate'
 import { CalendarIcon } from 'satellite-lucide-icons'
 

--- a/components/interactables/Search/Result/Result.vue
+++ b/components/interactables/Search/Result/Result.vue
@@ -2,7 +2,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
-// @ts-ignore
+// @ts-ignorex
 import VuejsPaginate from 'vuejs-paginate'
 import { CalendarIcon } from 'satellite-lucide-icons'
 

--- a/components/views/chat/chatbar/footer/is-connected/Connected.html
+++ b/components/views/chat/chatbar/footer/is-connected/Connected.html
@@ -3,7 +3,7 @@
   class="is-connected"
 >
   <circle-icon
-    :class="`status is-${ webrtc.connectedPeer ? $t('ui.online') : $t('ui.offline') }`"
+    :class="`status is-${ friendConnected($Hounddog.getActiveFriend(friends).address) ? $t('ui.online') : $t('ui.offline') }`"
     size="1x"
   />
   <TypographyText
@@ -12,7 +12,7 @@
     :size="6"
   />
   <TypographyText
-    :text="`is ${ webrtc.connectedPeer ? $t('ui.connected') : $t('ui.not_connected') }`"
+    :text="`is ${ friendConnected($Hounddog.getActiveFriend(friends).address) ? $t('ui.connected') : $t('ui.not_connected') }`"
     :size="6"
   />
 </div>

--- a/components/views/chat/chatbar/footer/is-connected/Connected.vue
+++ b/components/views/chat/chatbar/footer/is-connected/Connected.vue
@@ -20,6 +20,14 @@ export default Vue.extend({
   computed: {
     ...mapState(['ui', 'webrtc', 'friends']),
   },
+  methods: {
+    friendConnected(friendId: string): boolean {
+      if (this.webrtc) {
+        return this.webrtc.connectedPeers.includes(friendId)
+      }
+      return false
+    },
+  },
 })
 </script>
 

--- a/components/views/chat/chatbar/footer/is-connected/Connected.vue
+++ b/components/views/chat/chatbar/footer/is-connected/Connected.vue
@@ -21,6 +21,13 @@ export default Vue.extend({
     ...mapState(['ui', 'webrtc', 'friends']),
   },
   methods: {
+    /**
+     * @method friendConnected
+     * @description Send the user ID/address in, get a boolean of it the signal is currently open
+     * @param friendId Address of the current user
+     * @example
+     * friendConnected('user1') // true
+     */
     friendConnected(friendId: string): boolean {
       if (this.webrtc) {
         return this.webrtc.connectedPeers.includes(friendId)

--- a/components/views/navigation/sidebar/live/Live.vue
+++ b/components/views/navigation/sidebar/live/Live.vue
@@ -40,9 +40,9 @@ export default Vue.extend({
       )
       if (!activeFriend) return
       const identifier = activeFriend.address
-      if (!this.webrtc.connectedPeer) {
+      if (!this.webrtc.connectedPeers.includes(identifier)) {
         await this.$store.dispatch('webrtc/createPeerConnection', identifier)
-        if (!this.webrtc.connectedPeer) return
+        if (!this.webrtc.connectedPeers.includes(identifier)) return
       }
       // Trying to call the same user while call is already active
       if (identifier === this.$store.state.webrtc.activeCall) {

--- a/components/views/navigation/toolbar/Toolbar.html
+++ b/components/views/navigation/toolbar/Toolbar.html
@@ -54,8 +54,8 @@
     </UiFloatingContainer>
     <div
       :class="`has-tooltip has-tooltip-bottom has-tooltip-primary has-tooltip-hidden-touch control-button
-      ${!webrtc.connectedPeer || webrtc.activeCall ? 'disabled' : ''}`"
-      :data-tooltip="webrtc.connectedPeer ? $t('controls.call') : $t('controls.not_connected')"
+      ${!enableRTC || webrtc.activeCall ? 'disabled' : ''}`"
+      :data-tooltip="enableRTC ? $t('controls.call') : $t('controls.not_connected')"
       v-if="server"
       @click="() => call(['audio'])"
     >
@@ -63,8 +63,8 @@
     </div>
     <div
       :class="`has-tooltip has-tooltip-bottom has-tooltip-primary has-tooltip-hidden-touch control-button
-      ${!webrtc.connectedPeer || webrtc.activeCall ? 'disabled' : ''}`"
-      :data-tooltip="webrtc.connectedPeer ? $t('controls.video') : $t('controls.not_connected')"
+      ${!enableRTC || webrtc.activeCall ? 'disabled' : ''}`"
+      :data-tooltip="enableRTC ? $t('controls.video') : $t('controls.not_connected')"
       v-if="server"
       @click="() => call(['audio', 'video'])"
     >

--- a/components/views/navigation/toolbar/Toolbar.vue
+++ b/components/views/navigation/toolbar/Toolbar.vue
@@ -134,14 +134,14 @@ export default Vue.extend({
       this.$store.dispatch('ui/showProfile', this.user)
     },
     async call(kinds: TrackKind[]) {
-      if (!this.webrtc.connectedPeer) return
+      if (!this.webrtc.connectedPeers) return
       const activeFriend = this.$Hounddog.getActiveFriend(
         this.$store.state.friends,
       )
       if (!activeFriend) return
       const identifier = activeFriend.address
 
-      if (!this.webrtc.connectedPeer) {
+      if (!this.webrtc.connectedPeers.includes(identifier)) {
         await this.$store.dispatch('webrtc/createPeerConnection', identifier)
         if (!this.webrtc.connectedPeer) return
       }

--- a/components/views/navigation/toolbar/Toolbar.vue
+++ b/components/views/navigation/toolbar/Toolbar.vue
@@ -73,6 +73,15 @@ export default Vue.extend({
         return this.ui.showSearchResult
       },
     },
+    enableRTC(): boolean {
+      const activeFriend = this.$Hounddog.getActiveFriend(
+        this.$store.state.friends,
+      )
+      if (activeFriend) {
+        return this.webrtc.connectedPeers.includes(activeFriend.address)
+      }
+      return false
+    },
     searchQuery: {
       set(state) {
         this.$store.commit('search/setSearchQuery', state)
@@ -143,7 +152,7 @@ export default Vue.extend({
 
       if (!this.webrtc.connectedPeers.includes(identifier)) {
         await this.$store.dispatch('webrtc/createPeerConnection', identifier)
-        if (!this.webrtc.connectedPeer) return
+        if (!this.webrtc.connectedPeers.includes(identifier)) return
       }
 
       // Trying to call the same user while call is already active

--- a/middleware/authenticated.test.ts
+++ b/middleware/authenticated.test.ts
@@ -120,7 +120,7 @@ const initialRootState: RootState = {
     initialized: true,
     incomingCall: '',
     activeCall: '',
-    connectedPeer: '',
+    connectedPeers: [],
     activeStream: {
       createdAt: 0,
     },

--- a/plugins/thirdparty/persist.ts
+++ b/plugins/thirdparty/persist.ts
@@ -24,7 +24,7 @@ const commonProperties = [
   'accounts.initialized',
   'friends.all',
   'webrtc.activeStream',
-  'webrtc.connectedPeer',
+  'webrtc.connectedPeers',
   'webrtc.incomingCall',
   'ui.replyChatbarContent',
   'ui.editMessage',

--- a/store/getters.test.ts
+++ b/store/getters.test.ts
@@ -120,7 +120,7 @@ const initialRootState: RootState = {
     initialized: true,
     incomingCall: '',
     activeCall: '',
-    connectedPeer: '',
+    connectedPeers: [],
     activeStream: {
       createdAt: 0,
     },

--- a/store/webrtc/__snapshots__/state.test.ts.snap
+++ b/store/webrtc/__snapshots__/state.test.ts.snap
@@ -6,7 +6,7 @@ Object {
   "activeStream": Object {
     "createdAt": 0,
   },
-  "connectedPeer": "",
+  "connectedPeers": Array [],
   "incomingCall": "",
   "initialized": false,
   "localTracks": Object {

--- a/store/webrtc/actions.ts
+++ b/store/webrtc/actions.ts
@@ -36,6 +36,12 @@ const webRTCActions = {
 
     commit('setInitialized', true)
   },
+  /**
+   * @method getActivePeers
+   * @description returns an array of the user id's that have an open/active webtorrent signal
+   * @example
+   * this.$store.dispatch('webrtc/getActivePeers') // ['userid1', 'userid2']
+   */
   async getActivePeers() {
     const $WebRTC: WebRTC = Vue.prototype.$WebRTC
     const peersArray: string[] = []

--- a/store/webrtc/actions.ts
+++ b/store/webrtc/actions.ts
@@ -45,7 +45,7 @@ const webRTCActions = {
   async getActivePeers() {
     const $WebRTC: WebRTC = Vue.prototype.$WebRTC
     const peersArray: string[] = []
-    if ($WebRTC.peers) {
+    if ($WebRTC.peers.size > 0) {
       $WebRTC.peers.forEach((e) => {
         if (Object.keys(e.communicationBus.instance.peers).length !== 0) {
           peersArray.push(e.identifier)

--- a/store/webrtc/actions.ts
+++ b/store/webrtc/actions.ts
@@ -7,7 +7,7 @@ import { ActionsArguments } from '~/types/store/store'
 import WebRTC from '~/libraries/WebRTC/WebRTC'
 import Logger from '~/utilities/Logger'
 
-export default {
+const webRTCActions = {
   /**
    * @method initialized
    * @description Initializes the WebRTC Manager
@@ -23,18 +23,32 @@ export default {
     const $Logger: Logger = Vue.prototype.$Logger
 
     $WebRTC.init(originator)
-
-    $WebRTC.on('PEER_CONNECT', ({ peerId }) => {
+    $WebRTC.on('PEER_CONNECT', async ({ peerId }) => {
       $Logger.log('WebRTC', 'PEER_CONNECT', { peerId })
-      commit('setConnectedPeer', peerId)
+      const myPeers = await webRTCActions.getActivePeers()
+      commit('setAllConnectedPeers', myPeers)
     })
 
-    $WebRTC.on('ERROR', () => {
-      commit('setConnectedPeer', '')
+    $WebRTC.on('ERROR', async () => {
+      const myPeers = await webRTCActions.getActivePeers()
+      commit('setAllConnectedPeers', myPeers)
     })
 
     commit('setInitialized', true)
   },
+  async getActivePeers() {
+    const $WebRTC: WebRTC = Vue.prototype.$WebRTC
+    const peersArray: string[] = []
+    if ($WebRTC.peers) {
+      $WebRTC.peers.forEach((e) => {
+        if (Object.keys(e.communicationBus.instance.peers).length !== 0) {
+          peersArray.push(e.identifier)
+        }
+      })
+    }
+    return peersArray
+  },
+
   /**
    * @method createPeerConnection
    * @description Connects to a secret channel and waits the peer connection to happen
@@ -157,3 +171,5 @@ export default {
     commit('setActiveCall', '')
   },
 }
+
+export default webRTCActions

--- a/store/webrtc/mutations.test.ts
+++ b/store/webrtc/mutations.test.ts
@@ -1,3 +1,4 @@
+import { expect } from '@jest/globals'
 import * as WebRTC from '~/store/webrtc/mutations'
 
 describe('Mutate WebRTC by setting', () => {
@@ -7,7 +8,7 @@ describe('Mutate WebRTC by setting', () => {
       initialized: true,
       incomingCall: '',
       activeCall: '',
-      connectedPeer: '',
+      connectedPeers: [],
       streaming: true,
       activeStream: {
         createdAt: 123,
@@ -132,12 +133,12 @@ describe('Mutate WebRTC by setting', () => {
     })
   })
 
-  it('should set connected peer', () => {
+  it('should set connected peers', () => {
     const localStateForUnitTest = { ...state }
-    inst.setConnectedPeer(localStateForUnitTest, '0x0')
+    inst.setAllConnectedPeers(localStateForUnitTest, ['0x0', '0x1', '0x2'])
 
     expect(localStateForUnitTest).toMatchObject({
-      connectedPeer: '0x0',
+      connectedPeers: ['0x0', '0x1', '0x2'],
     })
   })
 })
@@ -149,7 +150,7 @@ describe('Mutate WebRTC by updating', () => {
       initialized: true,
       incomingCall: '',
       activeCall: '',
-      connectedPeer: '',
+      connectedPeers: [],
       streaming: true,
       activeStream: {
         createdAt: 123,

--- a/store/webrtc/mutations.ts
+++ b/store/webrtc/mutations.ts
@@ -10,8 +10,8 @@ const mutations = {
   setActiveCall(state: WebRTCState, id: string) {
     state.activeCall = id
   },
-  setConnectedPeer(state: WebRTCState, id: string) {
-    state.connectedPeer = id
+  setAllConnectedPeers(state: WebRTCState, ids: string[]) {
+    state.connectedPeers = ids
   },
   updateLocalTracks(
     state: WebRTCState,

--- a/store/webrtc/state.ts
+++ b/store/webrtc/state.ts
@@ -4,7 +4,7 @@ const InitialWebRTCState = (): WebRTCState => ({
   initialized: false,
   incomingCall: '',
   activeCall: '',
-  connectedPeer: '',
+  connectedPeers: [],
   activeStream: {
     createdAt: 0,
   },

--- a/store/webrtc/types.ts
+++ b/store/webrtc/types.ts
@@ -2,7 +2,7 @@ export interface WebRTCState {
   initialized: boolean
   incomingCall: string
   activeCall: string
-  connectedPeer: string
+  connectedPeers: string[]
   streaming: Boolean
   activeStream: {
     createdAt: number

--- a/utilities/Hounddog.test.ts
+++ b/utilities/Hounddog.test.ts
@@ -231,7 +231,7 @@ describe('Retrieve WebRTC calls with success', () => {
       initialized: true,
       incomingCall: '',
       activeCall: '',
-      connectedPeer: '',
+      connectedPeers: [],
       streaming: true,
       activeStream: {
         createdAt: 123,
@@ -366,7 +366,7 @@ describe('Retrieve WebRTC calls with failure', () => {
       initialized: true,
       incomingCall: '',
       activeCall: '',
-      connectedPeer: '',
+      connectedPeers: [],
       streaming: true,
       activeStream: {
         createdAt: 123,

--- a/utilities/Notifications.ts
+++ b/utilities/Notifications.ts
@@ -83,7 +83,6 @@ export const Notifications = class Notifications {
    * @example
    */
   requestNotificationPermission(): any {
-    // @ts-ignore
     if (
       (this.currentPlatform === 'web' || this.currentPlatform === 'electron') &&
       isSupported()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Before we were storing a single peer id in the state, so the last peer connection you set, if it was active, showed all of your connections as active. If that connection closed, it showed all of your dm's as not connected. Sorry the video is so long.

This update stores that data as an array. As connections are added or removed, that connection is added or removed from a list, so when you go to different users it shows the correct webrtc connection status, per user.

To test, on dev I created three users:

User A (regular Brave browser)
User B (incognito Brave Browser)
User C (regular chrome browser)

After this update you should see users appear online independent from each other.

Please use the local webtorrent when testing for the best results.


https://user-images.githubusercontent.com/2993032/157169478-8733616b-6aa0-4e37-be6b-5b6d8d9ffbc1.mov



**Which issue(s) this PR fixes** 🔨
No Ticket
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
