### PR TITLE
chore(jest): add more coverage on Solana.test.ts

### DIFF
--- a/libraries/Solana/Solana.test.ts
+++ b/libraries/Solana/Solana.test.ts
@@ -1,4 +1,3 @@
-import * as web3 from '@solana/web3.js'
 import * as Solana from '~/libraries/Solana/Solana'
 
 describe('Solana.getClusterFromNetworkConfig', () => {
@@ -25,5 +24,27 @@ describe('Solana.getClusterFromNetworkConfig', () => {
   test('4', () => {
     const result: any = Solana.getClusterFromNetworkConfig('')
     expect(result).toMatchSnapshot()
+  })
+
+  describe('Solana.sleep', () => {
+    test('0', () => {
+      const result: any = Solana.sleep(0)
+      expect(result).toMatchSnapshot()
+    })
+
+    test('1', () => {
+      const result: any = Solana.sleep(-5.48)
+      expect(result).toMatchSnapshot()
+    })
+
+    test('2', () => {
+      const result: any = Solana.sleep(-100)
+      expect(result).toMatchSnapshot()
+    })
+
+    test('3', () => {
+      const result: any = Solana.sleep(-Infinity)
+      expect(result).toMatchSnapshot()
+    })
   })
 })

--- a/libraries/Solana/__snapshots__/Solana.test.ts.snap
+++ b/libraries/Solana/__snapshots__/Solana.test.ts.snap
@@ -9,3 +9,11 @@ exports[`Solana.getClusterFromNetworkConfig 2 1`] = `"devnet"`;
 exports[`Solana.getClusterFromNetworkConfig 3 1`] = `"devnet"`;
 
 exports[`Solana.getClusterFromNetworkConfig 4 1`] = `"devnet"`;
+
+exports[`Solana.getClusterFromNetworkConfig Solana.sleep 0 1`] = `Promise {}`;
+
+exports[`Solana.getClusterFromNetworkConfig Solana.sleep 1 1`] = `Promise {}`;
+
+exports[`Solana.getClusterFromNetworkConfig Solana.sleep 2 1`] = `Promise {}`;
+
+exports[`Solana.getClusterFromNetworkConfig Solana.sleep 3 1`] = `Promise {}`;


### PR DESCRIPTION

**What this PR does** 📖

- Adds more coverage on`libraries/Solana/Solana.test.ts`
- Removes not used import


before

<img width="839" alt="Captura de ecrã 2022-03-16, às 16 16 15" src="https://user-images.githubusercontent.com/29093946/158637172-3737682c-2155-487d-b218-4c96f8cd3704.png">

after

<img width="883" alt="Captura de ecrã 2022-03-16, às 16 16 29" src="https://user-images.githubusercontent.com/29093946/158637183-1528b8e4-8ede-4d27-96e7-ad0869d16efa.png">

