### PR TITLE
fix(keybinds): add meta + l to blocked mac shortcuts

### DIFF
--- a/utilities/HotkeyList.ts
+++ b/utilities/HotkeyList.ts
@@ -89,6 +89,7 @@ export const macShortcuts = [
   'meta+r',
   'meta+shift+n',
   'meta+t',
+  'meta+l',
   'meta+shift+t',
   'meta+alt+arrowright',
   'meta+alt+arrowleft',

--- a/utilities/__snapshots__/HotkeyList.test.ts.snap
+++ b/utilities/__snapshots__/HotkeyList.test.ts.snap
@@ -9,6 +9,7 @@ Array [
   "meta+r",
   "meta+shift+n",
   "meta+t",
+  "meta+l",
   "meta+shift+t",
   "meta+alt+arrowright",
   "meta+alt+arrowleft",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
add meta + l to blocked mac shortcuts

**Which issue(s) this PR fixes** 🔨
[AP-1144](https://satellite-im.atlassian.net/browse/AP-1144)

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
