### PR TITLE
test(cypress): changes to privacy toggle and create account tests for registry public toggle

### DIFF
--- a/cypress/integration/privacy-page-toggles.js
+++ b/cypress/integration/privacy-page-toggles.js
@@ -17,45 +17,39 @@ describe('Privacy Page Toggles Tests', () => {
     cy.createAccountSecondScreen()
   })
 
-  /* Commenting code below because tests will fail due to bug AP-795 
-  switch for Register Username on privacy settings
-  it('Privacy page - Verify all toggles can be switched to enable', () => {
-      cy.get('.switch-button').each(($btn, index, $List) => {
-          if (!($btn.hasClass('enabled'))) {
-              cy.wrap($btn).click().should('have.class', 'enabled')
-          } else {
-              cy.wrap($btn).should('have.class', 'enabled')     
-          }
-      })
-  })
-  
-  it('Privacy page - Verify all toggles can be switched to disabled', () => {
-      cy.get('.switch-button').each(($btn, index, $List) => {
-          if ($btn.hasClass('enabled')) {
-              cy.wrap($btn).click().should('not.have.class', 'enabled')
-          } else {
-              cy.wrap($btn).should('not.have.class', 'enabled')     
-          }
-      })
-  })
-  */
-
-  it('Privacy page - Verify all toggles switches work as should', () => {
+  it('Privacy page - Verify all non-locked toggles switches work as should', () => {
     //Validating each toggle, checking status is correct after clicking them.
     //Finally, saving values into an array for later comparison
     cy.get('.switch-button', { timeout: 30000 }).each(($btn, index, $List) => {
-      if ($btn.hasClass('enabled')) {
-        cy.wrap($btn).click().should('not.have.class', 'enabled')
-        toggleStatusSaved.push(false)
-      } else {
-        cy.wrap($btn).click().should('have.class', 'enabled')
-        toggleStatusSaved.push(true)
+      if (!$btn.hasClass('locked')) {
+        if ($btn.hasClass('enabled')) {
+          cy.wrap($btn).click().should('not.have.class', 'enabled')
+          toggleStatusSaved.push(false)
+        } else {
+          cy.wrap($btn).click().should('have.class', 'enabled')
+          toggleStatusSaved.push(true)
+        }
       }
     })
-    cy.get('#custom-cursor-area').click()
+  })
+
+  it('Privacy page - Verify register publicly toggle is locked and disabled', () => {
+    cy.get('.switch-button', { timeout: 30000 }).each(($btn, index, $List) => {
+      if ($btn.hasClass('locked')) {
+        expect($btn).to.not.have.class('enabled')
+        expect($btn).to.have.class('locked')
+        cy.wrap($btn).realHover()
+        cy.wait(5000) // To see that hover displays a forbidden icon
+        // Move back cursor to top left again
+        cy.get('body').realHover({ position: 'topLeft' })
+      }
+    })
   })
 
   it('Privacy page - Verify user can still proceed after adjusting switches', () => {
+    //Click on next
+    cy.get('#custom-cursor-area').click()
+
     //Recovery Seed Screen
     cy.createAccountRecoverySeed()
 
@@ -69,21 +63,23 @@ describe('Privacy Page Toggles Tests', () => {
     })
       .scrollIntoView()
       .should('be.visible')
-  })
-
-  it('Profile - Verify the toggles user added when signing up are on the same status when user goes to settings', () => {
     //Going to Settings and Privacy screen
     cy.get('[data-tooltip="Settings"] > .is-rounded > svg', {
       timeout: 30000,
     }).click()
+  })
+
+  it('Profile - Verify the toggles user added when signing up are on the same status when user goes to settings', () => {
     cy.contains('Privacy').click()
     //Storing the values from toggle switches status of Settings screen into an array
     cy.get('.switch-button')
       .each(($btn, index, $List) => {
-        if ($btn.hasClass('enabled')) {
-          toggleStatusProfile.push(true)
-        } else {
-          toggleStatusProfile.push(false)
+        if (!$btn.hasClass('locked')) {
+          if ($btn.hasClass('enabled')) {
+            toggleStatusProfile.push(true)
+          } else {
+            toggleStatusProfile.push(false)
+          }
         }
       })
       .then(() => {
@@ -95,5 +91,37 @@ describe('Privacy Page Toggles Tests', () => {
   it('Profile - Verify user can’t update the register name publicly toggle on settings', () => {
     //Identify the first switch button and ensure that is locked
     cy.get('.switch-button').first().should('have.class', 'locked')
+  })
+
+  it('Privacy page - Verify all non-locked toggles can be switched to enable', () => {
+    //Adding pin to continue to toggles switches screen
+    cy.createAccountPINscreen(randomPIN)
+
+    //Create or Import account selection screen
+    cy.createAccountSecondScreen()
+
+    //Switch all non-locked switched to enabled
+    cy.get('.switch-button').each(($btn, index, $List) => {
+      if (!$btn.hasClass('locked')) {
+        if (!$btn.hasClass('enabled')) {
+          cy.wrap($btn).click().should('have.class', 'enabled')
+        } else {
+          cy.wrap($btn).should('have.class', 'enabled')
+        }
+      }
+    })
+  })
+
+  it('Privacy page - Verify all non-locked toggles can be switched to disabled', () => {
+    //Switch all non-locked switched to disabled
+    cy.get('.switch-button').each(($btn, index, $List) => {
+      if (!$btn.hasClass('locked')) {
+        if ($btn.hasClass('enabled')) {
+          cy.wrap($btn).click().should('not.have.class', 'enabled')
+        } else {
+          cy.wrap($btn).should('not.have.class', 'enabled')
+        }
+      }
+    })
   })
 })

--- a/cypress/integration/privacy-page-toggles.js
+++ b/cypress/integration/privacy-page-toggles.js
@@ -39,7 +39,6 @@ describe('Privacy Page Toggles Tests', () => {
         expect($btn).to.not.have.class('enabled')
         expect($btn).to.have.class('locked')
         cy.wrap($btn).realHover()
-        cy.wait(5000) // To see that hover displays a forbidden icon
         // Move back cursor to top left again
         cy.get('body').realHover({ position: 'topLeft' })
       }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -37,12 +37,16 @@ Cypress.Commands.add('visitRootPage', () => {
   cy.window().then((win) => {
     win.sessionStorage.clear()
   })
+  cy.clearCookies()
+  cy.clearLocalStorage()
   cy.visit('/')
   cy.url().then(($url) => {
     if (!($url === redirectedURL)) {
-      cy.clearLocalStorage()
+      cy.window().then((win) => {
+        win.sessionStorage.clear()
+      })
       cy.clearCookies()
-      cy.wait(100)
+      cy.clearLocalStorage()
       cy.visit('/')
     }
   })
@@ -59,10 +63,13 @@ Cypress.Commands.add('createAccount', (pin) => {
   cy.get('[data-cy=submit-input]').click()
   cy.get('.is-primary > #custom-cursor-area').click()
   cy.get('.switch-button').each(($btn, index, $List) => {
-    if ($btn.hasClass('enabled')) {
-      cy.wrap($btn).click().should('not.have.class', 'enabled')
-    } else {
-      cy.wrap($btn).click().should('have.class', 'enabled')
+    // Ignore locked switch toggle
+    if (!$btn.hasClass('locked')) {
+      if ($btn.hasClass('enabled')) {
+        cy.wrap($btn).click().should('not.have.class', 'enabled')
+      } else {
+        cy.wrap($btn).click().should('have.class', 'enabled')
+      }
     }
   })
   cy.get('#custom-cursor-area').click()
@@ -136,10 +143,12 @@ Cypress.Commands.add('createAccountPrivacyToggles', () => {
   cy.get('.switch-button')
     .should('be.visible')
     .each(($btn, index, $List) => {
-      if ($btn.hasClass('enabled')) {
-        cy.wrap($btn).click().should('not.have.class', 'enabled')
-      } else {
-        cy.wrap($btn).click().should('have.class', 'enabled')
+      if (!$btn.hasClass('locked')) {
+        if ($btn.hasClass('enabled')) {
+          cy.wrap($btn).click().should('not.have.class', 'enabled')
+        } else {
+          cy.wrap($btn).click().should('have.class', 'enabled')
+        }
       }
     })
   cy.get('#custom-cursor-area').should('be.visible').click()
@@ -160,7 +169,9 @@ Cypress.Commands.add('createAccountUserInput', (username, status) => {
   cy.get('[data-cy=username-input]', { timeout: 30000 })
     .should('be.visible')
     .type(randomName)
-  cy.get('[data-cy=status-input]').should('be.visible').type(randomStatus)
+  cy.get('[data-cy=status-input]', { timeout: 30000 })
+    .should('be.visible')
+    .type(randomStatus)
 })
 
 Cypress.Commands.add('createAccountAddImage', (filepath) => {


### PR DESCRIPTION
**What this PR does** 📖
- Added test into privacy-page-toggles.js cypress script to validate that registry public toggle is locked
- Updates to existing tests on privacy-page-toggles.js cypress script to consider that registry public toggle is locked
- Updates to cypress commands to consider the registry public toggle as locked, which will fix the create account cypress tests
- Small change into cypress commands to add a timeout for status input on account creation
- Change on cypress command for visiting root page to ensure that pin data is removed before visiting main page when creating/importing an account 

**Which issue(s) this PR fixes** 🔨
AP-1029 and AP-1071

**Special notes for reviewers** 🗒️
It is not possible to assert the hover image displayed when the mouse pointer is over the locked toggle. However, an assertion to verify that element is locked was included

**Additional comments** 🎤
Cypress Video for Create Account:
https://user-images.githubusercontent.com/35935591/157995725-13b68f60-14a1-4c4e-92d9-86121c386df2.mp4


Cypress Video for Privacy Page Toggles:
https://user-images.githubusercontent.com/35935591/157995721-3f1eb5ed-d91e-4ac7-ba32-ed02a6a8ff7e.mp4


