### PR TITLE
update(files): fs errors are translation friendly

### DIFF
--- a/components/views/files/controls/Controls.vue
+++ b/components/views/files/controls/Controls.vue
@@ -2,6 +2,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import { mapState } from 'vuex'
+import { TranslateResult } from 'vue-i18n'
 import {
   FolderPlusIcon,
   FilePlusIcon,
@@ -31,7 +32,7 @@ export default Vue.extend({
   data() {
     return {
       text: '' as string,
-      errors: [] as Array<string>,
+      errors: [] as Array<string | TranslateResult>,
     }
   },
   computed: {
@@ -65,7 +66,7 @@ export default Vue.extend({
       try {
         this.$FileSystem.createDirectory({ name: this.text })
       } catch (e: any) {
-        this.errors.push(e?.message ?? '')
+        this.errors.push(this.$t(e?.message))
         this.$store.commit('ui/setIsLoadingFileIndex', false)
         return
       }
@@ -94,7 +95,7 @@ export default Vue.extend({
         ) > this.$Config.personalFilesLimit
       ) {
         this.$store.commit('ui/setIsLoadingFileIndex', false)
-        this.errors.push(this.$t('pages.files.errors.limit') as string)
+        this.errors.push(this.$t('pages.files.errors.storage_limit'))
         return
       }
       // todo - move validation inside of file constructor
@@ -166,16 +167,16 @@ export default Vue.extend({
       this.$emit('forceRender')
 
       if (originalFiles.length !== invalidNameResults.length) {
-        this.errors.push(this.$t('pages.files.errors.invalid_name') as string)
+        this.errors.push(this.$t('pages.files.errors.invalid'))
       }
       if (invalidNameResults.length !== emptyFileResults.length) {
-        this.errors.push(this.$t('pages.files.errors.empty_file') as string)
+        this.errors.push(this.$t('pages.files.errors.file_size'))
       }
       if (emptyFileResults.length !== sameNameResults.length) {
-        this.errors.push(this.$t('pages.files.errors.item_name') as string)
+        this.errors.push(this.$t('pages.files.errors.duplicate_name'))
       }
       if (nsfwResults.length !== files.length) {
-        this.errors.push(this.$t('errors.chat.contains_nsfw') as string)
+        this.errors.push(this.$t('errors.chat.contains_nsfw'))
       }
     },
   },

--- a/components/views/files/rename/Rename.vue
+++ b/components/views/files/rename/Rename.vue
@@ -50,7 +50,7 @@ export default Vue.extend({
       try {
         this.$FileSystem.renameChild(this.ui.renameCurrentName, this.text)
       } catch (e: any) {
-        this.error = e.message
+        this.error = this.$t(e?.message) as string
         return
       }
       this.closeModal()

--- a/libraries/Files/Fil.ts
+++ b/libraries/Files/Fil.ts
@@ -1,4 +1,5 @@
 import { Item } from './abstracts/Item.abstract'
+import { FileSystemErrors } from './errors/Errors'
 
 import { FILE_TYPE } from './types/file'
 
@@ -36,10 +37,13 @@ export class Fil extends Item {
     type?: FILE_TYPE
     thumbnail?: string
   }) {
-    super({ name: name || 'un-named file', liked, shared, modified, id, type })
+    if (!size) {
+      throw new Error(FileSystemErrors.FILE_SIZE)
+    }
+    super({ name, liked, shared, modified, id, type })
     this._file = file || undefined
     this._description = description || ''
-    this._size = size || 0
+    this._size = size
     this._thumbnail = thumbnail || ''
   }
 
@@ -122,6 +126,6 @@ export class Fil extends Item {
    * @param {string} content the content to set the file description to
    */
   set description(content: string) {
-    this._description = `${content || ''}`
+    this._description = content || ''
   }
 }

--- a/libraries/Files/errors/Errors.ts
+++ b/libraries/Files/errors/Errors.ts
@@ -3,13 +3,19 @@ export enum TextileErrors {
 }
 
 export enum FileSystemErrors {
+  // internal
   METHOD_MISSING = 'Method not implemented.',
   RFM_ABSTRACT_ONLY = 'RFM class is Abstract. It can only be extended',
   ITEM_ABSTRACT_ONLY = 'Item class is Abstract. It can only be extended',
-  NO_EMPTY_STRING = 'Item name must be a non empty string',
-  INVALID = 'Item name cannot contain invalid symbols',
-  DUPLICATE_NAME = 'Item with name already exists in this directory',
-  DIR_PARADOX = 'Directory cannot contain itself',
-  DIR_PARENT_PARADOX = 'Directory cannot contain one of its ancestors',
-  LEADING_DOT = 'Item name cannot begin with .',
+  // user facing - Item
+  NO_EMPTY_STRING = 'pages.files.errors.no_empty',
+  INVALID = 'pages.files.errors.invalid',
+  DUPLICATE_NAME = 'pages.files.errors.duplicate_name',
+  LEADING_DOT = 'pages.files.errors.leading_dot',
+  // user facing - Directory
+  DIR_PARADOX = 'pages.files.errors.dir_paradox',
+  DIR_PARENT_PARADOX = 'pages.files.errors.dir_parent_paradox',
+  // user facing - Fil
+  FILE_SIZE = 'pages.files.errors.file_size',
+  LIMIT = 'pages.files.errors.storage_limit',
 }

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -154,13 +154,14 @@ export default {
         cancel: 'Cancel',
       },
       errors: {
-        folder_name:
-          'Please enter a folder name of at least one non-space character',
-        no_slash: 'Folder name cannot contain /',
-        invalid_name: 'Item name cannot contain invalid symbols',
-        empty_file: 'File needs to have a size of 1 byte or greater',
-        item_name: 'Item with name already exists in this directory',
-        limit: 'This upload would exceed your storage limit',
+        no_empty: 'Item name must be a non empty string',
+        leading_dot: 'Item name cannot begin with .',
+        invalid: 'Item name cannot contain invalid symbols',
+        file_size: 'File needs to have a size of 1 byte or greater',
+        duplicate_name: 'Item with name already exists in this directory',
+        storage_limit: 'This upload would exceed your storage limit',
+        dir_paradox: 'Directory cannot contain itself',
+        dir_parent_paradox: 'Directory cannot contain one of its ancestors',
       },
     },
     unlock: {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- change enums to their translation string
- switch all try catch file system calls to translate the received error string, rather than interpret as plain text
- throw file size error from Fil constructor. this won't be triggered at the moment, but later refactoring will use this

**Which issue(s) this PR fixes** 🔨
AP-1294

<!--AP-X-->

**Special notes for reviewers** 🗒️
- This cleans up Directory and item rename errors. Adding a new Fil will still validate in the Controls component. I have a ticket for fixing this later

**Additional comments** 🎤
