### PR TITLE
fix(chat): check magic number to determine embed type

### DIFF
--- a/components/ui/Chat/Embeds/AudioPlayer/AudioPlayer.less
+++ b/components/ui/Chat/Embeds/AudioPlayer/AudioPlayer.less
@@ -25,9 +25,3 @@
     max-width: @full;
   }
 }
-
-@media only screen and (max-width: @mobile-candybar-breakpoint) {
-  .download {
-    display: none;
-  }
-}

--- a/components/ui/Chat/Embeds/File/File.html
+++ b/components/ui/Chat/Embeds/File/File.html
@@ -1,21 +1,18 @@
-<div :class="file.type.includes('image') ? 'embedded-image' : 'embedded-file'">
-  <file-icon size="1x" class="file-icon" v-if="!file.type.includes('image')" />
-  <UiChatImage
-    v-if="file.type.includes('image')"
-    :image="file"
-    :alt="file.name"
-  />
-  <div class="file-info" v-if="!file.type.includes('image')">
-    <TypographySubtitle :size="6" :text="`${file.name}`" />
-    <TypographyText :text="`${file.type} - ${getFileSize}`" />
-  </div>
-  <a
-    :href="file.url"
-    target="_blank"
-    class="button is-primary"
-    data-cy="chat-file"
-    v-if="!file.type.includes('image')"
-  >
-    <download-icon size="1x" class="download control-icon" />
-  </a>
+<div :class="embeddable ? 'embedded-image' : 'embedded-file'">
+  <UiChatImage v-if="embeddable" :image="file" :alt="file.name" />
+  <template v-else>
+    <file-icon size="1x" class="file-icon" />
+    <div class="file-info">
+      <TypographySubtitle :size="6" :text="`${file.name}`" />
+      <TypographyText :text="`${file.type} - ${getFileSize}`" />
+    </div>
+    <a
+      :href="file.url"
+      target="_blank"
+      class="button is-primary"
+      data-cy="chat-file"
+    >
+      <download-icon size="1x" class="download" />
+    </a>
+  </template>
 </div>

--- a/components/ui/Chat/Embeds/File/File.less
+++ b/components/ui/Chat/Embeds/File/File.less
@@ -4,54 +4,55 @@
   &:extend(.round-corners);
   &:extend(.more-pad-sides);
   &:extend(.inline-flex-justify-center);
-  .image-file {
-    max-width: 80%;
-  }
+  align-items: center;
+  gap: @normal-spacing;
+  margin: @light-spacing 0;
+
   .file-icon {
+    margin: 0;
     font-size: @xl-icon-size;
-    align-self: center;
   }
-  .download {
+
+  .file-info {
+    align-items: flex-start;
+    display: flex;
+    flex-direction: column;
+    .subtitle {
+      &:extend(.font-secondary);
+      margin: 0;
+      font-weight: bold;
+      font-size: @text-size;
+    }
+    .is-text {
+      &:extend(.font-muted);
+      margin: 0;
+      font-family: @primary-font;
+      font-size: @mini-text-size;
+      line-height: 0.9;
+    }
+  }
+  .button {
     &:hover {
       &:extend(.font-secondary);
     }
-    &:extend(.file-icon);
-    align-self: center;
-    cursor: pointer;
   }
-  .subtitle {
-    &:extend(.font-secondary);
-    margin: 0;
-    font-weight: bold;
-    font-size: @text-size;
-  }
-  .file-info {
-    margin-right: @normal-spacing;
-    margin-left: @light-spacing;
-    align-self: center;
-  }
-  .is-text {
-    &:extend(.font-muted);
-    margin: 0;
-    font-family: @primary-font;
-    white-space: nowrap;
-    font-size: @mini-text-size;
-    line-height: 0.9;
-    margin-bottom: 0.4rem;
-  }
-  margin: @normal-spacing 0;
-  flex-direction: row;
 }
 
-.embedded-image {
-  width: fit-content;
-  img {
-    border-radius: @corner-rounding;
+@media only screen and (max-width: @mobile-small-breakpoint) {
+  .embedded-file {
+    width: @full;
+    .button {
+      margin-left: auto;
+    }
   }
 }
 
 @media only screen and (max-width: @mobile-candybar-breakpoint) {
-  .download {
-    display: none;
+  .embedded-file {
+    padding: @light-spacing;
+    justify-content: space-between;
+    .file-icon {
+      display: none;
+    }
   }
 }

--- a/components/ui/Chat/Embeds/File/File.vue
+++ b/components/ui/Chat/Embeds/File/File.vue
@@ -1,9 +1,9 @@
-<template src="./File.html" />
+<template src="./File.html"></template>
 <script lang="ts">
 import Vue, { PropType } from 'vue'
 import { DownloadIcon, FileIcon } from 'satellite-lucide-icons'
-import { TextileImage } from '~/types/textile/manager'
-import { FileMessage } from '~/types/textile/mailbox'
+import { isEmbeddableImage } from '~/utilities/FileType'
+import { FileMessagePayload } from '~/types/files/file'
 
 export default Vue.extend({
   components: {
@@ -12,13 +12,26 @@ export default Vue.extend({
   },
   props: {
     file: {
-      type: Object as PropType<FileMessage>,
+      type: Object as PropType<FileMessagePayload>,
       required: true,
     },
   },
+  data() {
+    return { embeddable: false as boolean }
+  },
   computed: {
-    getFileSize() {
+    getFileSize(): string {
       return this.$filesize(this.file.size)
+    },
+  },
+  async mounted() {
+    this.embeddable = await this.isEmbeddable()
+  },
+  methods: {
+    async isEmbeddable() {
+      const data = await fetch(this.file.url)
+      const blob = await data.blob()
+      return isEmbeddableImage(blob)
     },
   },
 })

--- a/components/views/chat/message/Message.html
+++ b/components/views/chat/message/Message.html
@@ -46,13 +46,8 @@
         ({{$t('ui.edited')}})
       </span>
     </template>
-    <UiChatImage
-      v-if="message.type === 'image'"
-      :image="message.payload"
-      alt=""
-    />
     <MessageGlyph
-      v-else-if="message.type === 'glyph'"
+      v-if="message.type === 'glyph'"
       :source="message.payload"
       :pack="message.pack"
     />

--- a/components/views/files/file/File.vue
+++ b/components/views/files/file/File.vue
@@ -14,19 +14,7 @@ import ContextMenu from '~/components/mixins/UI/ContextMenu'
 import { Item } from '~/libraries/Files/abstracts/Item.abstract'
 import { Directory } from '~/libraries/Files/Directory'
 import { Fil } from '~/libraries/Files/Fil'
-import { ModalWindows } from '~/store/ui/types'
-
-declare module 'vue/types/vue' {
-  interface Vue {
-    like: () => void
-    share: () => void
-    rename: () => void
-    remove: () => void
-    $filesize: (item: number) => string
-    linkHover: boolean
-    heartHover: boolean
-  }
-}
+import { ContextMenuItem, ModalWindows } from '~/store/ui/types'
 
 export default Vue.extend({
   components: {
@@ -77,22 +65,22 @@ export default Vue.extend({
     isArchive(): boolean {
       return Boolean(this.item.name.match(this.$Config.regex.archive))
     },
-    contextMenuValues() {
+    contextMenuValues(): ContextMenuItem[] {
       return [
         {
           text: this.item.liked
-            ? this.$t('context.unfav')
-            : this.$t('context.fav'),
+            ? (this.$t('context.unfav') as string)
+            : (this.$t('context.fav') as string),
           func: this.like,
         },
         {
           text: this.item.shared
-            ? this.$t('context.unshare')
-            : this.$t('context.share'),
+            ? (this.$t('context.unshare') as string)
+            : (this.$t('context.share') as string),
           func: this.share,
         },
-        { text: this.$t('context.rename'), func: this.rename },
-        { text: this.$t('context.delete'), func: this.remove },
+        { text: this.$t('context.rename') as string, func: this.rename },
+        { text: this.$t('context.delete') as string, func: this.remove },
       ]
     },
   },

--- a/components/views/files/file/File.vue
+++ b/components/views/files/file/File.vue
@@ -15,6 +15,7 @@ import { Item } from '~/libraries/Files/abstracts/Item.abstract'
 import { Directory } from '~/libraries/Files/Directory'
 import { Fil } from '~/libraries/Files/Fil'
 import { ContextMenuItem, ModalWindows } from '~/store/ui/types'
+import { isMimeArchive } from '~/utilities/FileType'
 
 export default Vue.extend({
   components: {
@@ -63,7 +64,7 @@ export default Vue.extend({
      * @returns {boolean} if item is archive file type
      */
     isArchive(): boolean {
-      return Boolean(this.item.name.match(this.$Config.regex.archive))
+      return isMimeArchive(this.item.type)
     },
     contextMenuValues(): ContextMenuItem[] {
       return [

--- a/components/views/files/row/Row.vue
+++ b/components/views/files/row/Row.vue
@@ -13,7 +13,8 @@ import {
 } from 'satellite-lucide-icons'
 import ContextMenu from '~/components/mixins/UI/ContextMenu'
 import { Item } from '~/libraries/Files/abstracts/Item.abstract'
-import { ModalWindows } from '~/store/ui/types'
+import { ContextMenuItem, ModalWindows } from '~/store/ui/types'
+import { isMimeArchive } from '~/utilities/FileType'
 
 export default Vue.extend({
   components: {
@@ -46,24 +47,24 @@ export default Vue.extend({
      * @returns {boolean} if item is archive file type
      */
     isArchive(): boolean {
-      return Boolean(this.item.name.match(this.$Config.regex.archive))
+      return isMimeArchive(this.item.type)
     },
-    contextMenuValues() {
+    contextMenuValues(): ContextMenuItem[] {
       return [
         {
           text: this.item.liked
-            ? this.$t('context.unfav')
-            : this.$t('context.fav'),
+            ? (this.$t('context.unfav') as string)
+            : (this.$t('context.fav') as string),
           func: this.like,
         },
         {
           text: this.item.shared
-            ? this.$t('context.unshare')
-            : this.$t('context.share'),
+            ? (this.$t('context.unshare') as string)
+            : (this.$t('context.share') as string),
           func: this.share,
         },
-        { text: this.$t('context.rename'), func: this.rename },
-        { text: this.$t('context.delete'), func: this.remove },
+        { text: this.$t('context.rename') as string, func: this.rename },
+        { text: this.$t('context.delete') as string, func: this.remove },
       ]
     },
   },

--- a/components/views/files/view/View.vue
+++ b/components/views/files/view/View.vue
@@ -37,8 +37,6 @@ export default Vue.extend({
   computed: {
     ...mapState(['ui']),
   },
-  /**
-   */
   async mounted() {
     this.load = true
     // if no file data available, pull encrypted file from textile bucket

--- a/config.ts
+++ b/config.ts
@@ -113,8 +113,6 @@ export const Config = {
   regex: {
     // identify if a file type is embeddable image
     image: '^.*.(apng|avif|gif|jpg|jpeg|jfif|pjpeg|pjp|png|svg|webp)$',
-    // determine if filetype is archive
-    archive: '^.*.(zip|vnd.rar|x-7z-compressed)$',
     // check for empty string or spaces/nbsp
     empty: /^\s*$/,
     // Regex to check if string contains only emoji's.

--- a/types/files/file.ts
+++ b/types/files/file.ts
@@ -24,3 +24,10 @@ export type UploadDropItemType = {
     status: boolean
   }
 }
+
+export interface FileMessagePayload {
+  name: string
+  size: number
+  type: string
+  url: string
+}

--- a/utilities/FileType.ts
+++ b/utilities/FileType.ts
@@ -1,0 +1,45 @@
+import { filetypemime } from 'magic-bytes.js'
+
+/**
+ * @function mimeType
+ * @description checks mime type with magic number https://en.wikipedia.org/wiki/List_of_file_signatures
+ * @param {Blob} file
+ * @returns {Promise<string>} mime type
+ * @example test.png => 'image/png'
+ */
+export async function mimeType(file: Blob): Promise<string> {
+  const buffer = new Uint8Array(await file.slice(0, 256).arrayBuffer())
+
+  // svg byte check returns xml, so we need to manually check
+  const decodedFile = new TextDecoder().decode(buffer)
+  if (decodedFile.includes('xmlns="http://www.w3.org/2000/svg"')) {
+    return 'image/svg+xml'
+  }
+  return filetypemime(buffer as any)[0]
+}
+
+/**
+ * @function isEmbeddableImage
+ * @description is file embeddable <img />
+ * @param {Blob} file
+ * @returns {Promise<boolean>}
+ * @example test.png => true, test.txt => false
+ */
+export async function isEmbeddableImage(file: Blob): Promise<boolean> {
+  const buffer = new Uint8Array(await file.slice(0, 256).arrayBuffer())
+  // svg byte check returns xml, so we need to manually check
+  const decodedFile = new TextDecoder().decode(buffer)
+  if (decodedFile.includes('xmlns="http://www.w3.org/2000/svg"')) {
+    return true
+  }
+
+  const valid = [
+    'image/apng',
+    'image/avif',
+    'image/gif',
+    'image/jpeg',
+    'image/png',
+    'image/webp',
+  ]
+  return valid.includes(filetypemime(buffer as any)[0])
+}

--- a/utilities/FileType.ts
+++ b/utilities/FileType.ts
@@ -43,3 +43,19 @@ export async function isEmbeddableImage(file: Blob): Promise<boolean> {
   ]
   return valid.includes(filetypemime(buffer as any)[0])
 }
+
+/**
+ * @function isArchive
+ * @description is file an archive
+ * @param {string} type mime type
+ * @returns {boolean}
+ * @example test.zip => true, test.txt => false
+ */
+export function isMimeArchive(type: string): boolean {
+  const valid = [
+    'application/zip',
+    'application/x-7z-compressed',
+    'application/vnd.rar',
+  ]
+  return valid.includes(type)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- create utility function to determine mime type via magic numbers
- fix tiff embed issue
- adjust mobile styles for file embed
- remove unused conditional render. all image messages are type 'file'
- minor unrelated issue of archive file checking. wanted to place utility function in this new file

**Which issue(s) this PR fixes** 🔨
AP-1181, AP-1155
<!--AP-X-->

**Special notes for reviewers** 🗒️
- Going to refactor this after nsfw goes through. Right now it's byte checking on the receiving end. I want to byte check on the upload end instead

<img width="224" alt="image" src="https://user-images.githubusercontent.com/33670767/160563618-183c2a4a-3d15-4580-a74b-6bb0f9cf78eb.png">


**Additional comments** 🎤
