### PR TITLE
chore(cypress): add github action

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -13,8 +13,8 @@ jobs:
       - name: Create .env file
         uses: SpicyPizza/create-envfile@v1.3
         with:
-          ENVIRONMENT: "dev"
-          TEXTILE_API_KEY: ${{ secrets.NUXT_ENV_TEXTILE_API_KEY }}
+          envkey_ENVIRONMENT: "dev"
+          envkey_TEXTILE_API_KEY: ${{ secrets.NUXT_ENV_TEXTILE_API_KEY }}
           directory: ./
           file_name: .env
           fail_on_empty: false

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -14,7 +14,7 @@ jobs:
         uses: SpicyPizza/create-envfile@v1.3
         with:
           envkey_ENVIRONMENT: "dev"
-          envkey_TEXTILE_API_KEY: ${{ secrets.NUXT_ENV_TEXTILE_API_KEY }}
+          envkey_NUXT_TEXTILE_API_KEY: ${{ secrets.NUXT_ENV_TEXTILE_API_KEY }}
           directory: ./
           file_name: .env
           fail_on_empty: false

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -28,7 +28,7 @@ jobs:
             wait-on: http://localhost:3000
             wait-on-timeout: 300
       - name: Artifacts
-      - uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2
         if: failure()
         with:
           name: cypress-screenshots

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           touch .env
           echo ENVIRONMENT="dev" >> .env
-          echo NUXT_TEXTILE_API_KEY=${{ secrets.NUXT_ENV_TEXTILE_API_KEY }} >> .env
+          echo NUXT_ENV_TEXTILE_API_KEY=${{ secrets.NUXT_ENV_TEXTILE_API_KEY }} >> .env
           cat .env
       - name: Read .env file
         id: envfile

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -29,7 +29,7 @@ jobs:
             working-directory: ./
             install: false
             start: yarn dev
-            command: npx cypress run --spec cypress/integration/chat-features.js --browser chrome --headless
+            command: npx cypress run --browser chrome --headless
             wait-on: http://localhost:3000
             wait-on-timeout: 300
       - name: Artifacts

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Create .env file
         uses: SpicyPizza/create-envfile@v1.3
         with:
-          ENVIRONMENT: dev
+          ENVIRONMENT: "dev"
           TEXTILE_API_KEY: ${{ secrets.NUXT_ENV_TEXTILE_API_KEY }}
           directory: ./
           file_name: .env

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -16,6 +16,13 @@ jobs:
           echo ENVIRONMENT="dev" >> .env
           echo NUXT_TEXTILE_API_KEY=${{ secrets.NUXT_ENV_TEXTILE_API_KEY }} >> .env
           cat .env
+      - name: Read .env file
+        id: envfile
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./.env
+      - name: Echo .env
+        run: echo "${{ steps.envfile.outputs.content }}"
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -24,6 +24,17 @@ jobs:
             working-directory: ./
             install: false
             start: yarn dev
-            command: npx cypress run --browser chrome --headless
+            command: npx cypress run cypress/integration/chat-features.js --browser chrome --headless
             wait-on: http://localhost:3000
             wait-on-timeout: 300
+      - name: Artifacts
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: cypress-videos
+          path: cypress/videos

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -13,8 +13,8 @@ jobs:
       - name: Create .env file
         uses: SpicyPizza/create-envfile@v1.3
         with:
-          envkey_ENVIRONMENT: "dev"
-          envkey_NUXT_TEXTILE_API_KEY: ${{ secrets.NUXT_ENV_TEXTILE_API_KEY }}
+          ENVIRONMENT: "dev"
+          NUXT_TEXTILE_API_KEY: ${{ secrets.NUXT_ENV_TEXTILE_API_KEY }}
           directory: ./
           file_name: .env
           fail_on_empty: false

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -24,7 +24,7 @@ jobs:
             working-directory: ./
             install: false
             start: yarn dev
-            command: npx cypress run cypress/integration/chat-features.js --browser chrome --headless
+            command: npx cypress run --spec cypress/integration/chat-features.js --browser chrome --headless
             wait-on: http://localhost:3000
             wait-on-timeout: 300
       - name: Artifacts

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -10,14 +10,12 @@ jobs:
         run: git submodule update --init --recursive
       - name: Install dependencies
         run: yarn
-      - name: Create .env file
-        uses: SpicyPizza/create-envfile@v1.3
-        with:
-          ENVIRONMENT: "dev"
-          NUXT_TEXTILE_API_KEY: ${{ secrets.NUXT_ENV_TEXTILE_API_KEY }}
-          directory: ./
-          file_name: .env
-          fail_on_empty: false
+      - name: Create env file
+        run: |
+          touch .env
+          echo ENVIRONMENT="dev" >> .env
+          echo NUXT_TEXTILE_API_KEY=${{ secrets.NUXT_ENV_TEXTILE_API_KEY }} >> .env
+          cat .env
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -14,7 +14,7 @@ jobs:
         uses: SpicyPizza/create-envfile@v1.3
         with:
           ENVIRONMENT: dev
-          TEXTILE_API_KEY: ${{ secrets.TEXTILE_API_KEY }}
+          TEXTILE_API_KEY: ${{ secrets.NUXT_ENV_TEXTILE_API_KEY }}
           directory: ./
           file_name: .env
           fail_on_empty: false
@@ -24,6 +24,6 @@ jobs:
             working-directory: ./
             install: false
             start: yarn dev
-            command: npx cypress run --spec cypress/integration/localstorage-validations.js --browser chrome --headless
+            command: npx cypress run --browser chrome --headless
             wait-on: http://localhost:3000
             wait-on-timeout: 300

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,0 +1,29 @@
+name: Cypress
+on: [pull_request]
+jobs:
+  cypress-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Update submodules
+        run: git submodule update --init --recursive
+      - name: Install dependencies
+        run: yarn
+      - name: Create .env file
+        uses: SpicyPizza/create-envfile@v1.3
+        with:
+          ENVIRONMENT: dev
+          TEXTILE_API_KEY: ${{ secrets.TEXTILE_API_KEY }}
+          directory: ./
+          file_name: .env
+          fail_on_empty: false
+      - name: Cypress run
+        uses: cypress-io/github-action@v2
+        with:
+            working-directory: ./
+            install: false
+            start: yarn dev
+            command: npx cypress run --spec cypress/integration/localstorage-validations.js --browser chrome --headless
+            wait-on: http://localhost:3000
+            wait-on-timeout: 300


### PR DESCRIPTION
**What this PR does** 📖

Adds Github Action to run Cypress on every PR

![image](https://user-images.githubusercontent.com/29093946/158481690-c382a938-130f-4ca9-9a85-7133a9794870.png)

<img width="843" alt="Captura de ecrã 2022-03-15, às 17 27 36" src="https://user-images.githubusercontent.com/29093946/158436558-0b1c93f1-f45b-443f-aea4-3c784bb7235b.png">

flow
- checkouts the code
- installs submodules
- `yarn`
- creates `.env` file same as we use locally
- `yarn dev` and runs Cypress on Chrome, on localhost:3000
