### PR TITLE
fix(nsfw): nsfw check valid files, allow unscannable/unembeddable files through

### DIFF
--- a/components/views/files/controls/Controls.vue
+++ b/components/views/files/controls/Controls.vue
@@ -120,7 +120,7 @@ export default Vue.extend({
       })
       const nsfwResults: Promise<{ file: File; nsfw: boolean }>[] =
         sameNameResults.map(async (file: File) => {
-          // todo - fix with AP-807. don't scan large files to prevent crash
+          // todo - fix with AP-1066. don't scan large files to prevent crash
           if (file.size > this.$Config.uploadByteLimit) {
             return { file, nsfw: false }
           }
@@ -138,7 +138,6 @@ export default Vue.extend({
             return { file, nsfw: await this.$Security.isNSFW(fileJpg) }
           }
 
-          // todo - fix this as part of AP-807. marks nsfw if unscannable image type (tiff)
           let nsfw
           try {
             nsfw = await this.$Security.isNSFW(file)

--- a/config.ts
+++ b/config.ts
@@ -102,7 +102,7 @@ export const Config = {
   routingMiddleware: {
     prerequisitesCheckBypass: ['auth', 'setup'],
   },
-  uploadByteLimit: 1000000 * 8, // 8MB - the current limit for an nsfw scan. Should be fixed in AP-807
+  uploadByteLimit: 1000000 * 8, // 8MB - the current limit for an nsfw scan. Should be fixed in AP-1066
   personalFilesLimit: 1000000000 * 4, // 4GB - free tier limit
   regex: {
     // identify if a file type is embeddable image

--- a/libraries/Files/types/file.ts
+++ b/libraries/Files/types/file.ts
@@ -51,7 +51,7 @@ export enum FILE_TYPE {
   OGA = 'audio/ogg',
   OPUS = 'audio/opus',
   WAV = 'audio/wav',
-  WEBA = 'audio/webm',
+  WEBMA = 'audio/webm',
   TGPA = 'audio/3gpp',
   TGPA2 = 'audio/3gpp2',
 

--- a/libraries/Files/types/file.ts
+++ b/libraries/Files/types/file.ts
@@ -72,7 +72,7 @@ export enum FILE_TYPE {
 
   // image - non-embeddable
   BMP = 'image/bmp',
-  HEIC = 'image/heic',
+  HEIC = 'image/heic', // non-embeddable by default, but we convert as needed
   ICO = 'image/vnd.microsoft.icon',
   TIFF = 'image/tiff',
 

--- a/libraries/Security/Security.test.ts
+++ b/libraries/Security/Security.test.ts
@@ -1,5 +1,5 @@
 import { stripEXIF } from '../../utilities/EXIF'
-import { isNSFW } from '../../utilities/NSFW'
+import isNSFW from '../../utilities/NSFW'
 import Security from './Security'
 
 describe('check properties', () => {

--- a/libraries/Security/Security.test.ts
+++ b/libraries/Security/Security.test.ts
@@ -1,6 +1,6 @@
-import { stripEXIF } from '../../utilities/EXIF'
-import isNSFW from '../../utilities/NSFW'
 import Security from './Security'
+import { stripEXIF } from '~/utilities/EXIF'
+import isNSFW from '~/utilities/NSFW'
 
 describe('check properties', () => {
   it('check stripEXIF', () => {

--- a/libraries/Security/Security.ts
+++ b/libraries/Security/Security.ts
@@ -1,5 +1,5 @@
-import { stripEXIF } from '../../utilities/EXIF'
-import { isNSFW } from '../../utilities/NSFW'
+import { stripEXIF } from '~/utilities/EXIF'
+import isNSFW from '~/utilities/NSFW'
 
 export default class Security {
   stripEXIF: Function = stripEXIF

--- a/utilities/NSFW.ts
+++ b/utilities/NSFW.ts
@@ -5,7 +5,7 @@ import { FILE_TYPE } from '~/libraries/Files/types/file'
  * @method isNSFW
  * @description Checks if an image is NSFW using nsfwjs
  * @param {File} file File object to be scanned
- * @returns boolean of nsfw status
+ * @returns {Promise} nsfw status
  */
 export default async function isNSFW(file: File): Promise<boolean> {
   const vidTypes = [FILE_TYPE.MP4, FILE_TYPE.WEBM, FILE_TYPE.OGV]

--- a/utilities/NSFW.ts
+++ b/utilities/NSFW.ts
@@ -8,7 +8,7 @@ import { FILE_TYPE } from '~/libraries/Files/types/file'
  * @returns {Promise} nsfw status
  */
 export default async function isNSFW(file: File): Promise<boolean> {
-  const vidTypes = [FILE_TYPE.MP4, FILE_TYPE.WEBM, FILE_TYPE.OGV]
+  const vidTypes = [FILE_TYPE.MP4, FILE_TYPE.MOV, FILE_TYPE.WEBM, FILE_TYPE.OGV]
   const imgTypes = [
     FILE_TYPE.APNG,
     FILE_TYPE.AVIF,
@@ -28,11 +28,17 @@ export default async function isNSFW(file: File): Promise<boolean> {
   // if embeddable video
   if (vidTypes.some((type) => file.type.includes(type))) {
     const vid = document.createElement('video')
-    // if browser can't check
-    if (!vid.canPlayType(file.type)) {
-      return false
-    }
     vid.src = URL.createObjectURL(file)
+    await (async () => {
+      return new Promise((resolve) => {
+        vid.onloadeddata = () => {
+          resolve(true)
+          vid.muted = true
+          vid.play()
+        }
+      })
+    })()
+
     const model = await nsfwjs.load()
     predictions = await model.classify(vid)
   }

--- a/utilities/NSFW.ts
+++ b/utilities/NSFW.ts
@@ -18,16 +18,20 @@ export default async function isNSFW(file: File): Promise<boolean> {
     FILE_TYPE.SVG,
     FILE_TYPE.WEBP,
   ]
-  // if unscannable/unembeddable type - return false
+  // if unscannable/unembeddable type
   if (![...vidTypes, ...imgTypes].includes(file.type as FILE_TYPE)) {
     return false
   }
 
   let predictions: nsfwjs.predictionType[]
 
-  // if embeddable video, handle appropriately
+  // if embeddable video
   if (vidTypes.some((type) => file.type.includes(type))) {
     const vid = document.createElement('video')
+    // if browser can't check
+    if (!vid.canPlayType(file.type)) {
+      return false
+    }
     vid.src = URL.createObjectURL(file)
     const model = await nsfwjs.load()
     predictions = await model.classify(vid)

--- a/utilities/NSFW.ts
+++ b/utilities/NSFW.ts
@@ -1,38 +1,49 @@
-// @ts-nocheck
 import * as nsfwjs from 'nsfwjs'
+import { FILE_TYPE } from '~/libraries/Files/types/file'
 
 /**
  * @method isNSFW
  * @description Checks if an image is NSFW using nsfwjs
- * @param file Image or GIF
- * @returns Boolean based on predictionResults
- * @example
+ * @param {File} file File object to be scanned
+ * @returns boolean of nsfw status
  */
-export const isNSFW = (file: File) => {
-  const fileTypePrefix = file.type.split('/')[0]
-  if (fileTypePrefix !== 'image') {
+export default async function isNSFW(file: File): Promise<boolean> {
+  const vidTypes = [FILE_TYPE.MP4, FILE_TYPE.WEBM, FILE_TYPE.OGV]
+  const imgTypes = [
+    FILE_TYPE.APNG,
+    FILE_TYPE.AVIF,
+    FILE_TYPE.GIF,
+    FILE_TYPE.JPG,
+    FILE_TYPE.PNG,
+    FILE_TYPE.SVG,
+    FILE_TYPE.WEBP,
+  ]
+  // if unscannable/unembeddable type - return false
+  if (![...vidTypes, ...imgTypes].includes(file.type as FILE_TYPE)) {
     return false
   }
-  const fileURL = URL.createObjectURL(file)
-  const imgElement = document.createElement('IMG')
-  imgElement.src = fileURL
 
-  return nsfwjs
-    .load()
-    .then((model) => {
-      return model.classify(imgElement)
-    })
-    .then((predictionsArr) => {
-      const predictionObj = {}
-      for (const prediction of predictionsArr) {
-        predictionObj[prediction.className] = prediction.probability
-      }
+  let predictions: nsfwjs.predictionType[]
 
-      const predictionResults =
-        predictionObj.Porn > 0.4 ||
-        predictionObj.Hentai > 0.6 ||
-        predictionObj.Sexy > 0.7
+  // if embeddable video, handle appropriately
+  if (vidTypes.some((type) => file.type.includes(type))) {
+    const vid = document.createElement('video')
+    vid.src = URL.createObjectURL(file)
+    const model = await nsfwjs.load()
+    predictions = await model.classify(vid)
+  }
+  // else, it's an embeddable image
+  else {
+    const img = new Image()
+    img.src = URL.createObjectURL(file)
+    const model = await nsfwjs.load()
+    predictions = await model.classify(img)
+  }
 
-      return predictionResults
-    })
+  const results: { [key: string]: number } = {}
+  for (const p of predictions) {
+    results[p.className] = p.probability
+  }
+
+  return results.Porn > 0.4 || results.Hentai > 0.6 || results.Sexy > 0.7
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- only try nsfw scan if its a valid format(embeddable images or videos)
- fix false positives for TIFF and other un-embeddable images
- use async await in favor of promises

**Which issue(s) this PR fixes** 🔨
AP-807

<!--AP-X-->

**Special notes for reviewers** 🗒️
- I know we typically avoid else, but it saves us from repetition in this case
- `const model = await nsfwjs.load()` is declared in both the if and else. If I placed it above, I would get weird errors

**Additional comments** 🎤
