### PR TITLE
test(cypress): small improvements to cypress scripts

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,7 +1,7 @@
 {
   "projectId": "4offi6",
   "baseUrl": "http://localhost:3000",
-  "numTestsKeptInMemory": 1,
+  "numTestsKeptInMemory": 0,
   "pageLoadTimeout": 120000,
   "defaultCommandTimeout": 10000,
   "retries": 2

--- a/cypress/integration/chat-features.js
+++ b/cypress/integration/chat-features.js
@@ -8,7 +8,7 @@ const recoverySeed =
   'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}'
 let imageURL
 
-describe.skip('Chat Features Tests', () => {
+describe('Chat Features Tests', () => {
   it('Chat - Send message on chat', () => {
     //Import account
     cy.importAccount(randomPIN, recoverySeed)
@@ -129,7 +129,7 @@ describe.skip('Chat Features Tests', () => {
         })
       })
     //Validating that preview of image is displayed and matches with image filename copied from clipboard
-    cy.get('.file-item').should('be.visible')
+    cy.get('.file-item').should('exist')
     cy.get('.file-info > .title').should('contain', 'logo.png')
   })
 })

--- a/cypress/integration/chat-pair-features.js
+++ b/cypress/integration/chat-pair-features.js
@@ -10,7 +10,7 @@ const fileLocalPath = 'cypress/fixtures/test-file.txt'
 const textReply = 'This is a reply to the message'
 let glyphURL, imageURL, fileURL
 
-describe.skip('Chat features with two accounts', () => {
+describe('Chat features with two accounts', () => {
   it('Ensure chat window from first account is displayed', () => {
     //Import first account
     cy.importAccount(randomPIN, recoverySeedAccountOne)
@@ -21,7 +21,7 @@ describe.skip('Chat features with two accounts', () => {
   it('Send message to user B', () => {
     cy.goToConversation('Chat User B')
     cy.chatFeaturesSendMessage(randomMessage)
-    cy.contains(randomMessage).last().scrollIntoView().should('be.visible')
+    cy.contains(randomMessage).last().scrollIntoView().should('exist')
   })
 
   it('Send emoji to user B', () => {
@@ -50,7 +50,7 @@ describe.skip('Chat features with two accounts', () => {
     cy.get('[data-cy=chat-image]')
       .last()
       .scrollIntoView()
-      .should('be.visible')
+      .should('exist')
       .invoke('attr', 'src')
       .then((imgSrcValue) => {
         imageURL = imgSrcValue
@@ -66,7 +66,7 @@ describe.skip('Chat features with two accounts', () => {
     cy.get('[data-cy=chat-file]')
       .last()
       .scrollIntoView()
-      .should('be.visible')
+      .should('exist')
       .invoke('attr', 'href')
       .then((fileSrcValue) => {
         fileURL = fileSrcValue
@@ -85,7 +85,7 @@ describe.skip('Chat features with two accounts', () => {
   it('Assert message received from user A', () => {
     //Adding assertion to validate that messages are displayed
     cy.goToConversation('Chat User A')
-    cy.contains(randomMessage).last().scrollIntoView().should('be.visible')
+    cy.contains(randomMessage).last().scrollIntoView().should('exist')
   })
 
   it('Message not sent by same user cannot be edited', () => {
@@ -111,15 +111,15 @@ describe.skip('Chat features with two accounts', () => {
     cy.get('@reply-preview').click()
     cy.get('[data-cy="reply-message"]').should('have.text', textReply)
     cy.get('[data-cy="reply-close"]')
-      .should('be.visible')
+      .should('exist')
       .should('contain', 'Collapse')
   })
 
   it('Reply to message is not displayed when clicking on Collapse', () => {
-    cy.get('[data-cy="reply-close"]').click()
+    cy.get('[data-cy="reply-close"]').scrollIntoView().click()
     cy.get('[data-cy="reply-message"]').should('not.exist')
     cy.getReply(randomMessage)
-    cy.get('@reply-preview').should('be.visible')
+    cy.get('@reply-preview').should('exist').scrollIntoView()
   })
 
   it('Assert emoji received from user A', () => {
@@ -141,7 +141,7 @@ describe.skip('Chat features with two accounts', () => {
     cy.get('[data-cy=chat-image]')
       .last()
       .scrollIntoView()
-      .should('be.visible')
+      .should('exist')
       .invoke('attr', 'src')
       .then((imageSecondAccountSrc) => {
         expect(imageSecondAccountSrc).to.be.eq(imageURL)
@@ -152,7 +152,7 @@ describe.skip('Chat features with two accounts', () => {
     cy.get('[data-cy=chat-file]')
       .last()
       .scrollIntoView()
-      .should('be.visible')
+      .should('exist')
       .invoke('attr', 'href')
       .then((fileSecondAccountSrc) => {
         expect(fileSecondAccountSrc).to.be.eq(fileURL)

--- a/cypress/integration/chat-text-validations.js
+++ b/cypress/integration/chat-text-validations.js
@@ -4,7 +4,7 @@ const recoverySeed =
   'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}'
 let longMessage = faker.random.alphaNumeric(2060) // generate random alphanumeric text with 2060 chars
 
-describe.skip('Chat Text Validations', () => {
+describe('Chat Text Validations', () => {
   it('Message with more than 2048 chars - Counter get reds', () => {
     //Import account
     cy.importAccount(randomPIN, recoverySeed)
@@ -44,6 +44,7 @@ describe.skip('Chat Text Validations', () => {
     cy.get('[data-cy=editable-input]').trigger('input').clear().type(' ')
     cy.validateCharlimit('1/2048', false)
     cy.get('[data-cy=editable-input]').clear()
+    cy.validateCharlimit('0/2048', false)
   })
 
   it('Chat Text Validation - Emoji counts only for 1 char', () => {

--- a/cypress/integration/chat-top-toolbar.js
+++ b/cypress/integration/chat-top-toolbar.js
@@ -3,7 +3,7 @@ const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate
 const recoverySeed =
   'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}'
 
-describe.skip('Chat Toolbar Tests', () => {
+describe('Chat Toolbar Tests', () => {
   it('Chat - Toolbar - Validate audio icon is displayed', () => {
     //Import account
     cy.importAccount(randomPIN, recoverySeed)

--- a/cypress/integration/mobiles-responsiveness.js
+++ b/cypress/integration/mobiles-responsiveness.js
@@ -10,7 +10,7 @@ const randomMessage = faker.lorem.sentence() // generate random sentence
 const recoverySeed =
   'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}'
 
-describe.skip('Run responsiveness tests on several devices', () => {
+describes.skip('Run responsiveness tests on several devices', () => {
   Cypress.config('pageLoadTimeout', 180000) //adding more time for pageLoadTimeout only for this spec
   Cypress.on('uncaught:exception', (err, runnable) => false) // to bypass Module build failed: Error: ENOENT: No such file or directory issue randomly presented
   data.allDevices.forEach((item) => {
@@ -33,9 +33,9 @@ describe.skip('Run responsiveness tests on several devices', () => {
       //User Image Input
       cy.createAccountAddImage(filepathCorrect)
       cy.get('[data-cy=cropper-container]', { timeout: 60000 })
-        .should('be.visible')
+        .should('exist')
         .then(() => {
-          cy.contains('Crop', { timeout: 30000 }).should('be.visible').click()
+          cy.contains('Crop', { timeout: 30000 }).should('exist').click()
         })
 
       //Finishing Account Creation

--- a/cypress/integration/mobiles-responsiveness.js
+++ b/cypress/integration/mobiles-responsiveness.js
@@ -10,7 +10,7 @@ const randomMessage = faker.lorem.sentence() // generate random sentence
 const recoverySeed =
   'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}'
 
-describes.skip('Run responsiveness tests on several devices', () => {
+describe.skip('Run responsiveness tests on several devices', () => {
   Cypress.config('pageLoadTimeout', 180000) //adding more time for pageLoadTimeout only for this spec
   Cypress.on('uncaught:exception', (err, runnable) => false) // to bypass Module build failed: Error: ENOENT: No such file or directory issue randomly presented
   data.allDevices.forEach((item) => {

--- a/cypress/integration/pin-unlock-validations.js
+++ b/cypress/integration/pin-unlock-validations.js
@@ -50,7 +50,7 @@ describe('Unlock pin should be persisted when store pin is enabled', () => {
     })
   })
 
-  it.skip('Import Account with store pin disabled', () => {
+  it('Import Account with store pin disabled', () => {
     //Go to URL, add a PIN and make sure that toggle for save pin is disabled
     cy.importAccountPINscreen(randomPIN, false, false)
 
@@ -68,7 +68,7 @@ describe('Unlock pin should be persisted when store pin is enabled', () => {
     })
   })
 
-  it.skip('Import Account with store pin enabled', () => {
+  it('Import Account with store pin enabled', () => {
     //Go to URL, add a PIN and make sure that toggle for save pin is enabled
     cy.importAccountPINscreen(randomPIN, true, false)
 

--- a/cypress/integration/privacy-page-toggles.js
+++ b/cypress/integration/privacy-page-toggles.js
@@ -43,7 +43,7 @@ describe('Privacy Page Toggles Tests', () => {
     })
   })
 
-  it.skip('Privacy page - Verify user can still proceed after adjusting switches', () => {
+  it('Privacy page - Verify user can still proceed after adjusting switches', () => {
     //Click on next
     cy.get('#custom-cursor-area').click()
 
@@ -64,7 +64,7 @@ describe('Privacy Page Toggles Tests', () => {
     }).click()
   })
 
-  it.skip('Profile - Verify the toggles user added when signing up are on the same status when user goes to settings', () => {
+  it('Profile - Verify the toggles user added when signing up are on the same status when user goes to settings', () => {
     cy.contains('Privacy').click()
     //Storing the values from toggle switches status of Settings screen into an array
     cy.get('.switch-button')
@@ -83,7 +83,7 @@ describe('Privacy Page Toggles Tests', () => {
       })
   })
 
-  it.skip('Profile - Verify user can’t update the register name publicly toggle on settings', () => {
+  it('Profile - Verify user can’t update the register name publicly toggle on settings', () => {
     //Identify the first switch button and ensure that is locked
     cy.get('.switch-button').first().should('have.class', 'locked')
   })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -282,11 +282,11 @@ Cypress.Commands.add('chatFeaturesSendMessage', (message) => {
     .should('be.visible')
     .trigger('input')
     .type(message)
-  cy.get('[data-cy=editable-input]').type('{enter}') // sending text message
+  cy.get('[data-cy=send-message]').click() //sending text message
   cy.contains(message, { timeout: 15000 })
     .last()
     .scrollIntoView()
-    .should('be.visible')
+    .should('exist')
 })
 
 Cypress.Commands.add(
@@ -294,21 +294,21 @@ Cypress.Commands.add(
   (receiver, selector, message) => {
     cy.selectContextMenuOption(selector, 'Reply')
     cy.get('.is-chatbar-reply')
-      .should('be.visible')
+      .should('exist')
       .should('include.text', 'Reply to')
       .should('include.text', receiver)
-    cy.get('[data-cy=editable-input]')
-      .should('be.visible')
-      .trigger('input')
-      .type(message)
-    cy.get('[data-cy=editable-input]').type('{enter}') // sending text message
+      .then(() => {
+        cy.get('[data-cy=editable-input]')
+          .should('be.visible')
+          .trigger('input')
+          .type(message)
+        cy.get('[data-cy=send-message]').click() // sending text message
+      })
   },
 )
 
 Cypress.Commands.add('getReply', (messageReplied) => {
   cy.contains(messageReplied)
-    .last()
-    .scrollIntoView()
     .parent()
     .parent()
     .find('[data-cy=reply-preview]')
@@ -318,14 +318,11 @@ Cypress.Commands.add('getReply', (messageReplied) => {
 Cypress.Commands.add('chatFeaturesSendEmoji', (emojiLocator, emojiValue) => {
   cy.get('#emoji-toggle > .control-icon').click()
   cy.get(emojiLocator).click() // sending emoji
-  cy.get('[data-cy=editable-input]')
-    .should('be.visible')
-    .trigger('input')
-    .type('{enter}')
+  cy.get('[data-cy=send-message]').click() //sending emoji message
   cy.contains(emojiValue)
     .last()
     .scrollIntoView({ timeout: 20000 })
-    .should('be.visible')
+    .should('exist')
 })
 
 Cypress.Commands.add(
@@ -334,15 +331,16 @@ Cypress.Commands.add(
     cy.contains(messageToEdit)
       .last()
       .scrollIntoView()
-      .should('be.visible')
+      .should('exist')
       .rightclick()
     cy.contains('Edit Message').click()
     cy.get('[data-cy=edit-message-input]')
-      .should('be.visible')
+      .scrollIntoView()
+      .should('exist')
       .trigger('input')
       .type(messageEdited) // editing message
     cy.get('[data-cy=edit-message-input]').type('{enter}')
-    cy.contains(messageEdited).last().scrollIntoView().should('be.visible')
+    cy.contains(messageEdited).last().scrollIntoView().should('exist')
   },
 )
 
@@ -350,18 +348,18 @@ Cypress.Commands.add('chatFeaturesSendGlyph', () => {
   cy.get('#glyph-toggle').click()
   cy.get('.pack-list > .is-text').should('contain', 'Try using some glyphs')
   cy.get('.glyph-item').first().click()
-  cy.get('[data-cy=editable-input]').trigger('input').type('{enter}')
+  cy.get('[data-cy=send-message]').click() //sending glyph message
 })
 
 Cypress.Commands.add('chatFeaturesSendImage', (imagePath) => {
   cy.get('#quick-upload').selectFile(imagePath, {
     force: true,
   })
-  cy.get('.file-item', { timeout: 30000 }).should('be.visible')
+  cy.get('.file-item', { timeout: 30000 }).should('exist')
   cy.get('.file-info > .title').should('contain', 'logo.png')
   cy.contains('Scanning', { timeout: 120000 }).should('not.exist')
-  cy.get('.thumbnail').should('be.visible')
-  cy.get('[data-cy=editable-input]').trigger('input').type('{enter}')
+  cy.get('.thumbnail').should('exist')
+  cy.get('[data-cy=send-message]').click() //sending image message
   cy.get('.thumbnail', { timeout: 120000 }).should('not.exist')
 })
 
@@ -369,10 +367,10 @@ Cypress.Commands.add('chatFeaturesSendFile', (filePath) => {
   cy.get('#quick-upload').selectFile(filePath, {
     force: true,
   })
-  cy.get('.file-item').should('be.visible')
+  cy.get('.file-item').should('exist')
   cy.get('.file-info > .title').should('contain', 'test-file.txt')
   cy.get('.preview', { timeout: 120000 }).should('exist')
-  cy.get('[data-cy=editable-input]').trigger('input').type('{enter}')
+  cy.get('[data-cy=send-message]').click() //sending file message
   cy.get('.preview', { timeout: 120000 }).should('not.exist')
 })
 
@@ -478,7 +476,7 @@ Cypress.Commands.add('closeModal', (locator) => {
 })
 
 Cypress.Commands.add('goToLastGlyphOnChat', () => {
-  cy.get('[data-cy=chat-glyph]').last().scrollIntoView().should('be.visible')
+  cy.get('[data-cy=chat-glyph]').last().scrollIntoView().should('exist')
 })
 
 Cypress.Commands.add('validateCharlimit', (text, assert) => {


### PR DESCRIPTION
**What this PR does** 📖
- Removing skipped instruction for all cypress tests except mobiles-responsiveness and snapshots
- Replacing should.be.visible for should.exist in chat elements for which cypress takes some time to scroll into view
- Small change on chat text validations for cypress test for the space/emoji chars count
- Changing the type enter for clicking into send message for cypress tests, since sometimes cypress fail when sending type command twice
- Small changes on two cypress commands for replies
- Changing numOfTestsToKeepInMemory to zero since is the setup used locally

**Which issue(s) this PR fixes** 🔨
None

**Special notes for reviewers** 🗒️
Sending this as a draft to see if the tests work in CI

**Additional comments** 🎤
