### PR TITLE
feat(privacy): re-work how signaling servers are stored in config.ts, and allow the user to change their settings.

### DIFF
--- a/components/views/settings/pages/privacy/Privacy.html
+++ b/components/views/settings/pages/privacy/Privacy.html
@@ -38,10 +38,19 @@
     <SettingsUnit
       :title="$t('pages.privacy.serverType.title')"
       :text="$t('pages.privacy.serverType.subtitle')"
+      :breakLine="false"
     >
+      <TypographyText
+        class="color-danger"
+        type="danger"
+        :size="6"
+        :text="$t('pages.privacy.serverType.warning')"
+      />
+      <br />
       <InteractablesSelect
         :options="serverTypes"
         v-model="serverType"
+        @change="onServerTypeChanged"
         size="small"
         class="form-control"
       />

--- a/components/views/settings/pages/privacy/index.vue
+++ b/components/views/settings/pages/privacy/index.vue
@@ -85,6 +85,11 @@ export default Vue.extend({
       },
     },
   },
+  methods: {
+    onServerTypeChanged() {
+      location.reload()
+    },
+  },
 })
 </script>
 

--- a/components/views/settings/unit/Unit.html
+++ b/components/views/settings/unit/Unit.html
@@ -1,6 +1,6 @@
 <div class="column unit">
   <TypographyTitle v-if="title.length" :size="6" :text="title" />
   <TypographyText v-if="text.length" :text="text" />
-  <br v-if="text.length" />
+  <br v-if="text.length && breakLine" />
   <slot></slot>
 </div>

--- a/components/views/settings/unit/Unit.vue
+++ b/components/views/settings/unit/Unit.vue
@@ -11,6 +11,10 @@ export default Vue.extend({
       type: String,
       default: '',
     },
+    breakLine: {
+      type: Boolean,
+      default: true,
+    },
   },
 })
 </script>

--- a/config.ts
+++ b/config.ts
@@ -33,17 +33,19 @@ export const Config = {
     user_lifespan: 90000,
   },
   webtorrent: {
-    announceURLs: process.env.NUXT_ENV_DEVELOPMENT_TRACKER
-      ? [process.env.NUXT_ENV_DEVELOPMENT_TRACKER] // DEVELOPMENT, yarn dev:tracker to start
-      : [
-          'wss://tracker.openwebtorrent.com',
-          'wss://tracker.sloppyta.co:443/announce',
-          'wss://tracker.novage.com.ua:443/announce',
-          'udp://opentracker.i2p.rocks:6969/announce',
-          'http://opentracker.i2p.rocks:6969/announce',
-          'udp://tracker.opentrackr.org:1337/announce',
-          'http://tracker.opentrackr.org:1337/announce',
-        ],
+    trackerURLS: process.env.NUXT_ENV_DEVELOPMENT_TRACKER // DEVELOPMENT, yarn dev:tracker to start
+      ? [process.env.NUXT_ENV_DEVELOPMENT_TRACKER]
+      : null,
+    publicURLs: [
+      'wss://tracker.openwebtorrent.com',
+      'wss://tracker.sloppyta.co:443/announce',
+      'wss://tracker.novage.com.ua:443/announce',
+      'udp://opentracker.i2p.rocks:6969/announce',
+      'http://opentracker.i2p.rocks:6969/announce',
+      'udp://tracker.opentrackr.org:1337/announce',
+      'http://tracker.opentrackr.org:1337/announce',
+    ],
+    satelliteURLS: ['ws://signal.satellite.one'],
   },
   solana: {
     customFaucet: 'https://faucet.satellite.one',

--- a/libraries/WebRTC/WebRTC.ts
+++ b/libraries/WebRTC/WebRTC.ts
@@ -19,7 +19,7 @@ export default class WebRTC extends Emitter<WebRTCEventListeners> {
   //
   // List of functions to execute after init
   protected _fnQueue: Array<Function>
-  protected _announceURLs: Array<string> = Config.webtorrent.publicURLs
+  protected _announceURLs: Array<string> = Config.webtorrent.trackerURLS || []
 
   constructor() {
     super()
@@ -83,8 +83,17 @@ export default class WebRTC extends Emitter<WebRTCEventListeners> {
    * @param announceURLs list of announce urls
    * @example
    */
-  setAnnounceURLs(announceURLs: Array<string>) {
-    this._announceURLs = announceURLs
+  setAnnounceURLs(option: string) {
+    /* only set urls when NUXT_ENV_DEVELOPMENT_TRACKER does not exist */
+    if (!Config.webtorrent.trackerURLS) {
+      this._announceURLs =
+        option === 'public'
+          ? Config.webtorrent.publicURLs
+          : [
+              ...Config.webtorrent.satelliteURLS,
+              ...Config.webtorrent.publicURLs,
+            ]
+    }
   }
 
   /**

--- a/libraries/WebRTC/WebRTC.ts
+++ b/libraries/WebRTC/WebRTC.ts
@@ -19,7 +19,7 @@ export default class WebRTC extends Emitter<WebRTCEventListeners> {
   //
   // List of functions to execute after init
   protected _fnQueue: Array<Function>
-  protected _announceURLs: Array<string> = Config.webtorrent.announceURLs
+  protected _announceURLs: Array<string> = Config.webtorrent.publicURLs
 
   constructor() {
     super()

--- a/libraries/WebRTC/WebRTC.ts
+++ b/libraries/WebRTC/WebRTC.ts
@@ -93,6 +93,7 @@ export default class WebRTC extends Emitter<WebRTCEventListeners> {
               ...Config.webtorrent.satelliteURLS,
               ...Config.webtorrent.publicURLs,
             ]
+      Vue.prototype.$Logger.log('Signaling URLS', this._announceURLs)
     }
   }
 

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -201,6 +201,7 @@ export default {
         title: 'Signaling Servers',
         subtitle:
           "Choose which signaling server group you want to use. If you use 'Satellite + Public Signaling Servers', you are using public servers and Satellite hosted servers to connect with your friends. We do not track connections. We only track server utilization (memory and cpu usage) to know if we need to turn on more signaling servers. If you opt to use 'Only Public Signaling Servers', those are totally outside of Satellite control, so we can not see or have any insight into their operation, logging, or data sharing practices, and you may experience difficulties connecting with friends if the signaling servers are overloaded.",
+        warning: 'Changing this value will reload the application.',
       },
       ownInfo: {
         title: 'Set my own Signaling Server',

--- a/pages/setup/privacy/Privacy.html
+++ b/pages/setup/privacy/Privacy.html
@@ -9,7 +9,6 @@
             <InteractablesButton
               class="right"
               type="primary"
-              :disabled="isDisabled()"
               :action="generateWallet"
             >
               {{ $t('pages.privacy.continue') }}

--- a/pages/setup/privacy/index.vue
+++ b/pages/setup/privacy/index.vue
@@ -15,9 +15,6 @@ export default Vue.extend({
       await this.$store.dispatch('accounts/generateWallet')
       this.$router.push('phrase')
     },
-    isDisabled() {
-      return !this.settings.ownInfo && this.settings.serverType === 'own'
-    },
   },
 })
 </script>

--- a/store/settings/state.ts
+++ b/store/settings/state.ts
@@ -16,7 +16,7 @@ const InitialSettingsState = (): SettingsState => ({
   embeddedLinks: true,
   displayCurrentActivity: true,
   removeState: false,
-  serverType: 'satellite',
+  serverType: 'public',
   ownInfo: '',
 })
 

--- a/store/webrtc/actions.ts
+++ b/store/webrtc/actions.ts
@@ -20,12 +20,12 @@ const webRTCActions = {
    * this.$store.dispatch('webrtc/initialize')
    */
   async initialize(
-    { commit }: ActionsArguments<WebRTCState>,
+    { commit, rootState }: ActionsArguments<WebRTCState>,
     originator: string,
   ) {
     const $WebRTC: WebRTC = Vue.prototype.$WebRTC
     const $Logger: Logger = Vue.prototype.$Logger
-
+    $WebRTC.setAnnounceURLs(rootState.settings.serverType)
     $WebRTC.init(originator)
     $WebRTC.on('PEER_CONNECT', async ({ peerId }) => {
       $Logger.log('WebRTC', 'PEER_CONNECT', { peerId })

--- a/types/store/store.ts
+++ b/types/store/store.ts
@@ -7,6 +7,7 @@ import { TextileState } from '~/store/textile/types'
 import { UIState } from '~/store/ui/types'
 import { WebRTCState } from '~/store/webrtc/types'
 import { GroupsState } from '~/store/groups/types'
+import { SettingsState } from '~/store/settings/types'
 
 export interface RootState {
   accounts: AccountsState
@@ -16,6 +17,7 @@ export interface RootState {
   webrtc: WebRTCState
   groups: GroupsState
   ui: UIState
+  settings: SettingsState
 }
 
 export type RootStore = Store<RootState>


### PR DESCRIPTION
**What this PR does** 📖
re-work how signaling servers are stored in config.ts, and allow the user to change their settings.

**Which issue(s) this PR fixes** 🔨

AP-1074

**Special notes for reviewers** 🗒️
- See console log for checking signaling urls
