### PR TITLE
feat(chat): copy image

### DIFF
--- a/components/views/chat/message/Message.vue
+++ b/components/views/chat/message/Message.vue
@@ -64,14 +64,8 @@ export default Vue.extend({
     contextMenuValues(): ContextMenuItem[] {
       const mainList = [
         { text: 'quickReaction', func: this.quickReaction },
-        {
-          text: this.$t('context.reaction'),
-          func: this.emojiReaction,
-        },
-        {
-          text: this.$t('context.reply'),
-          func: this.setReplyChatbarContent,
-        },
+        { text: this.$t('context.reaction'), func: this.emojiReaction },
+        { text: this.$t('context.reply'), func: this.setReplyChatbarContent },
         // AP-1120 copy link functionality
         // { text: this.$t('context.copy_link'), func: (this as any).testFunc },
       ]
@@ -80,20 +74,14 @@ export default Vue.extend({
         if (this.accounts.details.textilePubkey === this.$props.message.from) {
           return [
             ...mainList,
-            {
-              text: this.$t('context.copy_msg'),
-              func: this.copyMessage,
-            },
+            { text: this.$t('context.copy_msg'), func: this.copyMessage },
             { text: this.$t('context.edit'), func: this.editMessage },
           ]
         }
         // another persons text message
         return [
           ...mainList,
-          {
-            text: this.$t('context.copy_msg'),
-            func: this.copyMessage,
-          },
+          { text: this.$t('context.copy_msg'), func: this.copyMessage },
         ]
       }
       // if image message

--- a/components/views/chat/message/Message.vue
+++ b/components/views/chat/message/Message.vue
@@ -65,11 +65,11 @@ export default Vue.extend({
       const mainList = [
         { text: 'quickReaction', func: this.quickReaction },
         {
-          text: this.$t('context.reaction') as string,
+          text: this.$t('context.reaction'),
           func: this.emojiReaction,
         },
         {
-          text: this.$t('context.reply') as string,
+          text: this.$t('context.reply'),
           func: this.setReplyChatbarContent,
         },
         // AP-1120 copy link functionality
@@ -81,17 +81,17 @@ export default Vue.extend({
           return [
             ...mainList,
             {
-              text: this.$t('context.copy_msg') as string,
+              text: this.$t('context.copy_msg'),
               func: this.copyMessage,
             },
-            { text: this.$t('context.edit') as string, func: this.editMessage },
+            { text: this.$t('context.edit'), func: this.editMessage },
           ]
         }
         // another persons text message
         return [
           ...mainList,
           {
-            text: this.$t('context.copy_msg') as string,
+            text: this.$t('context.copy_msg'),
             func: this.copyMessage,
           },
         ]
@@ -103,7 +103,7 @@ export default Vue.extend({
       ) {
         return [
           ...mainList,
-          { text: this.$t('context.copy_img') as string, func: this.copyImage },
+          { text: this.$t('context.copy_img'), func: this.copyImage },
           // todo - add save img functionality
           // { text: this.$t('context.save_img'), func: (this as any).testFunc },
         ]

--- a/components/views/chat/message/Message.vue
+++ b/components/views/chat/message/Message.vue
@@ -174,13 +174,13 @@ export default Vue.extend({
       const blob = await data.blob()
       const type = filetypemime(
         new Uint8Array(await blob.slice(0, 256).arrayBuffer()),
-      )
+      )[0]
 
       // copy to clipboard if png, otherwise convert
       try {
         await this.$envinfo.navigator.clipboard.write([
           new ClipboardItem({
-            'image/png': type[0] === 'image/png' ? blob : this.toPng(blob),
+            'image/png': type === 'image/png' ? blob : this.toPng(blob),
           }),
         ])
       } catch (e: any) {

--- a/components/views/chat/message/Message.vue
+++ b/components/views/chat/message/Message.vue
@@ -177,17 +177,11 @@ export default Vue.extend({
       )[0]
 
       // copy to clipboard if png, otherwise convert
-      try {
-        await this.$envinfo.navigator.clipboard.write([
-          new ClipboardItem({
-            'image/png': type === 'image/png' ? blob : this.toPng(blob),
-          }),
-        ])
-      } catch (e: any) {
-        this.$Logger.log('Error', e)
-        this.$toast.show(this.$t('errors.chat.unsupported_type') as string)
-        return
-      }
+      await this.$envinfo.navigator.clipboard.write([
+        new ClipboardItem({
+          'image/png': type === 'image/png' ? blob : this.toPng(blob),
+        }),
+      ])
       this.$toast.show(this.$t('ui.copied') as string)
     },
     /**

--- a/components/views/files/upload/Upload.vue
+++ b/components/views/files/upload/Upload.vue
@@ -126,14 +126,14 @@ export default Vue.extend({
             /* convert .heic file to jpeg so that we can convert it for html5 style */
             const oBuffer = await converter({
               buffer, // the HEIC file buffer
-              format: 'JPEG', // output format
+              format: 'PNG', // output format
               quality: 1,
             })
             newFiles[i] = new File(
               [oBuffer.buffer],
-              `${newFiles[i].name.split('.')[0] || 'newImage'}.jpeg`,
+              `${newFiles[i].name.split('.')[0] || 'newImage'}.png`,
               {
-                type: 'image/jpeg',
+                type: 'image/png',
               },
             )
           }

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -527,6 +527,7 @@ export default {
       contains_nsfw: 'Unable to upload file/s due to NSFW status',
       empty_message_error:
         'Message must contain at least one non-space character',
+      unsupported_type: 'This image format cannot be copied',
     },
     textile: {
       friend_not_found: 'Friend not found',

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -527,7 +527,6 @@ export default {
       contains_nsfw: 'Unable to upload file/s due to NSFW status',
       empty_message_error:
         'Message must contain at least one non-space character',
-      unsupported_type: 'This image format cannot be copied',
     },
     textile: {
       friend_not_found: 'Friend not found',

--- a/store/ui/types.ts
+++ b/store/ui/types.ts
@@ -153,7 +153,7 @@ export enum SettingsRoutes {
 // | 'realms'
 
 export interface ContextMenuItem {
-  text: string
+  text: string | TranslateResult
   func: Function
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- reopened PR after some minor refactoring https://github.com/Satellite-im/Core-PWA/pull/2520
- copy image via clipboard API which only accepts png
- if png, copy. if other embeddable image format, convert to png with canvas
- change heic conversion in chat to png rather than jpeg. this skips a conversion step on copy
- switch ContextMenuItem definition so we don't need to do `as string` every time we use it

**Which issue(s) this PR fixes** 🔨
AP-1080
<!--AP-X-->

**Special notes for reviewers** 🗒️
https://developer.mozilla.org/en-US/docs/Web/API/ClipboardItem#writing_to_clipboard
we need the blob to write to the clipboard. Initially I was fetching it during the copy method, but it felt very slow. Decided to fetch the blob on mounted instead. It will only convert to png one time as needed. We could also convert every image on mount instead, what do you think?

**Additional comments** 🎤
