### PR TITLE
fix(preview): fix preview broken issue throughout app

### DIFF
--- a/components/ui/Chat/Image/Image.html
+++ b/components/ui/Chat/Image/Image.html
@@ -1,16 +1,4 @@
 <div class="image">
-  <div class="image-mask" v-if="showfull">
-    <div class="image-container">
-      <img
-        class="is-image-in-mask"
-        :src="image.url"
-        v-click-outside="clickHandler"
-      />
-      <a class="link" :href="image.url" target="_blank">
-        {{ $t('files.view_original') }}
-      </a>
-    </div>
-  </div>
   <img
     class="is-image"
     data-cy="chat-image"

--- a/components/ui/Chat/Image/Image.less
+++ b/components/ui/Chat/Image/Image.less
@@ -45,32 +45,6 @@
   margin-bottom: 10px;
 }
 
-.image-mask {
-  &:extend(.flex-justify-content-centered);
-  &:extend(.absolute-coverage);
-
-  .is-image-in-mask {
-    &:extend(.round-corners);
-    max-height: 80vh;
-    max-width: 80vw;
-    justify-content: center;
-    align-self: center;
-    margin: 0 auto;
-  }
-
-  .image-container {
-    display: inline-flex;
-    flex-direction: column;
-    max-width: fit-content;
-    align-self: center;
-  }
-
-  position: fixed;
-  background: rgba(0, 0, 0, 0.75);
-  z-index: @base-z-index + 102;
-  flex-direction: column;
-}
-
 @media only screen and (max-width: @mobile-breakpoint) {
   .is-normal-image {
     &:extend(.full-width);

--- a/components/ui/Chat/Image/Image.vue
+++ b/components/ui/Chat/Image/Image.vue
@@ -23,14 +23,9 @@ export default Vue.extend({
       required: true,
     },
   },
-  data() {
-    return {
-      showfull: false,
-    }
-  },
   methods: {
     clickHandler(event: MouseEvent): void {
-      this.showfull = !this.showfull
+      this.$store.commit('ui/setChatImageOverlay', this.image)
     },
   },
 })

--- a/components/ui/Chat/Image/Overlay/Overlay.html
+++ b/components/ui/Chat/Image/Overlay/Overlay.html
@@ -1,0 +1,12 @@
+<div class="image-mask" v-if="ui.chatImageOverlay">
+  <div class="image-container">
+    <img
+      class="is-image-in-mask"
+      :src="ui.chatImageOverlay.url"
+      v-click-outside="closeChatImageOverlay"
+    />
+    <a class="link" :href="ui.chatImageOverlay.url" target="_blank">
+      {{ $t('files.view_original') }}
+    </a>
+  </div>
+</div>

--- a/components/ui/Chat/Image/Overlay/Overlay.less
+++ b/components/ui/Chat/Image/Overlay/Overlay.less
@@ -1,0 +1,25 @@
+.image-mask {
+  &:extend(.flex-justify-content-centered);
+  &:extend(.absolute-coverage);
+
+  .is-image-in-mask {
+    &:extend(.round-corners);
+    height: 80vh;
+    max-width: 80vw;
+    justify-content: center;
+    align-self: center;
+    margin: 0 auto;
+  }
+
+  .image-container {
+    display: inline-flex;
+    flex-direction: column;
+    max-width: fit-content;
+    align-self: center;
+  }
+
+  position: fixed;
+  background: rgba(0, 0, 0, 0.75);
+  z-index: @base-z-index + 102;
+  flex-direction: column;
+}

--- a/components/ui/Chat/Image/Overlay/Overlay.vue
+++ b/components/ui/Chat/Image/Overlay/Overlay.vue
@@ -1,0 +1,22 @@
+<template src="./Overlay.html" />
+<script lang="ts">
+import Vue, { PropType } from 'vue'
+import { mapState } from 'vuex'
+
+export default Vue.extend({
+  computed: {
+    ...mapState(['ui']),
+  },
+  methods: {
+    /**
+     * @method closeChatImageOverlay
+     * @description Close Chat Image Overlay
+     * @example
+     */
+    closeChatImageOverlay() {
+      this.$store.commit('ui/setChatImageOverlay', undefined)
+    },
+  },
+})
+</script>
+<style scoped lang="less" src="./Overlay.less"></style>

--- a/components/ui/Global/Global.html
+++ b/components/ui/Global/Global.html
@@ -91,6 +91,12 @@
     v-if="ui.modals.changelog"
     v-click-outside="() => toggleModal(ModalWindows.CHANGELOG)"
   />
+  <FilesView
+    v-if="ui.filePreview"
+    :file="ui.filePreview"
+    @close="closeFilePreview()"
+    @share="share"
+  />
   <transition :name="$device.isMobile ? 'slide' : ''">
     <InteractablesQuickProfile v-if="ui.quickProfile" :user="ui.quickProfile" />
   </transition>

--- a/components/ui/Global/Global.html
+++ b/components/ui/Global/Global.html
@@ -91,6 +91,7 @@
     v-if="ui.modals.changelog"
     v-click-outside="() => toggleModal(ModalWindows.CHANGELOG)"
   />
+  <UiChatImageOverlay v-if="ui.chatImageOverlay"></UiChatImageOverlay>
   <FilesView
     v-if="ui.filePreview"
     :file="ui.filePreview"

--- a/components/ui/Global/Global.vue
+++ b/components/ui/Global/Global.vue
@@ -4,6 +4,7 @@ import Vue from 'vue'
 import { mapState } from 'vuex'
 import { TrackKind } from '~/libraries/WebRTC/types'
 import { ModalWindows } from '~/store/ui/types'
+import { Item } from '~/libraries/Files/abstracts/Item.abstract'
 
 declare module 'vue/types/vue' {
   interface Vue {
@@ -115,6 +116,28 @@ export default Vue.extend({
       peer?.call.hangUp()
       this.$store.dispatch('webrtc/hangUp')
       this.$store.commit('ui/fullscreen', false)
+    },
+    /**
+     * @method share
+     * @description copy link to clipboard
+     * @param {Item} item
+     */
+    async share(item: Item) {
+      this.$toast.show(this.$t('todo - share') as string)
+      // if (item instanceof Directory) {
+      //   this.$toast.show(this.$t('todo - share folders') as string)
+      //   return
+      // }
+      // if (!item.shared) {
+      //   this.$store.commit('ui/setIsLoadingFileIndex', true)
+      //   item.shareItem()
+      //   await this.$TextileManager.bucket?.updateIndex(this.$FileSystem.export)
+      //   this.$store.commit('ui/setIsLoadingFileIndex', false)
+      //   this.$emit('forceRender')
+      // }
+      // navigator.clipboard.writeText(this.path).then(() => {
+      //   this.$toast.show(this.$t('pages.files.link_copied') as string)
+      // })
     },
     /**
      * @method closeFilePreview

--- a/components/ui/Global/Global.vue
+++ b/components/ui/Global/Global.vue
@@ -116,6 +116,14 @@ export default Vue.extend({
       this.$store.dispatch('webrtc/hangUp')
       this.$store.commit('ui/fullscreen', false)
     },
+    /**
+     * @method closeFilePreview
+     * @description Close File Preview
+     * @example
+     */
+    closeFilePreview() {
+      this.$store.commit('ui/setFilePreview', undefined)
+    },
   },
 })
 </script>

--- a/pages/files/browse/Browse.html
+++ b/pages/files/browse/Browse.html
@@ -1,5 +1,4 @@
 <div id="files" class="hidden-scroll" v-scroll-lock="true">
-  <FilesView v-if="file" :file="file" @close="file = false" @share="share" />
   <FilesAside v-if="$device.isMobile" class="mobile-file-aside" />
   <div class="files-top">
     <FilesFilepath />

--- a/pages/files/browse/index.vue
+++ b/pages/files/browse/index.vue
@@ -12,7 +12,6 @@ export default Vue.extend({
   layout: 'files',
   data() {
     return {
-      file: false as Fil | boolean,
       view: 'grid',
       counter: 1 as number, // needed to force render on addChild. Vue2 lacks reactivity for Map
       fileSystem: this.$FileSystem as FilSystem,
@@ -47,7 +46,7 @@ export default Vue.extend({
      */
     handle(item: Item) {
       if (item instanceof Fil) {
-        this.file = item
+        this.$store.commit('ui/setFilePreview', item)
       }
       if (item instanceof Directory) {
         this.fileSystem.openDirectory(item.name)

--- a/pages/files/browse/index.vue
+++ b/pages/files/browse/index.vue
@@ -68,28 +68,6 @@ export default Vue.extend({
       this.forceRender()
     },
     /**
-     * @method share
-     * @description copy link to clipboard
-     * @param {Item} item
-     */
-    async share(item: Item) {
-      this.$toast.show(this.$t('todo - share') as string)
-      // if (item instanceof Directory) {
-      //   this.$toast.show(this.$t('todo - share folders') as string)
-      //   return
-      // }
-      // if (!item.shared) {
-      //   this.$store.commit('ui/setIsLoadingFileIndex', true)
-      //   item.shareItem()
-      //   await this.$TextileManager.bucket?.updateIndex(this.$FileSystem.export)
-      //   this.$store.commit('ui/setIsLoadingFileIndex', false)
-      //   this.$emit('forceRender')
-      // }
-      // navigator.clipboard.writeText(this.path).then(() => {
-      //   this.$toast.show(this.$t('pages.files.link_copied') as string)
-      // })
-    },
-    /**
      * @method remove
      * @description delete item from filesystem. If file, also remove from textile bucket
      * @param {Item} item

--- a/store/ui/__snapshots__/state.test.ts.snap
+++ b/store/ui/__snapshots__/state.test.ts.snap
@@ -28,6 +28,7 @@ Object {
     "route": "emotes",
     "show": false,
   },
+  "filePreview": undefined,
   "fullscreen": false,
   "glyphMarketplaceView": Object {
     "shopId": null,

--- a/store/ui/__snapshots__/state.test.ts.snap
+++ b/store/ui/__snapshots__/state.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`init should return the initial settings state 1`] = `
 Object {
   "activeChannel": undefined,
+  "chatImageOverlay": undefined,
   "chatbarContent": "",
   "chatbarFocus": false,
   "contextMenuPosition": Object {

--- a/store/ui/mutations.ts
+++ b/store/ui/mutations.ts
@@ -10,6 +10,7 @@ import {
 } from './types'
 import { MessageGroup } from '~/types/messaging'
 import { Channel } from '~/types/ui/server'
+import { Fil } from '~/libraries/Files/Fil'
 
 export default {
   togglePinned(state: UIState, visible: boolean) {
@@ -47,6 +48,9 @@ export default {
   },
   fullscreen(state: UIState, fullscreen: boolean) {
     state.fullscreen = fullscreen
+  },
+  setFilePreview(state: UIState, file: Fil | undefined) {
+    state.filePreview = file
   },
   toggleEnhancers(state: UIState, options: EnhancerInfo) {
     state.enhancers = {

--- a/store/ui/mutations.ts
+++ b/store/ui/mutations.ts
@@ -11,6 +11,7 @@ import {
 import { MessageGroup } from '~/types/messaging'
 import { Channel } from '~/types/ui/server'
 import { Fil } from '~/libraries/Files/Fil'
+import { ImageMessage } from '~/types/textile/mailbox'
 
 export default {
   togglePinned(state: UIState, visible: boolean) {
@@ -51,6 +52,9 @@ export default {
   },
   setFilePreview(state: UIState, file: Fil | undefined) {
     state.filePreview = file
+  },
+  setChatImageOverlay(state: UIState, image: ImageMessage | undefined) {
+    state.chatImageOverlay = image
   },
   toggleEnhancers(state: UIState, options: EnhancerInfo) {
     state.enhancers = {

--- a/store/ui/state.ts
+++ b/store/ui/state.ts
@@ -73,6 +73,7 @@ const InitialUIState = (): UIState => ({
   },
   isLoadingFileIndex: false,
   renameCurrentName: undefined,
+  filePreview: undefined,
 })
 
 export default InitialUIState

--- a/store/ui/state.ts
+++ b/store/ui/state.ts
@@ -74,6 +74,7 @@ const InitialUIState = (): UIState => ({
   isLoadingFileIndex: false,
   renameCurrentName: undefined,
   filePreview: undefined,
+  chatImageOverlay: undefined,
 })
 
 export default InitialUIState

--- a/store/ui/types.ts
+++ b/store/ui/types.ts
@@ -1,4 +1,5 @@
 import { Fil } from '~/libraries/Files/Fil'
+import { ImageMessage } from '~/types/textile/mailbox'
 import { Glyph } from '~/types/ui/glyph'
 import { Channel } from '~/types/ui/server'
 
@@ -208,6 +209,7 @@ export interface UIState {
   isLoadingFileIndex: boolean
   renameCurrentName?: string
   filePreview: Fil | undefined
+  chatImageOverlay: ImageMessage | undefined
 }
 
 export type Position = {

--- a/store/ui/types.ts
+++ b/store/ui/types.ts
@@ -1,3 +1,4 @@
+import { Fil } from '~/libraries/Files/Fil'
 import { Glyph } from '~/types/ui/glyph'
 import { Channel } from '~/types/ui/server'
 
@@ -206,6 +207,7 @@ export interface UIState {
   }
   isLoadingFileIndex: boolean
   renameCurrentName?: string
+  filePreview: Fil | undefined
 }
 
 export type Position = {


### PR DESCRIPTION
**What this PR does** 📖
Fix Preview broken issue when click chat image & file on file browse

**Which issue(s) this PR fixes** 🔨

AP-1150

**Special notes for reviewers** 🗒️
- Move these overlays up to the modal level (global component), so its not a child of any swiper container
reason: As @josephmcg  mentioned, if the preview/overlay component is a child of swiper container z-index & transform issue happen.
