### PR TITLE
test(cypress): add tests for chat replies and new satellite accounts

### DIFF
--- a/components/views/chat/chatbar/footer/is-connected/Connected.html
+++ b/components/views/chat/chatbar/footer/is-connected/Connected.html
@@ -9,6 +9,7 @@
   <TypographyText
     v-if="$Hounddog.getActiveFriend(friends)"
     :text="`${$Hounddog.getActiveFriend(friends).name}`"
+    data-cy="user-connected"
     :size="6"
   />
   <TypographyText

--- a/components/views/chat/message/reply/Reply.html
+++ b/components/views/chat/message/reply/Reply.html
@@ -1,5 +1,10 @@
 <div v-if="message.replies.length" class="replies-container">
-  <div v-if="!showReplies" class="reply-preview" @click="toggleReplies">
+  <div
+    v-if="!showReplies"
+    class="reply-preview"
+    data-cy="reply-preview"
+    @click="toggleReplies"
+  >
     <plus-square-icon size="1.1x" />
     &nbsp; {{ makeReplyText }}
   </div>
@@ -29,6 +34,7 @@
             v-if="reply.replyType === 'text'"
             :text="markdownToHtml(reply.payload)"
             class="markdown"
+            data-cy="reply-message"
           />
           <UiChatImage
             v-else-if="reply.replyType === 'image'"
@@ -57,7 +63,12 @@
     </div>
     <MessageReactions :message="message" :group="group" :reply="reply" />
   </div>
-  <div v-if="showReplies" @click="toggleReplies" class="reply-close">
+  <div
+    v-if="showReplies"
+    @click="toggleReplies"
+    class="reply-close"
+    data-cy="reply-close"
+  >
     <minus-square-icon size="1.1x" />
     &nbsp; {{$t('conversation.collapse')}}
   </div>

--- a/components/views/friends/friend/Friend.html
+++ b/components/views/friends/friend/Friend.html
@@ -1,7 +1,7 @@
 <div class="friend">
   <UiUserState :user="friend" :src="src" />
   <div class="description">
-    <TypographySubtitle :size="6" :text="friend.name" />
+    <TypographySubtitle :size="6" :text="friend.name" data-cy="friend-name" />
     <TypographyText :text="friend.status" />
   </div>
   <div class="spacer"></div>
@@ -71,6 +71,7 @@
       type="primary"
       size="small"
       class="has-tooltip has-tooltip-primary has-tooltip-bottom has-tooltip-desktop-only"
+      data-cy="friend-send-message"
       :data-tooltip="$t('friends.message')"
       :action="sendMessageRequest"
     >

--- a/components/views/navigation/sidebar/Sidebar.html
+++ b/components/views/navigation/sidebar/Sidebar.html
@@ -31,6 +31,7 @@
         <InteractablesButton
           :inactive="$route.path.includes('/friends/list') ? false : true"
           class="sidebar-full-btn"
+          data-cy="sidebar-friends"
           :type="$route.path.includes('/friends/list') ? 'primary' : 'dark'"
           size="small"
           :action="() => { friends.incomingRequests.length ? $router.push('/friends/list?tab=requests') : $router.push('/friends/list') }"
@@ -48,6 +49,7 @@
       <InteractablesButton
         :inactive="$route.path.includes('/files') ? false : true"
         class="sidebar-full-btn"
+        data-cy="sidebar-files"
         :type="$route.path.includes('/files') ? 'primary' : 'dark'"
         size="small"
         :action="() => $router.push('/files/browse')"

--- a/cypress/integration-pair-chat/chat-first-user.js
+++ b/cypress/integration-pair-chat/chat-first-user.js
@@ -1,12 +1,12 @@
 const faker = require('faker')
 const recoverySeed =
-  'lonely dust spring orphan pulp angry mystery bracket pottery metal bright damp{enter}'
+  'memory cherry add return that phrase suit plate ladder earth people gravity{enter}'
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 const redirectedURL = 'http://localhost:3000/#/auth/unlock' // URL redirected from root
 const longMessage = faker.lorem.words(250) // generate random sentence
 
 describe('Chat features with two accounts at the same time - First User', () => {
-  before(() => {
+  it('Load account from Chat User A', () => {
     //Delete database before starting
     new Cypress.Promise(async (resolve) => {
       const req = indexedDB.deleteDatabase('SatelliteDB')

--- a/cypress/integration-pair-chat/chat-second-user.js
+++ b/cypress/integration-pair-chat/chat-second-user.js
@@ -1,11 +1,11 @@
 const faker = require('faker')
 const recoverySeed =
-  'urban clump gather december smoke upset chicken spice steel hope doll pigeon{enter}'
+  'position few settle fold sister transfer song speed million congress acoustic version{enter}'
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 const redirectedURL = 'http://localhost:3000/#/auth/unlock' // URL redirected from root
 
 describe('Chat features with two accounts at the same time - Second User', () => {
-  before(() => {
+  it('Load account from Chat User B', () => {
     //Delete database before starting
     new Cypress.Promise(async (resolve) => {
       const req = indexedDB.deleteDatabase('SatelliteDB')

--- a/cypress/integration/chat-features.js
+++ b/cypress/integration/chat-features.js
@@ -5,7 +5,7 @@ const randomMessage = faker.lorem.sentence() // generate random sentence
 const imageLocalPath = 'cypress/fixtures/images/logo.png'
 const randomTextToCopy = faker.lorem.sentence() // generate random sentence
 const recoverySeed =
-  'veteran intact there despair unique trouble season rebel sort file unit hard{enter}'
+  'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}'
 let imageURL
 
 describe('Chat Features Tests', () => {
@@ -16,11 +16,8 @@ describe('Chat Features Tests', () => {
     //Validate profile name displayed
     cy.chatFeaturesProfileName('cypress')
 
-    // Click on hamburger menu if width < height
-    cy.get('.toggle-sidebar').should('be.visible').click()
-
     //Validate message is sent
-    cy.waitForMessagesToLoad()
+    cy.goToConversation('cypress friend')
     cy.chatFeaturesSendMessage(randomMessage)
   })
 
@@ -32,7 +29,7 @@ describe('Chat Features Tests', () => {
     cy.chatFeaturesEditMessage(randomMessage, randomNumber)
   })
 
-  it.skip('Chat - Message edited shows edited status', () => {
+  it('Chat - Message edited shows edited status', () => {
     cy.contains(randomNumber)
       .siblings('[data-cy=message-edited]')
       .should('contain', '(edited)')
@@ -63,7 +60,7 @@ describe('Chat Features Tests', () => {
     cy.get('#glyph-toggle').click()
   })
 
-  it.skip('Chat - Copy paste text', () => {
+  it('Chat - Copy paste text', () => {
     //Sending another random message to validate the scenario
     cy.chatFeaturesSendMessage(randomTextToCopy)
 

--- a/cypress/integration/chat-pair-features.js
+++ b/cypress/integration/chat-pair-features.js
@@ -1,27 +1,25 @@
 const faker = require('faker')
 const recoverySeedAccountOne =
-  'lonely dust spring orphan pulp angry mystery bracket pottery metal bright damp{enter}'
+  'memory cherry add return that phrase suit plate ladder earth people gravity{enter}'
 const recoverySeedAccountTwo =
-  'urban clump gather december smoke upset chicken spice steel hope doll pigeon{enter}'
+  'position few settle fold sister transfer song speed million congress acoustic version{enter}'
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 const randomMessage = faker.lorem.sentence() // generate random sentence
 const imageLocalPath = 'cypress/fixtures/images/logo.png'
 const fileLocalPath = 'cypress/fixtures/test-file.txt'
+const textReply = 'This is a reply to the message'
 let glyphURL, imageURL, fileURL
 
 describe('Chat features with two accounts', () => {
-  before(() => {
+  it('Ensure chat window from first account is displayed', () => {
     //Import first account
     cy.importAccount(randomPIN, recoverySeedAccountOne)
-  })
-
-  it('Ensure chat window from first account is displayed', () => {
     //Validate Chat Screen is loaded
     cy.contains('Chat User A', { timeout: 240000 }).should('be.visible')
   })
 
   it('Send message to user B', () => {
-    cy.waitForMessagesToLoad()
+    cy.goToConversation('Chat User B')
     cy.chatFeaturesSendMessage(randomMessage)
     cy.contains(randomMessage).last().scrollIntoView().should('be.visible')
   })
@@ -86,13 +84,42 @@ describe('Chat features with two accounts', () => {
 
   it('Assert message received from user A', () => {
     //Adding assertion to validate that messages are displayed
-    cy.waitForMessagesToLoad()
+    cy.goToConversation('Chat User A')
     cy.contains(randomMessage).last().scrollIntoView().should('be.visible')
   })
 
   it('Message not sent by same user cannot be edited', () => {
     cy.contains(randomMessage).last().as('lastmessage')
     cy.validateOptionNotInContextMenu('@lastmessage', 'Edit')
+  })
+
+  it('User should be able to reply a message', () => {
+    cy.contains(randomMessage).last().as('lastmessage')
+    cy.chatFeaturesReplyMessage('Chat User A', '@lastmessage', textReply)
+  })
+
+  it('Reply to message shows as collapsed first', () => {
+    //reply path
+    cy.getReply(randomMessage)
+    cy.get('@reply-preview')
+      .scrollIntoView()
+      .should('contain', 'Reply from Chat User B')
+  })
+
+  it('Reply to message is displayed by clicking on it', () => {
+    cy.getReply(randomMessage)
+    cy.get('@reply-preview').click()
+    cy.get('[data-cy="reply-message"]').should('have.text', textReply)
+    cy.get('[data-cy="reply-close"]')
+      .should('be.visible')
+      .should('contain', 'Collapse')
+  })
+
+  it('Reply to message is not displayed when clicking on Collapse', () => {
+    cy.get('[data-cy="reply-close"]').click()
+    cy.get('[data-cy="reply-message"]').should('not.exist')
+    cy.getReply(randomMessage)
+    cy.get('@reply-preview').should('be.visible')
   })
 
   it('Assert emoji received from user A', () => {
@@ -139,5 +166,10 @@ describe('Chat features with two accounts', () => {
       .then(($text) => {
         expect($text).to.match(/d+[hour[s]? |minute[s]? |second[s]?]\s/)
       })
+  })
+
+  it('User should be able to reply without first clicking into the chat bar - Chat User C', () => {
+    cy.goToConversation('Chat User C')
+    cy.get('[data-cy=editable-input]').should('be.visible').type(randomMessage)
   })
 })

--- a/cypress/integration/chat-text-validations.js
+++ b/cypress/integration/chat-text-validations.js
@@ -1,21 +1,17 @@
 const faker = require('faker')
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 const recoverySeed =
-  'veteran intact there despair unique trouble season rebel sort file unit hard{enter}'
+  'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}'
 let longMessage = faker.random.alphaNumeric(2060) // generate random alphanumeric text with 2060 chars
 
 describe('Chat Text Validations', () => {
-  before(() => {
+  it('Message with more than 2048 chars - Counter get reds', () => {
     //Import account
     cy.importAccount(randomPIN, recoverySeed)
 
     //Ensure messages are displayed before starting
     cy.contains('cypress', { timeout: 180000 }).should('be.visible')
-    cy.get('.toggle-sidebar').should('be.visible').click()
-  })
-
-  it('Message with more than 2048 chars - Counter get reds', () => {
-    cy.waitForMessagesToLoad()
+    cy.goToConversation('cypress friend')
     cy.get('[data-cy=editable-input]')
       .should('be.visible')
       .trigger('input')

--- a/cypress/integration/chat-top-toolbar.js
+++ b/cypress/integration/chat-top-toolbar.js
@@ -1,20 +1,16 @@
 const faker = require('faker')
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 const recoverySeed =
-  'veteran intact there despair unique trouble season rebel sort file unit hard{enter}'
+  'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}'
 
 describe('Chat Toolbar Tests', () => {
-  before(() => {
+  it('Chat - Toolbar - Validate audio icon is displayed', () => {
     //Import account
     cy.importAccount(randomPIN, recoverySeed)
 
     //Ensure messages are displayed before starting
     cy.contains('cypress', { timeout: 180000 }).should('be.visible')
-    cy.get('.toggle-sidebar').should('be.visible').click()
-  })
-
-  it('Chat - Toolbar - Validate audio icon is displayed', () => {
-    cy.waitForMessagesToLoad()
+    cy.goToConversation('cypress friend')
     cy.hoverOnActiveIcon('[data-cy=toolbar-enable-audio]')
   })
 

--- a/cypress/integration/import-account.js
+++ b/cypress/integration/import-account.js
@@ -24,7 +24,7 @@ describe('Import Account Validations', () => {
       .should('be.visible')
       .click()
       .type(
-        'veteran intact there despair unique trouble season rebel sort file unit hard{enter}',
+        'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}',
         { log: false },
         { force: true },
       )

--- a/cypress/integration/localstorage-validations.js
+++ b/cypress/integration/localstorage-validations.js
@@ -1,7 +1,7 @@
 const faker = require('faker')
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 const recoverySeed =
-  'veteran intact there despair unique trouble season rebel sort file unit hard{enter}'
+  'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}'
 
 describe('Verify passphrase does not get stored in localstorage', () => {
   before(() => {

--- a/cypress/integration/mobiles-responsiveness.js
+++ b/cypress/integration/mobiles-responsiveness.js
@@ -8,7 +8,7 @@ const filepathCorrect = 'images/logo.png'
 const randomNumber = faker.datatype.number() // generate random number
 const randomMessage = faker.lorem.sentence() // generate random sentence
 const recoverySeed =
-  'veteran intact there despair unique trouble season rebel sort file unit hard{enter}'
+  'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}'
 
 describe.skip('Run responsiveness tests on several devices', () => {
   Cypress.config('pageLoadTimeout', 180000) //adding more time for pageLoadTimeout only for this spec
@@ -54,11 +54,8 @@ describe.skip('Run responsiveness tests on several devices', () => {
       //Validate profile name displayed
       cy.chatFeaturesProfileName('cypress')
 
-      // Click on hamburger menu if width < height
-      cy.get('.toggle-sidebar').should('be.visible').click()
-
       //Validate message and emojis are sent
-      cy.waitForMessagesToLoad()
+      cy.goToConversation('cypress friend')
       cy.chatFeaturesSendMessage(randomMessage)
       cy.chatFeaturesSendEmoji('[title="smile"]', '😄')
 

--- a/cypress/integration/pin-unlock-validations.js
+++ b/cypress/integration/pin-unlock-validations.js
@@ -1,6 +1,6 @@
 const faker = require('faker')
 const userPassphrase =
-  'veteran intact there despair unique trouble season rebel sort file unit hard'
+  'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower'
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 
 describe('Unlock pin should be persisted when store pin is enabled', () => {

--- a/cypress/integration/privacy-page-toggles.js
+++ b/cypress/integration/privacy-page-toggles.js
@@ -9,15 +9,13 @@ let toggleStatusProfile = []
 
 describe('Privacy Page Toggles Tests', () => {
   Cypress.on('uncaught:exception', (err, runnable) => false) // to bypass Module build failed: Error: ENOENT: No such file or directory issue randomly presented
-  before(() => {
+
+  it('Privacy page - Verify all non-locked toggles switches work as should', () => {
     //Adding pin to continue to toggles switches screen
     cy.createAccountPINscreen(randomPIN)
 
     //Create or Import account selection screen
     cy.createAccountSecondScreen()
-  })
-
-  it('Privacy page - Verify all non-locked toggles switches work as should', () => {
     //Validating each toggle, checking status is correct after clicking them.
     //Finally, saving values into an array for later comparison
     cy.get('.switch-button', { timeout: 30000 }).each(($btn, index, $List) => {

--- a/cypress/integration/snapshots-test.js
+++ b/cypress/integration/snapshots-test.js
@@ -1,7 +1,7 @@
 const faker = require('faker')
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 const recoverySeed =
-  'atom sure lecture jungle capital adjust mango increase pizza destroy entire second'
+  'skin hotel finger toe face pill rather age acid ticket demise insane'
 const randomName = faker.internet.userName(name) // generate random name
 const randomStatus = faker.lorem.word() // generate random status
 


### PR DESCRIPTION
**What this PR does** 📖
- Created the tests required for tickets AP-1135 and AP-1136 in chat-pair-features.js
- Created new cypress commands for handling replies and context menu selection
- Created and implemented if needed, a new cypress command goToConversation which makes the previous wait for messages to load no longer needed
- Removed the click to hamburger button from cypress tests when chat page is loaded since is no longer needed now with the new cypress command goToConversation
- Adding data-cy attributes for is connected chat footer, message replies, friends and sidebar buttons
- Replacing satellite accounts in cypress tests with new accounts, due to the textile api key recent change
- Moving actions from before hooks into it blocks inside cypress tests, in order to have the availability to retry executing if account import process fails
- Unskipped chat features tests that are no longer failing

**Which issue(s) this PR fixes** 🔨
AP-1135 and AP-1136

**Special notes for reviewers** 🗒️

**Additional comments** 🎤

New tests added:
Chat Pair Features Cypress Video:
https://user-images.githubusercontent.com/35935591/161207132-d92cee5f-2c51-42fb-9d7a-92c09762e99c.mp4

Specs now fixed:

Chat Features Cypress Video:
https://user-images.githubusercontent.com/35935591/161207124-57d6c0cd-4941-4496-9b62-ef01fd1ba094.mp4

Chat Top Toolbar Cypress Video:
https://user-images.githubusercontent.com/35935591/161207160-5395a3ea-3d26-446c-9dae-6c5540ccfc86.mp4

Chat Text Validations Cypress Video:
https://user-images.githubusercontent.com/35935591/161207247-aa36e203-de10-470e-9c5d-2d2378e075b8.mp4

Pin Unlock Validations Cypress Video:
https://user-images.githubusercontent.com/35935591/161207309-a506914e-1332-442d-8cf2-deb15499e48a.mp4



