### PR TITLE
fix(chat): rclick options for non-embeddable images

### DIFF
--- a/components/views/chat/message/Message.vue
+++ b/components/views/chat/message/Message.vue
@@ -11,6 +11,7 @@ import { refreshTimestampInterval } from '~/utilities/Messaging'
 import { toHTML } from '~/libraries/ui/Markdown'
 import { ContextMenuItem } from '~/store/ui/types'
 import { isMimeEmbeddableImage } from '~/utilities/FileType'
+import { FILE_TYPE } from '~/libraries/Files/types/file'
 
 export default Vue.extend({
   components: {
@@ -92,6 +93,13 @@ export default Vue.extend({
         this.message.type === 'file' &&
         isMimeEmbeddableImage(this.message.payload.type)
       ) {
+        // remove copy from GIF because it copies a still png version
+        if (this.message.payload.type === FILE_TYPE.GIF) {
+          return [
+            ...mainList,
+            { text: this.$t('context.save_img'), func: this.saveImage },
+          ]
+        }
         return [
           ...mainList,
           { text: this.$t('context.copy_img'), func: this.copyImage },
@@ -159,7 +167,7 @@ export default Vue.extend({
      * @description clipboard API only accepts png. if not png, convert via canvas
      */
     async copyImage() {
-      if (this.blob.type !== 'image/png') {
+      if (this.blob?.type !== 'image/png') {
         this.pngBlob = await this.toPng()
       }
       await this.$envinfo.navigator.clipboard.write([

--- a/components/views/chat/message/Message.vue
+++ b/components/views/chat/message/Message.vue
@@ -10,6 +10,7 @@ import { UIMessage, Group } from '~/types/messaging'
 import { refreshTimestampInterval } from '~/utilities/Messaging'
 import { toHTML } from '~/libraries/ui/Markdown'
 import { ContextMenuItem } from '~/store/ui/types'
+import { isMimeEmbeddableImage } from '~/utilities/FileType'
 
 export default Vue.extend({
   components: {
@@ -89,7 +90,7 @@ export default Vue.extend({
       // if image message
       if (
         this.message.type === 'file' &&
-        this.$props.message.payload.type.includes('image')
+        isMimeEmbeddableImage(this.message.payload.type)
       ) {
         return [
           ...mainList,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- context menu was incorrectly showing options for 'copy image' & 'save image` on un-embeddable images
- remove copy image from gifs because it copies a still png

**Which issue(s) this PR fixes** 🔨
AP-1295, AP-1290
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
