### PR TITLE
feat(importAccount): typeahead support using searchindex

### DIFF
--- a/components/ui/TypeAhead/TypeAhead.html
+++ b/components/ui/TypeAhead/TypeAhead.html
@@ -1,5 +1,5 @@
 <div
-  class="typehead-container"
+  class="typeahead-container"
   data-cy="add-passphrase"
   v-click-outside="lostFocus"
 >
@@ -14,12 +14,14 @@
     v-on:keydown.up="onUpBrowseItem"
     v-on:keydown.down="onDownBrowseItem"
   />
-  <div v-if="isFocus && searchList.length" class="search-options">
+  <div v-if="isFocus && searchResults.length" class="search-options">
     <ul class="search-option-group">
       <li
-        v-for="(item, i) in searchList"
+        v-for="(item, i) in searchResults"
         :class="{'active': i === browseIndex}"
-        @click="onItemClicked(item)"
+        @click="onItemClicked(item, i)"
+        @mousemove="onItemHighlighted(i)"
+        @focus="onItemHighlighted(i)"
       >
         {{ label ? item[label] : item}}
       </li>

--- a/components/ui/TypeAhead/TypeAhead.less
+++ b/components/ui/TypeAhead/TypeAhead.less
@@ -1,4 +1,4 @@
-.typehead-container {
+.typeahead-container {
   position: relative;
   .search-options {
     position: absolute;
@@ -17,7 +17,10 @@
         font-size: 16px;
         padding: 5px 10px;
         text-align: center;
-        &:hover,
+        &:not(.active) {
+          background: transparent !important;
+          box-shadow: none !important;
+        }
         &.active {
           &:extend(.background-primary);
           &:extend(.glow-primary);

--- a/pages/setup/ImportAccount/ImportAccount.html
+++ b/pages/setup/ImportAccount/ImportAccount.html
@@ -2,7 +2,7 @@
   <div class="input-account-body">
     <TypographyTitle :size="4" :text="$t('pages.inputAccount.title')" />
     <TypographySubtitle :size="6" :text="$t('pages.inputAccount.subtitle')" />
-    <UiTypeHead
+    <UiTypeAhead
       :list="bipList"
       size="small"
       type="primary"


### PR DESCRIPTION
**What this PR does** 📖
Implements a typeahead filter on the import account page

**Which issue(s) this PR fixes** 🔨
AP-322

**Special notes for reviewers** 🗒️
Made some changes to the active item logic:
- Only one item can be active, mouse and keyboard will now take focus from one another
- Pressing enter immediately after typing will now select the first match in the list

**Additional comments** 🎤
extends #2179 