### PR TITLE
fix(lifecycleHook): fix Vue3 syntax

### DIFF
--- a/components/interactables/ContextMenu/ContextMenu.vue
+++ b/components/interactables/ContextMenu/ContextMenu.vue
@@ -24,7 +24,7 @@ export default Vue.extend({
       el.addEventListener('contextmenu', this.handleOverflow)
     }
   },
-  beforeUnmount() {
+  beforeDestroy() {
     const el = document.querySelector('body')
     if (el) {
       el.removeEventListener('contextmenu', this.handleOverflow)

--- a/components/ui/Chat/Scroll/Scroll.vue
+++ b/components/ui/Chat/Scroll/Scroll.vue
@@ -71,7 +71,7 @@ export default Vue.extend({
       this.autoScrollToBottom()
     })
   },
-  beforeUnmount() {
+  beforeDestroy() {
     this.loaded = false
   },
   methods: {

--- a/components/views/chat/group/Group.vue
+++ b/components/views/chat/group/Group.vue
@@ -67,7 +67,7 @@ export default Vue.extend({
       Config.chat.timestampUpdateInterval,
     )
   },
-  beforeUnmount() {
+  beforeDestroy() {
     clearInterval(this.$data.refreshTimestampEveryMinute)
   },
   methods: {

--- a/components/views/chat/message/Message.vue
+++ b/components/views/chat/message/Message.vue
@@ -102,7 +102,7 @@ export default Vue.extend({
       Config.chat.timestampUpdateInterval,
     )
   },
-  beforeUnmount() {
+  beforeDestroy() {
     clearInterval(this.$data.refreshTimestampEveryMinute)
   },
   methods: {

--- a/components/views/media/actions/volume/Volume.vue
+++ b/components/views/media/actions/volume/Volume.vue
@@ -48,7 +48,7 @@ export default Vue.extend({
   mounted() {
     document.addEventListener('click', this.hideSlider)
   },
-  beforeUnmount() {
+  beforeDestroy() {
     document.removeEventListener('click', this.hideSlider)
   },
   methods: {

--- a/components/views/media/heading/Heading.vue
+++ b/components/views/media/heading/Heading.vue
@@ -23,7 +23,7 @@ export default Vue.extend({
     this.timer = false
     this.setTimer()
   },
-  beforeUnmount() {
+  beforeDestroy() {
     this.clearTimer()
   },
   methods: {

--- a/components/views/settings/pages/audio/index.vue
+++ b/components/views/settings/pages/audio/index.vue
@@ -164,7 +164,7 @@ export default Vue.extend({
     this.setupDefaults()
     this.$data.updateInterval = setInterval(this.setupDefaults, 1000)
   },
-  beforeUnmount() {
+  beforeDestroy() {
     if (this.$data.stream) {
       this.$data.stream
         .getAudioTracks()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- some components are using Vue3 syntax (beforeUnmount), probably changed by a linter while we had incorrect config

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
