### PR TITLE
test(cypress): add chat toolbar cypress tests

### DIFF
--- a/components/views/navigation/toolbar/Toolbar.html
+++ b/components/views/navigation/toolbar/Toolbar.html
@@ -93,10 +93,10 @@
 
     <div class="vertical-divider" v-if="!$device.isMobile"></div>
     <UiComingSoon
+      data-cy="toolbar-marketplace"
       v-if="!$device.isMobile"
       :tooltipText="$t('coming_soon.marketplace')"
       :tooltipPosition="'bottom'"
-      data-cy="toolbar-marketplace"
     >
       <div
         class="market-place has-tooltip has-tooltip-primary has-tooltip-bottom"

--- a/components/views/navigation/toolbar/Toolbar.html
+++ b/components/views/navigation/toolbar/Toolbar.html
@@ -27,6 +27,7 @@
       v-if="!$device.isMobile"
       :tooltipText="$t('coming_soon.alerts')"
       :tooltipPosition="'bottom'"
+      :data-cy="`toolbar-alerts`"
     >
       <div
         class="has-tooltip has-tooltip-bottom has-tooltip-primary has-tooltip-hidden-touch"
@@ -56,6 +57,7 @@
       :class="`has-tooltip has-tooltip-bottom has-tooltip-primary has-tooltip-hidden-touch control-button
       ${!enableRTC || webrtc.activeCall ? 'disabled' : ''}`"
       :data-tooltip="enableRTC ? $t('controls.call') : $t('controls.not_connected')"
+      data-cy="toolbar-enable-audio"
       v-if="server"
       @click="() => call(['audio'])"
     >
@@ -65,6 +67,7 @@
       :class="`has-tooltip has-tooltip-bottom has-tooltip-primary has-tooltip-hidden-touch control-button
       ${!enableRTC || webrtc.activeCall ? 'disabled' : ''}`"
       :data-tooltip="enableRTC ? $t('controls.video') : $t('controls.not_connected')"
+      data-cy="toolbar-enable-video"
       v-if="server"
       @click="() => call(['audio', 'video'])"
     >
@@ -74,6 +77,7 @@
       v-if="!$device.isMobile"
       :tooltipText="$t('coming_soon.archived')"
       :tooltipPosition="'bottom'"
+      :data-cy="`toolbar-archived-messages`"
     >
       <div
         class="has-tooltip has-tooltip-bottom has-tooltip-primary has-tooltip-hidden-touch"
@@ -92,6 +96,7 @@
       v-if="!$device.isMobile"
       :tooltipText="$t('coming_soon.marketplace')"
       :tooltipPosition="'bottom'"
+      :data-cy="`toolbar-marketplace`"
     >
       <div
         class="market-place has-tooltip has-tooltip-primary has-tooltip-bottom"
@@ -105,6 +110,7 @@
       v-if="!$device.isMobile"
       :tooltipText="$t('coming_soon.wallet')"
       :tooltipPosition="'bottom'"
+      :data-cy="`toolbar-wallet`"
     >
       <div
         class="has-tooltip has-tooltip-primary has-tooltip-bottom"

--- a/components/views/navigation/toolbar/Toolbar.html
+++ b/components/views/navigation/toolbar/Toolbar.html
@@ -92,20 +92,14 @@
     </UiComingSoon>
 
     <div class="vertical-divider" v-if="!$device.isMobile"></div>
-    <UiComingSoon
+    <div
+      class="market-place has-tooltip has-tooltip-primary has-tooltip-bottom"
+      @click="() => toggleModal(ModalWindows.CALLTOACTION)"
+      data-tooltip="Marketplace"
       data-cy="toolbar-marketplace"
-      v-if="!$device.isMobile"
-      :tooltipText="$t('coming_soon.marketplace')"
-      :tooltipPosition="'bottom'"
     >
-      <div
-        class="market-place has-tooltip has-tooltip-primary has-tooltip-bottom"
-        @click="() => toggleModal(ModalWindows.MARKETPLACE)"
-        data-tooltip="Marketplace"
-      >
-        <shopping-bag-icon class="control-icon" size="1x" color="grey" />
-      </div>
-    </UiComingSoon>
+      <shopping-bag-icon class="control-icon" size="1x" />
+    </div>
     <UiComingSoon
       v-if="!$device.isMobile"
       :tooltipText="$t('coming_soon.wallet')"

--- a/components/views/navigation/toolbar/Toolbar.html
+++ b/components/views/navigation/toolbar/Toolbar.html
@@ -27,7 +27,7 @@
       v-if="!$device.isMobile"
       :tooltipText="$t('coming_soon.alerts')"
       :tooltipPosition="'bottom'"
-      :data-cy="`toolbar-alerts`"
+      data-cy="toolbar-alerts"
     >
       <div
         class="has-tooltip has-tooltip-bottom has-tooltip-primary has-tooltip-hidden-touch"
@@ -56,8 +56,8 @@
     <div
       :class="`has-tooltip has-tooltip-bottom has-tooltip-primary has-tooltip-hidden-touch control-button
       ${!enableRTC || webrtc.activeCall ? 'disabled' : ''}`"
-      :data-tooltip="enableRTC ? $t('controls.call') : $t('controls.not_connected')"
       data-cy="toolbar-enable-audio"
+      :data-tooltip="enableRTC ? $t('controls.call') : $t('controls.not_connected')"
       v-if="server"
       @click="() => call(['audio'])"
     >
@@ -66,8 +66,8 @@
     <div
       :class="`has-tooltip has-tooltip-bottom has-tooltip-primary has-tooltip-hidden-touch control-button
       ${!enableRTC || webrtc.activeCall ? 'disabled' : ''}`"
-      :data-tooltip="enableRTC ? $t('controls.video') : $t('controls.not_connected')"
       data-cy="toolbar-enable-video"
+      :data-tooltip="enableRTC ? $t('controls.video') : $t('controls.not_connected')"
       v-if="server"
       @click="() => call(['audio', 'video'])"
     >
@@ -77,7 +77,7 @@
       v-if="!$device.isMobile"
       :tooltipText="$t('coming_soon.archived')"
       :tooltipPosition="'bottom'"
-      :data-cy="`toolbar-archived-messages`"
+      data-cy="toolbar-archived-messages"
     >
       <div
         class="has-tooltip has-tooltip-bottom has-tooltip-primary has-tooltip-hidden-touch"
@@ -96,7 +96,7 @@
       v-if="!$device.isMobile"
       :tooltipText="$t('coming_soon.marketplace')"
       :tooltipPosition="'bottom'"
-      :data-cy="`toolbar-marketplace`"
+      data-cy="toolbar-marketplace"
     >
       <div
         class="market-place has-tooltip has-tooltip-primary has-tooltip-bottom"
@@ -110,7 +110,7 @@
       v-if="!$device.isMobile"
       :tooltipText="$t('coming_soon.wallet')"
       :tooltipPosition="'bottom'"
-      :data-cy="`toolbar-wallet`"
+      data-cy="toolbar-wallet"
     >
       <div
         class="has-tooltip has-tooltip-primary has-tooltip-bottom"

--- a/cypress/integration/chat-features.js
+++ b/cypress/integration/chat-features.js
@@ -9,7 +9,7 @@ const recoverySeed =
 let imageURL
 
 describe('Chat Features Tests', () => {
-  it('Chat - Send stuff on chat', () => {
+  it('Chat - Send message on chat', () => {
     //Import account
     cy.importAccount(randomPIN, recoverySeed)
 
@@ -19,21 +19,25 @@ describe('Chat Features Tests', () => {
     // Click on hamburger menu if width < height
     cy.get('.toggle-sidebar').should('be.visible').click()
 
-    //Validate message and emojis are sent
+    //Validate message is sent
     cy.waitForMessagesToLoad()
     cy.chatFeaturesSendMessage(randomMessage)
-    cy.chatFeaturesSendEmoji('[title="smile"]', '😄')
+  })
 
-    //Validate message can be edited
+  it('Chat - Send Emoji on chat', () => {
+    cy.chatFeaturesSendEmoji('[title="smile"]', '😄')
+  })
+
+  it('Chat - Edit message on chat', () => {
     cy.chatFeaturesEditMessage(randomMessage, randomNumber)
   })
 
   it('Chat - Verify when clicking on Send Money, coming soon appears', () => {
     //Hover over on Send Money and Coming Soon tooltip will appear when clicking on its button
-    cy.get('#chatbar-controls > span > .tooltip-container')
-      .realHover()
-      .should('have.attr', 'data-tooltip', 'Send Money\nComing Soon')
-    cy.get('body').realHover({ position: 'topLeft' })
+    cy.hoverOnActiveIcon(
+      '#chatbar-controls > span > .tooltip-container',
+      'Send Money\nComing Soon',
+    )
   })
 
   it('Chat - Verify when clicking on Emoji, the emoji picker appears', () => {

--- a/cypress/integration/chat-features.js
+++ b/cypress/integration/chat-features.js
@@ -34,7 +34,7 @@ describe('Chat Features Tests', () => {
 
   it('Chat - Verify when clicking on Send Money, coming soon appears', () => {
     //Hover over on Send Money and Coming Soon tooltip will appear when clicking on its button
-    cy.hoverOnActiveIcon(
+    cy.hoverOnComingSoonIcon(
       '#chatbar-controls > span > .tooltip-container',
       'Send Money\nComing Soon',
     )

--- a/cypress/integration/chat-top-toolbar.js
+++ b/cypress/integration/chat-top-toolbar.js
@@ -38,12 +38,9 @@ describe('Chat Features Tests', () => {
     )
   })
 
-  it('Chat - Toolbar - Marketplace icon shows Coming Soon', () => {
+  it('Chat - Toolbar - Marketplace icon is displayed', () => {
     cy.get('[data-cy=toolbar-marketplace]').should('be.visible')
-    cy.hoverOnComingSoonIcon(
-      '[data-cy=toolbar-marketplace] > .tooltip-container',
-      'Marketplace\nComing Soon',
-    )
+    cy.hoverOnComingSoonIcon('[data-cy=toolbar-marketplace]', 'Marketplace')
   })
 
   it('Chat - Toolbar - Wallet icon shows Coming Soon', () => {

--- a/cypress/integration/chat-top-toolbar.js
+++ b/cypress/integration/chat-top-toolbar.js
@@ -1,0 +1,65 @@
+const faker = require('faker')
+const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
+const recoverySeed =
+  'boring over tilt regret diamond rubber example there fire roof sheriff always{enter}'
+
+describe('Chat Features Tests', () => {
+  before(() => {
+    //Import account
+    cy.importAccount(randomPIN, recoverySeed)
+
+    //Validate profile name displayed
+    cy.chatFeaturesProfileName('sadad')
+
+    // Click on hamburger menu if width < height
+    cy.get('.toggle-sidebar').should('be.visible').click()
+
+    //Validate message is sent
+    cy.waitForMessagesToLoad()
+  })
+
+  it('Chat - Toolbar - Validate expected icons are displayed', () => {
+    cy.get('[data-cy=toolbar-alerts]').should('be.visible')
+    cy.get('[data-cy=toolbar-enable-audio]').should('be.visible')
+    cy.get('[data-cy=toolbar-enable-video]').should('be.visible')
+    cy.get('[data-cy=toolbar-archived-messages]').should('be.visible')
+    cy.get('[data-cy=toolbar-marketplace]').should('be.visible')
+    cy.get('[data-cy=toolbar-wallet]').should('be.visible')
+  })
+
+  it('Chat - Toolbar - Alerts icon shows Coming Soon', () => {
+    cy.hoverOnActiveIcon(
+      '[data-cy=toolbar-alerts] > .tooltip-container',
+      'Alerts\nComing Soon',
+    )
+  })
+
+  it('Chat - Toolbar - Call icon is disabled', () => {
+    cy.validateDisabledIcon('[data-cy=toolbar-enable-audio]')
+  })
+
+  it('Chat - Toolbar - Video icon is disabled', () => {
+    cy.validateDisabledIcon('[data-cy=toolbar-enable-video]')
+  })
+
+  it('Chat - Toolbar - Archived Messages icon shows Coming Soon', () => {
+    cy.hoverOnActiveIcon(
+      '[data-cy=toolbar-archived-messages] > .tooltip-container',
+      'Archived Messages\nComing Soon',
+    )
+  })
+
+  it('Chat - Toolbar - Marketplace icon shows Coming Soon', () => {
+    cy.hoverOnActiveIcon(
+      '[data-cy=toolbar-marketplace] > .tooltip-container',
+      'Marketplace\nComing Soon',
+    )
+  })
+
+  it('Chat - Toolbar - Wallet icon shows Coming Soon', () => {
+    cy.hoverOnActiveIcon(
+      '[data-cy=toolbar-wallet] > .tooltip-container',
+      'Wallet\nComing Soon',
+    )
+  })
+})

--- a/cypress/integration/chat-top-toolbar.js
+++ b/cypress/integration/chat-top-toolbar.js
@@ -8,56 +8,47 @@ describe('Chat Features Tests', () => {
     //Import account
     cy.importAccount(randomPIN, recoverySeed)
 
-    //Validate profile name displayed
-    cy.chatFeaturesProfileName('sadad')
-
-    // Click on hamburger menu if width < height
+    //Ensure messages are displayed before starting
+    cy.contains('sadad', { timeout: 180000 }).should('be.visible')
     cy.get('.toggle-sidebar').should('be.visible').click()
-
-    //Validate message is sent
     cy.waitForMessagesToLoad()
   })
 
-  it('Chat - Toolbar - Validate expected icons are displayed', () => {
-    cy.get('[data-cy=toolbar-alerts]').should('be.visible')
-    cy.get('[data-cy=toolbar-enable-audio]').should('be.visible')
-    cy.get('[data-cy=toolbar-enable-video]').should('be.visible')
-    cy.get('[data-cy=toolbar-archived-messages]').should('be.visible')
-    cy.get('[data-cy=toolbar-marketplace]').should('be.visible')
-    cy.get('[data-cy=toolbar-wallet]').should('be.visible')
+  it('Chat - Toolbar - Validate audio icon is displayed', () => {
+    cy.hoverOnActiveIcon('[data-cy=toolbar-enable-audio]')
+  })
+
+  it('Chat - Toolbar - Validate video icon is displayed', () => {
+    cy.hoverOnActiveIcon('[data-cy=toolbar-enable-video]')
   })
 
   it('Chat - Toolbar - Alerts icon shows Coming Soon', () => {
-    cy.hoverOnActiveIcon(
+    cy.get('[data-cy=toolbar-alerts]').should('be.visible')
+    cy.hoverOnComingSoonIcon(
       '[data-cy=toolbar-alerts] > .tooltip-container',
       'Alerts\nComing Soon',
     )
   })
 
-  it('Chat - Toolbar - Call icon is disabled', () => {
-    cy.validateDisabledIcon('[data-cy=toolbar-enable-audio]')
-  })
-
-  it('Chat - Toolbar - Video icon is disabled', () => {
-    cy.validateDisabledIcon('[data-cy=toolbar-enable-video]')
-  })
-
   it('Chat - Toolbar - Archived Messages icon shows Coming Soon', () => {
-    cy.hoverOnActiveIcon(
+    cy.get('[data-cy=toolbar-archived-messages]').should('be.visible')
+    cy.hoverOnComingSoonIcon(
       '[data-cy=toolbar-archived-messages] > .tooltip-container',
       'Archived Messages\nComing Soon',
     )
   })
 
   it('Chat - Toolbar - Marketplace icon shows Coming Soon', () => {
-    cy.hoverOnActiveIcon(
+    cy.get('[data-cy=toolbar-marketplace]').should('be.visible')
+    cy.hoverOnComingSoonIcon(
       '[data-cy=toolbar-marketplace] > .tooltip-container',
       'Marketplace\nComing Soon',
     )
   })
 
   it('Chat - Toolbar - Wallet icon shows Coming Soon', () => {
-    cy.hoverOnActiveIcon(
+    cy.get('[data-cy=toolbar-wallet]').should('be.visible')
+    cy.hoverOnComingSoonIcon(
       '[data-cy=toolbar-wallet] > .tooltip-container',
       'Wallet\nComing Soon',
     )

--- a/cypress/integration/snapshots-test.js
+++ b/cypress/integration/snapshots-test.js
@@ -5,7 +5,7 @@ const recoverySeed =
 const randomName = faker.internet.userName(name) // generate random name
 const randomStatus = faker.lorem.word() // generate random status
 
-describe('Snapshots Testing', () => {
+describe.skip('Snapshots Testing', () => {
   //Import account and snapshot on each screen
   Cypress.on('uncaught:exception', (err, runnable) => false) // temporary until AP-48 gets fixed
   it('Import account - PIN screen', () => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -307,16 +307,17 @@ Cypress.Commands.add('waitForMessagesToLoad', () => {
     .should('be.visible')
 })
 
-Cypress.Commands.add('hoverOnActiveIcon', (locator, expectedMessage) => {
+Cypress.Commands.add('hoverOnComingSoonIcon', (locator, expectedMessage) => {
   cy.get(locator)
     .realHover()
     .should('have.attr', 'data-tooltip', expectedMessage)
+  cy.wait(1000)
   cy.get('body').realHover({ position: 'topLeft' })
 })
 
-Cypress.Commands.add('validateDisabledIcon', (locator) => {
-  cy.get(locator).should('have.class', 'disabled')
-  cy.get(locator).realHover()
+Cypress.Commands.add('hoverOnActiveIcon', (locator) => {
+  cy.get(locator).should('be.visible').realHover()
+  cy.wait(1000)
   cy.get('body').realHover({ position: 'topLeft' })
 })
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -307,6 +307,19 @@ Cypress.Commands.add('waitForMessagesToLoad', () => {
     .should('be.visible')
 })
 
+Cypress.Commands.add('hoverOnActiveIcon', (locator, expectedMessage) => {
+  cy.get(locator)
+    .realHover()
+    .should('have.attr', 'data-tooltip', expectedMessage)
+  cy.get('body').realHover({ position: 'topLeft' })
+})
+
+Cypress.Commands.add('validateDisabledIcon', (locator) => {
+  cy.get(locator).should('have.class', 'disabled')
+  cy.get(locator).realHover()
+  cy.get('body').realHover({ position: 'topLeft' })
+})
+
 //Version Release Notes Commands
 
 Cypress.Commands.add('releaseNotesScreenValidation', () => {


### PR DESCRIPTION
**What this PR does** 📖
- Add cypress tests for chat toolbar icons active and with coming soon status
- Add cypress commands to validate hovering on icons
- Implemented the new command in one existing cypress test for Send Money icon on chat-features.js
- Placed send message, send emoji and edit message validations in different test blocks instead of having the 3 validations in the same it block
- Added data-cy attributes to elements on components/views/navigation/toolbar/Toolbar.html

**Which issue(s) this PR fixes** 🔨
AP-631 and AP-1031

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
Cypress Video for chat-top-toolbar.js:
https://user-images.githubusercontent.com/35935591/158925875-413c79c9-b0eb-4a73-b383-d96f08959b25.mp4

Cypress Video for chat-features.js:
https://user-images.githubusercontent.com/35935591/158925910-5b453763-b554-479d-9ae4-b1129dac0eed.mp4