### PR TITLE
feat(chat): copy image

### DIFF
--- a/components/views/chat/message/Message.vue
+++ b/components/views/chat/message/Message.vue
@@ -174,13 +174,13 @@ export default Vue.extend({
       const blob = await data.blob()
       const type = filetypemime(
         new Uint8Array(await blob.slice(0, 256).arrayBuffer()),
-      )
+      )[0]
 
       // copy to clipboard if png, otherwise convert
       try {
         await this.$envinfo.navigator.clipboard.write([
           new ClipboardItem({
-            'image/png': type[0] === 'image/png' ? blob : this.toPng(blob),
+            'image/png': type === 'image/png' ? blob : this.toPng(blob),
           }),
         ])
       } catch (e: any) {

--- a/components/views/chat/message/Message.vue
+++ b/components/views/chat/message/Message.vue
@@ -177,17 +177,11 @@ export default Vue.extend({
       )[0]
 
       // copy to clipboard if png, otherwise convert
-      try {
-        await this.$envinfo.navigator.clipboard.write([
-          new ClipboardItem({
-            'image/png': type === 'image/png' ? blob : this.toPng(blob),
-          }),
-        ])
-      } catch (e: any) {
-        this.$Logger.log('Error', e)
-        this.$toast.show(this.$t('errors.chat.unsupported_type') as string)
-        return
-      }
+      await this.$envinfo.navigator.clipboard.write([
+        new ClipboardItem({
+          'image/png': type === 'image/png' ? blob : this.toPng(blob),
+        }),
+      ])
       this.$toast.show(this.$t('ui.copied') as string)
     },
     /**

--- a/components/views/files/upload/Upload.vue
+++ b/components/views/files/upload/Upload.vue
@@ -126,14 +126,14 @@ export default Vue.extend({
             /* convert .heic file to jpeg so that we can convert it for html5 style */
             const oBuffer = await converter({
               buffer, // the HEIC file buffer
-              format: 'JPEG', // output format
+              format: 'PNG', // output format
               quality: 1,
             })
             newFiles[i] = new File(
               [oBuffer.buffer],
-              `${newFiles[i].name.split('.')[0] || 'newImage'}.jpeg`,
+              `${newFiles[i].name.split('.')[0] || 'newImage'}.png`,
               {
-                type: 'image/jpeg',
+                type: 'image/png',
               },
             )
           }

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -527,6 +527,7 @@ export default {
       contains_nsfw: 'Unable to upload file/s due to NSFW status',
       empty_message_error:
         'Message must contain at least one non-space character',
+      unsupported_type: 'This image format cannot be copied',
     },
     textile: {
       friend_not_found: 'Friend not found',

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -527,7 +527,6 @@ export default {
       contains_nsfw: 'Unable to upload file/s due to NSFW status',
       empty_message_error:
         'Message must contain at least one non-space character',
-      unsupported_type: 'This image format cannot be copied',
     },
     textile: {
       friend_not_found: 'Friend not found',


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- copy image via clipboard API which only accepts png
- if png, copy. if other embeddable image format, convert to png with canvas
- change heic conversion in chat to png rather than jpeg. this skips a conversion step on copy

**Which issue(s) this PR fixes** 🔨
AP-1080
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
