### PR TITLE
test(cypress): add tests for glyphs

### DIFF
--- a/components/views/chat/enhancers/glyphs/nav/Nav.html
+++ b/components/views/chat/enhancers/glyphs/nav/Nav.html
@@ -9,6 +9,7 @@
         :key="glyph.url"
         :src="glyph.url"
         :pack="glyph.pack"
+        data-cy="recent-glyph-item"
         :height="32"
         :width="32"
         :sendOnClick="true"

--- a/components/views/chat/enhancers/glyphs/pack/Pack.html
+++ b/components/views/chat/enhancers/glyphs/pack/Pack.html
@@ -1,4 +1,4 @@
-<div class="pack-group">
+<div class="pack-group" data-cy="glyph-pack">
   <div class="pack-title" @click="togglePack">
     <image-icon size="1x" />
     <span>{{ pack.name }}</span>
@@ -10,6 +10,7 @@
       v-for="glyph in pack.stickerURLs"
       :key="glyph"
       :src="glyph"
+      data-cy="pack-glyph-item"
       :pack="pack"
       :sendOnClick="true"
     />

--- a/cypress/integration/chat-glyphs-validations.js
+++ b/cypress/integration/chat-glyphs-validations.js
@@ -1,0 +1,53 @@
+const faker = require('faker')
+const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
+const recoverySeed =
+  'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}'
+
+describe('Chat - Sending Glyphs Tests', () => {
+  it('Send a glyph on chat', () => {
+    //Import account
+    cy.importAccount(randomPIN, recoverySeed)
+
+    //Validate profile name displayed
+    cy.contains('cypress', { timeout: 180000 }).should('be.visible')
+
+    //Validate message is sent
+    cy.goToConversation('cypress friend')
+
+    //Send first glyph from Astrobunny pack
+    cy.chatFeaturesSendGlyph()
+
+    //Assert glyph received
+    cy.goToLastGlyphOnChat()
+  })
+
+  it('Send a glyph after scrolling in the selection screen', () => {
+    //Send fourth glyph from Genshin Impact 2 pack
+    cy.chatFeaturesSendGlyph(6, 3)
+
+    //Assert glyph received
+    cy.goToLastGlyphOnChat()
+  })
+
+  it('Send a glyph from the recents section', () => {
+    //Send a glyph from recents section
+    cy.get('#glyph-toggle').click()
+    cy.get('#glyphs').should('be.visible')
+    cy.get('[data-cy=recent-glyph-item]').first().click()
+    cy.get('[data-cy=send-message]').click() //sending glyph message
+
+    //Assert glyph received
+    cy.goToLastGlyphOnChat()
+  })
+
+  it('Validate glyph pack screen appears', () => {
+    cy.goToLastGlyphOnChat().click()
+    cy.validateGlyphsModal()
+  })
+
+  it('Validate coming soon modal is displayed on glyph pack screen', () => {
+    cy.contains('View Glyph Pack').click()
+    cy.get('[data-cy=modal-cta]').should('be.visible')
+    cy.closeModal('[data-cy=modal-cta]')
+  })
+})

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -344,12 +344,21 @@ Cypress.Commands.add(
   },
 )
 
-Cypress.Commands.add('chatFeaturesSendGlyph', () => {
-  cy.get('#glyph-toggle').click()
-  cy.get('.pack-list > .is-text').should('contain', 'Try using some glyphs')
-  cy.get('.glyph-item').first().click()
-  cy.get('[data-cy=send-message]').click() //sending glyph message
-})
+Cypress.Commands.add(
+  'chatFeaturesSendGlyph',
+  (packIndex = 0, itemIndex = 0) => {
+    cy.get('#glyph-toggle').click()
+    cy.get('#glyphs').should('be.visible')
+    cy.get('[data-cy=glyph-pack]').eq(packIndex).as('glyph-pack')
+    cy.get('@glyph-pack')
+      .scrollIntoView()
+      .find('[data-cy=pack-glyph-item]')
+      .eq(itemIndex)
+      .scrollIntoView()
+      .click()
+    cy.get('[data-cy=send-message]').click() //sending glyph message
+  },
+)
 
 Cypress.Commands.add('chatFeaturesSendImage', (imagePath, filename) => {
   cy.get('#quick-upload').selectFile(imagePath, {


### PR DESCRIPTION
**What this PR does** 📖
- Add cypress tests for glyphs on chats
- Improved cypress command for sending glyphs, so we can pass the pack and item indexes as arguments
- Added data-cy attributes to glyph pack and nav bar elements used in the new cypress test for glyphs

**Which issue(s) this PR fixes** 🔨
AP-635

**Special notes for reviewers** 🗒️
All test specs passing after this change:
![image](https://user-images.githubusercontent.com/35935591/161830417-d0373dcd-178d-443b-9981-e1f2e21625c8.png)

**Additional comments** 🎤
Cypress Video:
https://user-images.githubusercontent.com/35935591/161830470-7b3b6041-8f03-4462-b1d3-af01edcad36d.mp4


