### PR TITLE
refactor(files): move common methods up and emit from children

### DIFF
--- a/components/views/files/file/File.html
+++ b/components/views/files/file/File.html
@@ -1,7 +1,7 @@
 <div
   class="file"
-  :class="ui.isLoadingFileIndex ? 'disabled' : 'clickable'"
-  v-on="ui.isLoadingFileIndex ? {} : {click: fileClick, contextmenu: contextMenu}"
+  :class="{'disabled' : ui.isLoadingFileIndex}"
+  v-on="ui.isLoadingFileIndex ? {} : {click: click, contextmenu: contextMenu}"
   @mouseover="fileHover=true"
   @mouseleave="fileHover=false"
 >

--- a/components/views/files/file/File.less
+++ b/components/views/files/file/File.less
@@ -4,10 +4,7 @@
   min-height: 234px;
   border-radius: @corner-rounding-smaller;
   &:extend(.background-semitransparent-light);
-
-  &.clickable {
-    cursor: pointer;
-  }
+  cursor: pointer;
 
   .quick-actions {
     width: @full;
@@ -34,7 +31,7 @@
     justify-content: center;
     align-items: center;
     flex-grow: 1;
-    padding-top: 36px; // half of the text area height. this centers
+    padding-top: 36px; // half of the text area height, centers icon
 
     .file-type-icon {
       &:extend(.font-accent);

--- a/components/views/files/file/File.vue
+++ b/components/views/files/file/File.vue
@@ -21,7 +21,7 @@ declare module 'vue/types/vue' {
     like: () => void
     share: () => void
     rename: () => void
-    delete: () => void
+    remove: () => void
     $filesize: (item: number) => string
   }
 }
@@ -56,7 +56,7 @@ export default Vue.extend({
         { text: 'Favorite', func: this.like },
         { text: 'Share', func: this.share },
         { text: 'Rename', func: this.rename },
-        { text: 'Delete', func: this.delete },
+        { text: 'Delete', func: this.remove },
       ],
     }
   },
@@ -85,10 +85,10 @@ export default Vue.extend({
   },
   methods: {
     /**
-     * @method fileClick
-     * @description Handle regular file click. avoiding regular behavior(handle) if user clicks heart or link icon
+     * @method click
+     * @description handle file click depending on various hover statuses
      */
-    fileClick() {
+    click() {
       if (this.linkHover) {
         this.share()
         return
@@ -101,59 +101,31 @@ export default Vue.extend({
     },
     /**
      * @method like
-     * @description toggle like on file and force render for files
+     * @description Emit to like item - pages/files/browse/index.vue
      */
-    async like() {
-      this.$store.commit('ui/setIsLoadingFileIndex', true)
-      this.item.toggleLiked()
-      await this.$TextileManager.bucket?.updateIndex(this.$FileSystem.export)
-      this.item.liked
-        ? this.$toast.show(this.$t('pages.files.add_favorite') as string)
-        : this.$toast.show(this.$t('pages.files.remove_favorite') as string)
-      this.$store.commit('ui/setIsLoadingFileIndex', false)
-      this.$emit('forceRender')
+    like() {
+      this.$emit('like', this.item)
     },
     /**
      * @method share
-     * @description copy link to clipboard
+     * @description Emit to share item - pages/files/browse/index.vue
      */
-    async share() {
-      this.$toast.show(this.$t('todo - share') as string)
-      // if (this.item instanceof Directory) {
-      //   this.$toast.show(this.$t('todo - share folders') as string)
-      //   return
-      // }
-      // if (!this.item.shared) {
-      //   this.$store.commit('ui/setIsLoadingFileIndex', true)
-      //   this.item.shareItem()
-      //   await this.$TextileManager.bucket?.updateIndex(this.$FileSystem.export)
-      //   this.$store.commit('ui/setIsLoadingFileIndex', false)
-      //   this.$emit('forceRender')
-      // }
-      // navigator.clipboard.writeText(this.path).then(() => {
-      //   this.$toast.show(this.$t('pages.files.link_copied') as string)
-      // })
+    share() {
+      this.$emit('share', this.item)
     },
     /**
      * @method rename
-     * @description todo
+     * @description Emit to rename item - pages/files/browse/index.vue
      */
     rename() {
-      this.$toast.show(this.$t('todo - rename items') as string)
+      this.$emit('rename', this.item)
     },
     /**
-     * @method delete
-     * @description delete folder/file from filesystem. If file, also remove from textile bucket
+     * @method remove
+     * @description Emit to delete item - pages/files/browse/index.vue
      */
-    async delete() {
-      this.$store.commit('ui/setIsLoadingFileIndex', true)
-      if (this.item instanceof Fil) {
-        await this.$FileSystem.removeFile(this.item.name)
-      }
-      this.$FileSystem.removeChild(this.item.name)
-      await this.$TextileManager.bucket?.updateIndex(this.$FileSystem.export)
-      this.$store.commit('ui/setIsLoadingFileIndex', false)
-      this.$emit('forceRender')
+    remove() {
+      this.$emit('remove', this.item)
     },
   },
 })

--- a/components/views/files/grid/Grid.html
+++ b/components/views/files/grid/Grid.html
@@ -9,8 +9,11 @@
       v-for="item, i in directory"
       :item="item"
       :key="i + counter"
+      @like="like"
+      @share="share"
+      @rename="rename"
+      @remove="remove"
       @handle="handle"
-      @forceRender="forceRender"
     />
   </div>
 </div>

--- a/components/views/files/grid/Grid.vue
+++ b/components/views/files/grid/Grid.vue
@@ -10,7 +10,7 @@ export default Vue.extend({
      */
     directory: {
       type: Array as PropType<Array<Item>>,
-      default: () => [],
+      required: true,
     },
     /**
      * counter to force reactivity for Map
@@ -29,11 +29,32 @@ export default Vue.extend({
       this.$emit('handle', item)
     },
     /**
-     * @method forceRender
-     * @description force reactivity for Map
+     * @method like
+     * @description Emit to like item - pages/files/browse/index.vue
      */
-    forceRender() {
-      this.$emit('forceRender')
+    like(item: Item) {
+      this.$emit('like', item)
+    },
+    /**
+     * @method share
+     * @description Emit to share item - pages/files/browse/index.vue
+     */
+    share(item: Item) {
+      this.$emit('share', item)
+    },
+    /**
+     * @method rename
+     * @description Emit to rename item - pages/files/browse/index.vue
+     */
+    rename(item: Item) {
+      this.$emit('rename', item)
+    },
+    /**
+     * @method remove
+     * @description Emit to delete item - pages/files/browse/index.vue
+     */
+    remove(item: Item) {
+      this.$emit('remove', item)
     },
   },
 })

--- a/components/views/files/list/List.html
+++ b/components/views/files/list/List.html
@@ -24,6 +24,10 @@
         v-for="item, i in directory"
         :key="i + counter"
         :item="item"
+        @like="like"
+        @share="share"
+        @rename="rename"
+        @remove="remove"
         @handle="handle"
       />
     </tbody>

--- a/components/views/files/list/List.vue
+++ b/components/views/files/list/List.vue
@@ -63,6 +63,13 @@ export default Vue.extend({
   },
   methods: {
     /**
+     * @method forceRender
+     * @description refresh items timestamp - called every minute
+     */
+    forceRender() {
+      this.$emit('forceRender')
+    },
+    /**
      * @method handle
      * @description Emit item to be handled in pages/files/browse/index.vue
      */
@@ -70,11 +77,32 @@ export default Vue.extend({
       this.$emit('handle', item)
     },
     /**
-     * @method forceRender
-     * @description force reactivity for Map
+     * @method like
+     * @description Emit to like item - pages/files/browse/index.vue
      */
-    forceRender() {
-      this.$emit('forceRender')
+    like(item: Item) {
+      this.$emit('like', item)
+    },
+    /**
+     * @method share
+     * @description Emit to share item - pages/files/browse/index.vue
+     */
+    share(item: Item) {
+      this.$emit('share', item)
+    },
+    /**
+     * @method rename
+     * @description Emit to rename item - pages/files/browse/index.vue
+     */
+    rename(item: Item) {
+      this.$emit('rename', item)
+    },
+    /**
+     * @method remove
+     * @description Emit to delete item - pages/files/browse/index.vue
+     */
+    remove(item: Item) {
+      this.$emit('remove', item)
     },
     sort() {
       this.$toast.show(this.$t('todo - sort') as string)

--- a/components/views/files/row/Row.vue
+++ b/components/views/files/row/Row.vue
@@ -39,10 +39,10 @@ export default Vue.extend({
     return {
       menuHover: false as boolean,
       contextMenuValues: [
-        { text: 'Favorite', func: this.todo },
-        { text: 'Share', func: this.todo },
-        { text: 'Rename', func: this.todo },
-        { text: 'Delete', func: this.todo },
+        { text: 'Favorite', func: this.like },
+        { text: 'Share', func: this.share },
+        { text: 'Rename', func: this.rename },
+        { text: 'Delete', func: this.remove },
       ],
     }
   },
@@ -61,10 +61,32 @@ export default Vue.extend({
       this.$emit('handle', this.item)
     },
     /**
-     * @description handle in AP-1054
+     * @method like
+     * @description Emit to like item - pages/files/browse/index.vue
      */
-    todo() {
-      this.$toast.show(this.$t('todo') as string)
+    like() {
+      this.$emit('like', this.item)
+    },
+    /**
+     * @method share
+     * @description Emit to share item - pages/files/browse/index.vue
+     */
+    share() {
+      this.$emit('share', this.item)
+    },
+    /**
+     * @method rename
+     * @description Emit to rename item - pages/files/browse/index.vue
+     */
+    rename() {
+      this.$emit('rename', this.item)
+    },
+    /**
+     * @method remove
+     * @description Emit to delete item - pages/files/browse/index.vue
+     */
+    remove() {
+      this.$emit('remove', this.item)
     },
   },
 })

--- a/components/views/files/view/View.vue
+++ b/components/views/files/view/View.vue
@@ -52,20 +52,10 @@ export default Vue.extend({
   methods: {
     /**
      * @method share
-     * @description copy link to clipboard and toggle shared status
+     * @description Emit to share item - pages/files/browse/index.vue
      */
-    async share() {
-      this.$toast.show(this.$t('todo - share') as string)
-      // if (!this.file.shared) {
-      //   this.$store.commit('ui/setIsLoadingFileIndex', true)
-      //   this.file.shareItem()
-      //   await this.$TextileManager.bucket?.updateIndex(this.$FileSystem.export)
-      //   this.$store.commit('ui/setIsLoadingFileIndex', false)
-      // }
-      // navigator.clipboard.writeText(this.path).then(() => {
-      //   this.$toast.show(this.$t('pages.files.link_copied') as string)
-      // })
-      // this.$emit('forceRender')
+    share() {
+      this.$emit('share', this.file)
     },
   },
 })

--- a/pages/files/browse/Browse.html
+++ b/pages/files/browse/Browse.html
@@ -1,10 +1,5 @@
 <div id="files" class="hidden-scroll" v-scroll-lock="true">
-  <FilesView
-    v-if="file"
-    :file="file"
-    @close="file = false"
-    @forceRender="forceRender"
-  />
+  <FilesView v-if="file" :file="file" @close="file = false" @share="share" />
   <FilesAside v-if="$device.isMobile" class="mobile-file-aside" />
   <div class="files-top">
     <FilesFilepath />
@@ -20,6 +15,10 @@
         v-else-if="view === 'list'"
         :directory="directory"
         :counter="counter"
+        @like="like"
+        @share="share"
+        @rename="rename"
+        @remove="remove"
         @handle="handle"
         @forceRender="forceRender"
       />
@@ -27,8 +26,11 @@
         v-else
         :directory="directory"
         :counter="counter"
+        @like="like"
+        @share="share"
+        @rename="rename"
+        @remove="remove"
         @handle="handle"
-        @forceRender="forceRender"
       />
     </div>
     <FilesAside v-if="!$device.isMobile" class="files-right" />


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- after adding like/share/delete functionality to list view, I realized this needed refactoring.
- to avoid repeating code, I moved those methods to the parent component (files/index page) then emit from the children

**Which issue(s) this PR fixes** 🔨
AP-1054
<!--AP-X-->

**Special notes for reviewers** 🗒️
- not really new functionality worth mentioning, just make sure like/share/rename/delete works in list and grid view

**Additional comments** 🎤
