### PR TITLE
test(cypress): add chat text validation tests

### DIFF
--- a/components/views/chat/chatbar/controls/Controls.html
+++ b/components/views/chat/chatbar/controls/Controls.html
@@ -42,6 +42,7 @@
   <button
     :data-tooltip="$t('ui.send')"
     class="control-tooltip-wrap has-tooltip has-tooltip-top has-tooltip-primary has-tooltip-hidden-touch send-message-btn"
+    data-cy="send-message"
     :disabled="disabled"
     @click="sendMessage"
   >

--- a/cypress/integration/chat-text-validations.js
+++ b/cypress/integration/chat-text-validations.js
@@ -1,0 +1,58 @@
+const faker = require('faker')
+const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
+const recoverySeed =
+  'veteran intact there despair unique trouble season rebel sort file unit hard{enter}'
+let longMessage = faker.random.alphaNumeric(2060) // generate random alphanumeric text with 2060 chars
+
+describe('Chat Text Validations', () => {
+  before(() => {
+    //Import account
+    cy.importAccount(randomPIN, recoverySeed)
+
+    //Ensure messages are displayed before starting
+    cy.contains('cypress', { timeout: 180000 }).should('be.visible')
+    cy.get('.toggle-sidebar').should('be.visible').click()
+  })
+
+  it('Message with more than 2048 chars - Counter get reds', () => {
+    cy.waitForMessagesToLoad()
+    cy.get('[data-cy=editable-input]')
+      .should('be.visible')
+      .trigger('input')
+      .type(longMessage)
+    let expectedMessage = longMessage.length.toString() + '/2048'
+    cy.validateCharlimit(expectedMessage, true)
+  })
+
+  it('Message with more than 2048 chars - Message will only send the first 2048 chars', () => {
+    cy.get('[data-cy=send-message]').click()
+    cy.contains(longMessage.slice(0, 2048)).scrollIntoView().should('exist')
+    cy.contains(longMessage).should('not.exist')
+  })
+
+  it('Attempt to send empty message with a space', () => {
+    cy.get('[data-cy=editable-input]').trigger('input').clear().type(' ')
+    cy.validateCharlimit('1/2048', false)
+    cy.get('[data-cy=send-message]').click()
+    cy.get('[data-cy=editable-input]').should('have.text', '')
+    cy.validateCharlimit('0/2048', false)
+  })
+
+  it('Send empty message by clicking on send icon', () => {
+    cy.get('[data-cy=send-message]').click()
+    cy.get('[data-cy=editable-input]').should('have.text', '')
+    cy.validateCharlimit('0/2048', false)
+  })
+
+  it('Chat Text Validation - Space counts only for 1 char', () => {
+    cy.get('[data-cy=editable-input]').trigger('input').clear().type(' ')
+    cy.validateCharlimit('1/2048', false)
+    cy.get('[data-cy=editable-input]').clear()
+  })
+
+  it('Chat Text Validation - Emoji counts only for 1 char', () => {
+    cy.get('[data-cy=editable-input]').trigger('input').type('😄')
+    cy.validateCharlimit('1/2048', false)
+    cy.get('[data-cy=send-message]').click()
+  })
+})

--- a/cypress/integration/chat-top-toolbar.js
+++ b/cypress/integration/chat-top-toolbar.js
@@ -11,10 +11,10 @@ describe('Chat Toolbar Tests', () => {
     //Ensure messages are displayed before starting
     cy.contains('cypress', { timeout: 180000 }).should('be.visible')
     cy.get('.toggle-sidebar').should('be.visible').click()
-    cy.waitForMessagesToLoad()
   })
 
   it('Chat - Toolbar - Validate audio icon is displayed', () => {
+    cy.waitForMessagesToLoad()
     cy.hoverOnActiveIcon('[data-cy=toolbar-enable-audio]')
   })
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -313,11 +313,11 @@ Cypress.Commands.add(
       .should('be.visible')
       .rightclick()
     cy.contains('Edit Message').click()
-    cy.get('.edit-message-body-input')
+    cy.get('[data-cy=edit-message-input]')
       .should('be.visible')
       .trigger('input')
       .type(messageEdited) // editing message
-    cy.get('.edit-message-body-input').type('{enter}')
+    cy.get('[data-cy=edit-message-input]').type('{enter}')
     cy.contains(messageEdited).last().scrollIntoView().should('be.visible')
   },
 )
@@ -448,6 +448,19 @@ Cypress.Commands.add('closeModal', (locator) => {
 
 Cypress.Commands.add('goToLastGlyphOnChat', () => {
   cy.get('[data-cy=chat-glyph]').last().scrollIntoView().should('be.visible')
+})
+
+Cypress.Commands.add('validateCharlimit', (text, assert) => {
+  cy.get('.charlimit')
+    .should('be.visible')
+    .should('contain', text)
+    .then(($selector) => {
+      if (assert === true) {
+        cy.wrap($selector).should('have.class', 'is-error')
+      } else {
+        cy.wrap($selector).should('not.have.class', 'is-error')
+      }
+    })
 })
 
 //Version Release Notes Commands


### PR DESCRIPTION
**What this PR does** 📖
- Add cypress test for chat text limits and char counts
- Add cypress commands for actions commonly used in the tests mentioned above
- Added one data-cy attribute for chat send message button used in cypress tests
- Small improvement to chat features edit message cypress command
- In chat-top-toolbar.js moved the wait for messages to load command into a test block, in order that retries work correctly if needed

**Which issue(s) this PR fixes** 🔨
AP-623

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
Chat Text Validations Cypress Video:
https://user-images.githubusercontent.com/35935591/160725235-43247aa1-2345-4e7f-a9b6-00dbe444b655.mp4

Chat Top Toolbar Cypress Video:
https://user-images.githubusercontent.com/35935591/160725630-3775f31b-3ac1-4a78-9a59-390e1b575ccb.mp4

Chat Features Cypress Video:
https://user-images.githubusercontent.com/35935591/160725669-29f6f892-b397-47f0-9b2d-e1125b547d7c.mp4


