### PR TITLE
fix(toolbarTitle): shows the group name as toolbar title

### DIFF
--- a/components/views/navigation/toolbar/Toolbar.html
+++ b/components/views/navigation/toolbar/Toolbar.html
@@ -2,8 +2,16 @@
   <div class="circle-container">
     <UiUserState
       :user="user"
-      v-if="!server || $device.isMobile"
+      v-if="user.state && (!server || $device.isMobile)"
       :clickHandler="openProfile"
+    />
+    <UiCircle
+      :type="src ? 'image' : 'random'"
+      :seed="user.id"
+      :size="35"
+      :source="src"
+      @click="openProfile"
+      v-if="!user.state && !$device.isMobile"
     />
     <UiCircle
       :type="src ? 'image' : 'random'"
@@ -11,7 +19,7 @@
       :size="35"
       :source="src"
       @click="openProfile"
-      v-if="!$device.isMobile"
+      v-if="server && !$device.isMobile"
     />
   </div>
   <div class="user-info">
@@ -19,7 +27,9 @@
     <TypographySubtitle
       v-if="!$device.isMobile"
       :size="6"
-      :text="server ? (server.status || server.state) : user.status"
+      :text="server ? (server.status || server.state) 
+          : user.state ? user.state
+          : `${user.members} ${$tc('groups.member', user.members)}`"
     />
   </div>
   <div class="controls">

--- a/components/views/navigation/toolbar/Toolbar.vue
+++ b/components/views/navigation/toolbar/Toolbar.vue
@@ -20,6 +20,7 @@ import { searchRecommend } from '~/mock/search'
 import { SearchQueryItem } from '~/types/search/search'
 import { ModalWindows } from '~/store/ui/types'
 import { TrackKind } from '~/libraries/WebRTC/types'
+import { Group } from '~/types/messaging'
 
 declare module 'vue/types/vue' {
   interface Vue {
@@ -44,7 +45,11 @@ export default Vue.extend({
     },
     server: {
       type: Object as PropType<Server>,
-      default: () => {},
+      default: () => ({
+        name: '',
+        address: '',
+        desc: '',
+      }),
     },
     user: {
       type: Object as PropType<User>,
@@ -53,7 +58,6 @@ export default Vue.extend({
         address: '',
         status: '',
       }),
-      required: true,
     },
   },
   data() {

--- a/layouts/chat.vue
+++ b/layouts/chat.vue
@@ -44,7 +44,7 @@
             <Toolbar
               v-if="recipient"
               id="toolbar"
-              :server="recipient"
+              :server="null"
               :user="recipient"
             />
             <Media
@@ -160,7 +160,9 @@ export default Vue.extend({
       const groupId = this.$route.params.id
 
       const recipient = groupId
-        ? { textilePubkey: groupId }
+        ? this.$typedStore.state.groups.all.find(
+            (group) => group.id === groupId,
+          )
         : isMe
         ? null
         : this.$typedStore.state.friends.all.find(

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -476,6 +476,9 @@ export default {
       new_group_name: 'Add a group name here...',
     },
   },
+  groups: {
+    member: 'member | members',
+  },
   servers: {
     new_server: 'New Community',
     create: {


### PR DESCRIPTION
**What this PR does** 📖
A group chat should show the group name as title
![image](https://user-images.githubusercontent.com/81814644/160612880-907f1c01-9226-47d4-8627-eeafd3452428.png)

**Which issue(s) this PR fixes** 🔨
AP-734

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
