### PR TITLE
chore(chat-scroll): scroll fixed while on call

### DIFF
--- a/layouts/Layout.less
+++ b/layouts/Layout.less
@@ -9,9 +9,7 @@
   }
 
   .media-open {
-    &::-webkit-scrollbar-track {
-      margin-top: @media_open_offset;
-    }
+    margin-top: @media_open_offset;
   }
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Fixes chat scroll while the user is on call and allow him to see old messages

**Which issue(s) this PR fixes** 🔨
AP-1209
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
It's not clear from the ticket if the bar appears or not.
The thing that i noticed, is that when the messages go behind the modal, it's impossibile to go read them (that's the thing that got fixed 🔨 ).
