### PR TITLE
fix(messages): context menu shows correct options

### DIFF
--- a/components/views/chat/message/Message.vue
+++ b/components/views/chat/message/Message.vue
@@ -16,6 +16,7 @@ declare module 'vue/types/vue' {
     quickReaction: (emoji: String) => void
     editMessage: () => void
     emojiReaction: (e: MouseEvent) => void
+    copyMessage: () => void
   }
 }
 
@@ -54,26 +55,6 @@ export default Vue.extend({
   data() {
     return {
       disData: 'DataFromTheProperty',
-      contextMenuValues: [
-        { text: 'quickReaction', func: this.quickReaction },
-        { text: this.$t('context.edit'), func: this.editMessage },
-        { text: this.$t('context.reaction'), func: this.emojiReaction },
-        { text: this.$t('context.reply'), func: this.setReplyChatbarContent },
-        {
-          text: this.$t('context.copy_msg'),
-          func: () => {
-            const { type, payload } = this.$props.message
-            let finalPayload = payload
-            if (['image', 'video', 'audio', 'file'].includes(type)) {
-              finalPayload = this.$t('conversation.multimedia')
-            }
-            this.$envinfo.navigator.clipboard.writeText(finalPayload)
-          },
-        },
-        { text: this.$t('context.copy_img'), func: (this as any).testFunc },
-        { text: this.$t('context.save'), func: (this as any).testFunc },
-        { text: this.$t('context.copy_link'), func: (this as any).testFunc },
-      ],
       timestampRefreshInterval: null,
       timestamp: this.$dayjs(this.$props.message.at).fromNow(),
     }
@@ -87,6 +68,47 @@ export default Vue.extend({
     },
     messageEdit() {
       return this.ui.editMessage.id === this.$props.message.id
+    },
+    contextMenuValues() {
+      const mainList = [
+        { text: 'quickReaction', func: this.quickReaction },
+        { text: this.$t('context.reaction'), func: this.emojiReaction },
+        { text: this.$t('context.reply'), func: this.setReplyChatbarContent },
+        // { text: this.$t('context.copy_link'), func: (this as any).testFunc },
+      ]
+      if (this.message.type === 'text') {
+        // if your own text message
+        if (this.accounts.details.textilePubkey === this.$props.message.from) {
+          return [
+            ...mainList,
+            {
+              text: this.$t('context.copy_msg'),
+              func: this.copyMessage,
+            },
+            { text: this.$t('context.edit'), func: this.editMessage },
+          ]
+        }
+        // another persons text message
+        return [
+          ...mainList,
+          {
+            text: this.$t('context.copy_msg'),
+            func: this.copyMessage,
+          },
+        ]
+      }
+      // if image message
+      if (
+        this.message.type === 'file' &&
+        this.$props.message.payload.type.includes('image')
+      ) {
+        return [
+          ...mainList,
+          { text: this.$t('context.copy_img'), func: (this as any).testFunc },
+          { text: this.$t('context.save_img'), func: (this as any).testFunc },
+        ]
+      }
+      return mainList
     },
   },
   created() {
@@ -133,6 +155,21 @@ export default Vue.extend({
     },
     testFunc() {
       this.$Logger.log('Message Context', 'Test func')
+    },
+    /**
+     * @method copyMessage
+     * @description copy contents of message. Will only be called if text message
+     */
+    copyMessage() {
+      this.$envinfo.navigator.clipboard.writeText(this.message.payload)
+    },
+    /**
+     * @method mouseOver DocsTODO
+     * @description
+     * @example
+     */
+    mouseOver() {
+      this.$data.messageHover = !this.$data.messageHover
     },
     /**
      * @method setReplyChatbarContent DocsTODO

--- a/components/views/chat/message/Message.vue
+++ b/components/views/chat/message/Message.vue
@@ -164,14 +164,6 @@ export default Vue.extend({
       this.$envinfo.navigator.clipboard.writeText(this.message.payload)
     },
     /**
-     * @method mouseOver DocsTODO
-     * @description
-     * @example
-     */
-    mouseOver() {
-      this.$data.messageHover = !this.$data.messageHover
-    },
-    /**
      * @method setReplyChatbarContent DocsTODO
      * @description
      * @example

--- a/components/views/chat/message/Message.vue
+++ b/components/views/chat/message/Message.vue
@@ -74,6 +74,7 @@ export default Vue.extend({
         { text: 'quickReaction', func: this.quickReaction },
         { text: this.$t('context.reaction'), func: this.emojiReaction },
         { text: this.$t('context.reply'), func: this.setReplyChatbarContent },
+        // AP-1120 copy link functionality
         // { text: this.$t('context.copy_link'), func: (this as any).testFunc },
       ]
       if (this.message.type === 'text') {

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -671,7 +671,7 @@ export default {
     reply: 'Reply',
     copy_msg: 'Copy Message',
     copy_img: 'Copy Image',
-    save: 'Save Image',
+    save_img: 'Save Image',
     copy_link: 'Copy Link',
   },
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- show edit for your own text messages
  - do not show on other types 
- show image related options for images - any sender (still no functionality. will be implemented separately)
- commented out `copy link` for now, that should be a separate ticket

**Which issue(s) this PR fixes** 🔨

AP-1091
AP-1095
AP-1096

**Special notes for reviewers** 🗒️
- I jumbled the order around, adding conditional options at the bottom. That way the position of static options remains the same and a user can click via muscle memory. let me know if you'd like to adjust these

**Additional comments** 🎤
