### PR TITLE
fix(files): show full size icon all the time

### DIFF
--- a/components/views/files/controls/Controls.less
+++ b/components/views/files/controls/Controls.less
@@ -36,6 +36,7 @@
     }
     svg {
       color: @red;
+      flex-shrink: 0;
       &.close {
         margin-left: auto;
         cursor: pointer;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- if the error messages were long/numerous, the close icon could shrink since it's displayed with flex. this forces full size all the time

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
