### PR TITLE
chore(update): update swiper due to security alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "simple-markdown": "^0.7.3",
     "simple-peer": "^9.11.1",
     "skaler": "^1.0.7",
-    "swiper": "^8.0.7",
+    "swiper": "6.5.1",
     "uuid": "^8.3.2",
     "v-calendar": "^2.4.1",
     "v-click-outside": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "simple-markdown": "^0.7.3",
     "simple-peer": "^9.11.1",
     "skaler": "^1.0.7",
-    "swiper": "6.5.1",
+    "swiper": "^8.0.7",
     "uuid": "^8.3.2",
     "v-calendar": "^2.4.1",
     "v-click-outside": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "simple-markdown": "^0.7.3",
     "simple-peer": "^9.11.1",
     "skaler": "^1.0.7",
-    "swiper": "5.x",
+    "swiper": "6.5.1",
     "uuid": "^8.3.2",
     "v-calendar": "^2.4.1",
     "v-click-outside": "^3.1.2",

--- a/plugins/thirdparty/swiper.ts
+++ b/plugins/thirdparty/swiper.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import { Swiper, SwiperSlide } from 'vue-awesome-swiper'
-import 'swiper/css/swiper.css'
+import 'swiper/swiper-bundle.min.css'
 
 Vue.component('Swiper', Swiper)
 Vue.component('SwiperSlide', SwiperSlide)


### PR DESCRIPTION
**What this PR does** 📖


Updates swiper lib to the latest version due to

<img width="991" alt="Captura de ecrã 2022-03-20, às 19 47 52" src="https://user-images.githubusercontent.com/29093946/159180095-7e83fb82-8a38-40e9-a3eb-be041a269617.png">

was also needed to update the imports due to this error when building

![image](https://user-images.githubusercontent.com/29093946/159379015-dc9bd4c0-1422-4e11-82bd-149aa9faa7ae.png)

now is fixed

![image](https://user-images.githubusercontent.com/29093946/159379028-bc0ab06f-3cfb-438a-874e-d8e12f1f59fe.png)

