### PR TITLE
fix(files): rename quality of life update

### DIFF
--- a/components/views/files/controls/Controls.vue
+++ b/components/views/files/controls/Controls.vue
@@ -97,7 +97,7 @@ export default Vue.extend({
         this.errors.push(this.$t('pages.files.errors.limit') as string)
         return
       }
-      // todo - for now, index is stored in the bucket. we could try moving it to the thread, then sat.json wouldn't be reserved
+      // todo - move validation inside of file constructor
       const invalidNameResults: File[] = originalFiles.filter(
         (file) => !this.$Config.regex.invalid.test(file.name),
       )

--- a/config.ts
+++ b/config.ts
@@ -120,6 +120,8 @@ export const Config = {
     image: '^.*.(apng|avif|gif|jpg|jpeg|jfif|pjpeg|pjp|png|svg|webp)$',
     // check for empty string or spaces/nbsp
     empty: /^\s*$/,
+    // invalid characters in filesystem name
+    invalid: /[/:"*?<>|~#%&+{}\\]+/,
     // Regex to check if string contains only emoji's.
     isEmoji:
       /^(\u00A9|\u00AE|[\u2000-\u3300]|\uD83C[\uD000-\uDFFF]|\uD83D[\uD000-\uDFFF]|\uD83E[\uD000-\uDFFF])+$/gi,

--- a/libraries/Files/Directory.ts
+++ b/libraries/Files/Directory.ts
@@ -9,7 +9,7 @@ export class Directory extends Item {
 
   /**
    * @constructor
-   * @param {object} param0 directory info - name, liked, shared, type
+   * @description call Item constructor
    * @returns {Directory}
    */
   constructor({

--- a/libraries/Files/Directory.ts
+++ b/libraries/Files/Directory.ts
@@ -5,7 +5,6 @@ import { Fil } from './Fil'
 import { DIRECTORY_TYPE } from './types/directory'
 
 export class Directory extends Item {
-  private _type: DIRECTORY_TYPE.DEFAULT
   private _children = new Map()
 
   /**
@@ -28,8 +27,14 @@ export class Directory extends Item {
     modified?: number
     type?: DIRECTORY_TYPE
   }) {
-    super({ id, name: name || 'un-named directory', liked, shared, modified })
-    this._type = type || DIRECTORY_TYPE.DEFAULT
+    super({
+      id,
+      name: name || 'un-named directory',
+      liked,
+      shared,
+      modified,
+      type,
+    })
   }
 
   /**
@@ -38,14 +43,6 @@ export class Directory extends Item {
    */
   get content(): Array<Item> {
     return Array.from(this._children.values())
-  }
-
-  /**
-   * @getter type
-   * @returns {DIRECTORY_TYPE} returns the type of directory
-   */
-  get type(): DIRECTORY_TYPE {
-    return this._type
   }
 
   /**
@@ -78,7 +75,7 @@ export class Directory extends Item {
       name: `${this.name} copy`,
       liked: this.liked,
       shared: this.shared,
-      type: this.type,
+      type: this.type as DIRECTORY_TYPE,
     })
 
     this.content.forEach((item) => {

--- a/libraries/Files/Directory.ts
+++ b/libraries/Files/Directory.ts
@@ -29,7 +29,7 @@ export class Directory extends Item {
   }) {
     super({
       id,
-      name: name || 'un-named directory',
+      name,
       liked,
       shared,
       modified,

--- a/libraries/Files/Fil.ts
+++ b/libraries/Files/Fil.ts
@@ -10,7 +10,7 @@ export class Fil extends Item {
 
   /**
    * @constructor
-   * @param param0  id, name, file, size, liked, shared, modified, description, type, thumbnail
+   * @description call Item constructor, set Fil specific properties
    * @returns {Fil}
    */
   constructor({

--- a/libraries/Files/Fil.ts
+++ b/libraries/Files/Fil.ts
@@ -3,7 +3,6 @@ import { Item } from './abstracts/Item.abstract'
 import { FILE_TYPE } from './types/file'
 
 export class Fil extends Item {
-  private _type = FILE_TYPE.GENERIC
   private _description: string = ''
   private _size: number = 0
   private _file: File | undefined
@@ -37,11 +36,10 @@ export class Fil extends Item {
     type?: FILE_TYPE
     thumbnail?: string
   }) {
-    super({ name: name || 'un-named file', liked, shared, modified, id })
+    super({ name: name || 'un-named file', liked, shared, modified, id, type })
     this._file = file || undefined
     this._description = description || ''
     this._size = size || 0
-    this._type = type || FILE_TYPE.GENERIC
     this._thumbnail = thumbnail || ''
   }
 
@@ -51,14 +49,6 @@ export class Fil extends Item {
    */
   get description(): string {
     return this._description
-  }
-
-  /**
-   * @getter type
-   * @returns file type in plain text
-   */
-  get type(): FILE_TYPE {
-    return this._type
   }
 
   /**
@@ -74,7 +64,7 @@ export class Fil extends Item {
       liked: this.liked,
       shared: this.shared,
       description: this.description,
-      type: this.type,
+      type: this.type as FILE_TYPE,
       thumbnail: this.thumbnail,
     })
   }

--- a/libraries/Files/FilSystem.ts
+++ b/libraries/Files/FilSystem.ts
@@ -298,7 +298,7 @@ export class FilSystem {
     type,
     modified,
   }: {
-    id: string
+    id?: string
     name: string
     liked?: boolean
     shared?: boolean

--- a/libraries/Files/FilSystem.ts
+++ b/libraries/Files/FilSystem.ts
@@ -98,7 +98,7 @@ export class FilSystem {
   }
 
   /**
-   * @method flat
+   * @getter flat
    * @returns {ExportItem[]} flattened list of files in order to check if file exists
    */
   get flat(): ExportItem[] {
@@ -118,7 +118,7 @@ export class FilSystem {
   }
 
   /**
-   * @method totalSize
+   * @getter totalSize
    * @returns {number} total size of all tracked files
    */
   get totalSize(): number {
@@ -132,7 +132,7 @@ export class FilSystem {
   }
 
   /**
-   * @method percentStorageUsed
+   * @getter percentStorageUsed
    * @returns {number} percentage of available storage used
    */
   get percentStorageUsed(): number {
@@ -409,7 +409,7 @@ export class FilSystem {
 
   /**
    * @method goBack
-   * This will navigate the filesystem to the directory at this path
+   * @description navigate the filesystem to the directory at this path
    * @argument {string} steps number of steps to go back (will go to root if too many are provided)
    * @returns {Directory | null} returns the opened directory
    */
@@ -522,7 +522,7 @@ export class FilSystem {
 
   /**
    * @method moveItemTo
-   * move an item into a specific directory
+   * @description move an item into a specific directory
    * @argument {string} childName name of item to move
    * @argument {string} dirPath name of directory to move item into
    * @returns {Directory | null} directory the item has been moved to

--- a/libraries/Files/TextileFileSystem.ts
+++ b/libraries/Files/TextileFileSystem.ts
@@ -21,6 +21,7 @@ export class TextileFileSystem extends FilSystem {
   /**
    * @method uploadFile
    * @description Upload file to the bucket and create in the file system afterwards
+   * use uuid as bucket path so files can be renamed freely
    * @param {File} file file to be uploaded
    */
   async uploadFile(file: File) {
@@ -43,7 +44,7 @@ export class TextileFileSystem extends FilSystem {
   /**
    * @method removeFile
    * @description Remove file/folder from bucket and file system
-   * @param {string} id id and path in bucket
+   * @param {string} id uuid = path in bucket
    */
   async removeFile(id: string) {
     await this.bucket.removeFile(id)

--- a/libraries/Files/abstracts/Item.abstract.ts
+++ b/libraries/Files/abstracts/Item.abstract.ts
@@ -4,6 +4,7 @@ import { FileSystemErrors } from '../errors/Errors'
 import { ItemInterface } from '../interface/Item.interface'
 import { DIRECTORY_TYPE } from '../types/directory'
 import { FILE_TYPE } from '../types/file'
+import { Config } from '~/config'
 
 export abstract class Item implements ItemInterface {
   private _id: string = ''
@@ -12,7 +13,7 @@ export abstract class Item implements ItemInterface {
   private _liked: boolean = false
   private _shared: boolean = false
   private _modified: number
-  abstract type: DIRECTORY_TYPE | FILE_TYPE
+  private _type: FILE_TYPE | DIRECTORY_TYPE
   abstract modified: number
   abstract size: number
 
@@ -29,6 +30,7 @@ export abstract class Item implements ItemInterface {
     shared,
     parent,
     modified,
+    type,
   }: {
     id?: string
     name: string
@@ -36,9 +38,12 @@ export abstract class Item implements ItemInterface {
     liked?: boolean
     parent?: Directory
     modified?: number
+    type?: FILE_TYPE | DIRECTORY_TYPE
   }) {
     if (this.constructor.name === 'Item')
       throw new Error(FileSystemErrors.ITEM_ABSTRACT_ONLY)
+
+    this.validateName(name)
 
     this._id = id || uuidv4()
     this._name = name
@@ -46,6 +51,11 @@ export abstract class Item implements ItemInterface {
     this._liked = liked || false
     this._parent = parent || null
     this._modified = modified || Date.now()
+    this._type =
+      type ||
+      (this.constructor.name === 'Fil'
+        ? FILE_TYPE.GENERIC
+        : DIRECTORY_TYPE.DEFAULT)
   }
 
   /**
@@ -101,6 +111,14 @@ export abstract class Item implements ItemInterface {
   }
 
   /**
+   * @getter type
+   * @returns file type in plain text
+   */
+  get type(): FILE_TYPE | DIRECTORY_TYPE {
+    return this._type
+  }
+
+  /**
    * @protected
    * @getter modifiedVal
    * @returns last modified timestamp
@@ -128,7 +146,7 @@ export abstract class Item implements ItemInterface {
   /**
    * Validate that the parent is of the correct instance type
    * @method validateParent
-   * @param {string} newName - The new name of the associated file.
+   * @param {Directory} parent - The new name of the associated file.
    */
   private validateParent(parent: Directory | null): boolean {
     // In the future we may want shared directory types and more
@@ -138,22 +156,35 @@ export abstract class Item implements ItemInterface {
   }
 
   /**
+   * Validate that the parent is of the correct instance type
+   * @method validateName
+   * @param {string} name
+   */
+  private validateName(name: string) {
+    if (Config.regex.empty.test(name)) {
+      throw new Error(FileSystemErrors.NO_EMPTY_STRING)
+    }
+
+    if (name[0] === '.') {
+      throw new Error(FileSystemErrors.LEADING_DOT)
+    }
+
+    if (Config.regex.invalid.test(name)) {
+      throw new Error(FileSystemErrors.INVALID)
+    }
+
+    if (this.validateParent(this.parent) && this.parent?.hasChild(name)) {
+      throw new Error(FileSystemErrors.DUPLICATE_NAME)
+    }
+  }
+
+  /**
    * Set a new name for this item.
    * @setter
    * @param {string} newName - The new name of the associated file.
    */
   set name(newName: string) {
-    const filenameTest = /[/:"*?<>|]+/
-
-    if (!newName || typeof newName !== 'string' || !newName.trim().length)
-      throw new Error(FileSystemErrors.NO_EMPTY_STRING)
-
-    if (filenameTest.test(newName))
-      throw new Error(FileSystemErrors.INVALID_SYMBOL)
-
-    if (this.validateParent(this.parent) && this.parent?.hasChild(newName))
-      throw new Error(FileSystemErrors.DUPLICATE_NAME)
-
+    this.validateName(newName)
     this._name = newName
   }
 

--- a/libraries/Files/abstracts/Item.abstract.ts
+++ b/libraries/Files/abstracts/Item.abstract.ts
@@ -18,10 +18,8 @@ export abstract class Item implements ItemInterface {
   abstract size: number
 
   /**
-   * Update the parent directory for this item
    * @constructor
-   * @param {string} name - Name of the item.
-   * @param {Parent} parent - Optional parent of the item.
+   * @description set shared properties for Fil and Directory
    */
   constructor({
     id,
@@ -43,7 +41,7 @@ export abstract class Item implements ItemInterface {
     if (this.constructor.name === 'Item')
       throw new Error(FileSystemErrors.ITEM_ABSTRACT_ONLY)
 
-    this.validateName(name)
+    this._validateName(name)
 
     this._id = id || uuidv4()
     this._name = name
@@ -79,7 +77,7 @@ export abstract class Item implements ItemInterface {
 
   /**
    * @getter
-   * @returns a unique identifier for the item
+   * @returns a unique identifier for the item - uuid
    */
   get id(): string {
     return this._id
@@ -144,8 +142,8 @@ export abstract class Item implements ItemInterface {
   }
 
   /**
-   * Validate that the parent is of the correct instance type
    * @method validateParent
+   * @description Validate that the parent is of the correct instance type
    * @param {Directory} parent - The new name of the associated file.
    */
   private validateParent(parent: Directory | null): boolean {
@@ -156,11 +154,11 @@ export abstract class Item implements ItemInterface {
   }
 
   /**
-   * Validate prospective item name
    * @method validateName
+   * @description Validate prospective item name
    * @param {string} name
    */
-  private validateName(name: string) {
+  private _validateName(name: string) {
     if (Config.regex.empty.test(name)) {
       throw new Error(FileSystemErrors.NO_EMPTY_STRING)
     }
@@ -179,18 +177,18 @@ export abstract class Item implements ItemInterface {
   }
 
   /**
-   * Set a new name for this item.
    * @setter
+   * @description Set a new name for this item.
    * @param {string} newName - The new name of the associated file.
    */
   set name(newName: string) {
-    this.validateName(newName)
+    this._validateName(newName)
     this._name = newName
   }
 
   /**
-   * Update the parent directory for this item
-   * @method
+   * @setter
+   * @description Update the parent directory for this item
    * @param {Directory} newPARENT - The new name of the associated file.
    */
   set parent(newParent: Directory | null) {

--- a/libraries/Files/abstracts/Item.abstract.ts
+++ b/libraries/Files/abstracts/Item.abstract.ts
@@ -156,7 +156,7 @@ export abstract class Item implements ItemInterface {
   }
 
   /**
-   * Validate that the parent is of the correct instance type
+   * Validate prospective item name
    * @method validateName
    * @param {string} name
    */

--- a/libraries/Files/errors/Errors.ts
+++ b/libraries/Files/errors/Errors.ts
@@ -7,8 +7,9 @@ export enum FileSystemErrors {
   RFM_ABSTRACT_ONLY = 'RFM class is Abstract. It can only be extended',
   ITEM_ABSTRACT_ONLY = 'Item class is Abstract. It can only be extended',
   NO_EMPTY_STRING = 'Item name must be a non empty string',
-  INVALID_SYMBOL = 'Item name contains invalid symbol',
+  INVALID = 'Item name cannot contain invalid symbols',
   DUPLICATE_NAME = 'Item with name already exists in this directory',
   DIR_PARADOX = 'Directory cannot contain itself',
   DIR_PARENT_PARADOX = 'Directory cannot contain one of its ancestors',
+  LEADING_DOT = 'Item name cannot begin with .',
 }

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -157,9 +157,9 @@ export default {
         folder_name:
           'Please enter a folder name of at least one non-space character',
         no_slash: 'Folder name cannot contain /',
-        reserved_name: 'sat.json is a reserved file name',
+        invalid_name: 'Item name cannot contain invalid symbols',
         empty_file: 'File needs to have a size of 1 byte or greater',
-        file_name: 'File with name already exists in this file system',
+        item_name: 'Item with name already exists in this directory',
         limit: 'This upload would exceed your storage limit',
       },
     },

--- a/pages/files/browse/index.vue
+++ b/pages/files/browse/index.vue
@@ -30,6 +30,9 @@ export default Vue.extend({
       )
     },
   },
+  mounted() {
+    console.log(this.fileSystem)
+  },
   methods: {
     /**
      * @method changeView DocsTODO

--- a/pages/files/browse/index.vue
+++ b/pages/files/browse/index.vue
@@ -30,9 +30,6 @@ export default Vue.extend({
       )
     },
   },
-  mounted() {
-    console.log(this.fileSystem)
-  },
   methods: {
     /**
      * @method changeView DocsTODO


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- enforce invalid name rules on file/directory creation and rename
- refactor name validation to a separate method which can be called from the constructor
- move Directory name validation inside constructor rather than inside of Controls.vue
- allow files of the same name to be located in different directories. Rename update switch to uuid for the bucket identifier rather than name, so now it's allowed. Still preventing same name inside a directory

**Which issue(s) this PR fixes** 🔨
AP-1179
<!--AP-X-->

**Special notes for reviewers** 🗒️
- I want to improve file Upload validation in a separate ticket. Right now I'm checking on the front end before attempting to upload. I would much rather move it to the constructor, but it would be fairly involved

**Additional comments** 🎤
- ticket mentioned feedback for max char limit in folder name input. That should probably be a global change for all Input/InputGroup. separate ticket
