### PR TITLE
fix(files): rework store for files modal

### DIFF
--- a/components/ui/Global/Global.html
+++ b/components/ui/Global/Global.html
@@ -92,12 +92,7 @@
     v-click-outside="() => toggleModal(ModalWindows.CHANGELOG)"
   />
   <UiChatImageOverlay v-if="ui.chatImageOverlay" />
-  <FilesView
-    v-if="ui.filePreview"
-    :fileName="ui.filePreview"
-    @close="closeFilePreview()"
-    @share="share"
-  />
+  <FilesView v-if="ui.filePreview" @close="closeFilePreview()" @share="share" />
   <transition :name="$device.isMobile ? 'slide' : ''">
     <InteractablesQuickProfile v-if="ui.quickProfile" :user="ui.quickProfile" />
   </transition>

--- a/components/ui/Global/Global.html
+++ b/components/ui/Global/Global.html
@@ -91,10 +91,10 @@
     v-if="ui.modals.changelog"
     v-click-outside="() => toggleModal(ModalWindows.CHANGELOG)"
   />
-  <UiChatImageOverlay v-if="ui.chatImageOverlay"></UiChatImageOverlay>
+  <UiChatImageOverlay v-if="ui.chatImageOverlay" />
   <FilesView
     v-if="ui.filePreview"
-    :file="ui.filePreview"
+    :fileName="ui.filePreview"
     @close="closeFilePreview()"
     @share="share"
   />

--- a/components/views/files/view/View.html
+++ b/components/views/files/view/View.html
@@ -1,7 +1,7 @@
 <div id="view-file">
   <div class="file-nav">
     <div class="file-info">
-      <TypographyTitle :text="file.name" :size="6" />
+      <TypographyTitle :text="fileName" :size="6" />
       <TypographyText :text="file.type" :size="6" />
       <TypographyText :text="$filesize(file.size)" :size="6" />
       <TypographyText :text="$dayjs(file.modified).fromNow()" :size="6" />
@@ -49,7 +49,7 @@
     >
       <download-icon size="1x" class="file-icon" />
     </a>
-    <TypographyTitle :size="4" :text="file.name" />
+    <TypographyTitle :size="4" :text="fileName" />
     <TypographySubtitle :size="6" :text="file.type" />
     <TypographySubtitle :text="$filesize(file.size)" :size="6" />
     <TypographySubtitle :text="$dayjs(file.modified).fromNow()" :size="6" />

--- a/components/views/files/view/View.html
+++ b/components/views/files/view/View.html
@@ -1,7 +1,7 @@
 <div id="view-file">
   <div class="file-nav">
     <div class="file-info">
-      <TypographyTitle :text="fileName" :size="6" />
+      <TypographyTitle :text="file.name" :size="6" />
       <TypographyText :text="file.type" :size="6" />
       <TypographyText :text="$filesize(file.size)" :size="6" />
       <TypographyText :text="$dayjs(file.modified).fromNow()" :size="6" />
@@ -49,7 +49,7 @@
     >
       <download-icon size="1x" class="file-icon" />
     </a>
-    <TypographyTitle :size="4" :text="fileName" />
+    <TypographyTitle :size="4" :text="file.name" />
     <TypographySubtitle :size="6" :text="file.type" />
     <TypographySubtitle :text="$filesize(file.size)" :size="6" />
     <TypographySubtitle :text="$dayjs(file.modified).fromNow()" :size="6" />

--- a/components/views/files/view/View.vue
+++ b/components/views/files/view/View.vue
@@ -1,6 +1,6 @@
 <template src="./View.html"></template>
 <script lang="ts">
-import Vue, { PropType } from 'vue'
+import Vue from 'vue'
 import { mapState } from 'vuex'
 import {
   FileIcon,
@@ -23,15 +23,16 @@ export default Vue.extend({
     LinkIcon,
   },
   props: {
-    file: {
-      type: Object as PropType<Fil>,
+    fileName: {
+      type: String,
       required: true,
     },
   },
   data() {
     return {
       load: false as boolean,
-      name: this.file.name as string,
+      file: undefined as Fil | undefined,
+      name: '' as string,
     }
   },
   computed: {
@@ -39,8 +40,12 @@ export default Vue.extend({
   },
   /**
    */
-  async mounted() {
+  async created() {
     this.load = true
+
+    this.file = this.$FileSystem.getChild(this.fileName) as Fil
+    this.name = this.file?.name
+
     // if no file data available, pull encrypted file from textile bucket
     if (!this.file.file) {
       const fsFil: Fil = this.$FileSystem.getChild(this.file.name) as Fil

--- a/components/views/files/view/View.vue
+++ b/components/views/files/view/View.vue
@@ -22,12 +22,6 @@ export default Vue.extend({
     XIcon,
     LinkIcon,
   },
-  props: {
-    fileName: {
-      type: String,
-      required: true,
-    },
-  },
   data() {
     return {
       load: false as boolean,
@@ -43,7 +37,7 @@ export default Vue.extend({
   async created() {
     this.load = true
 
-    this.file = this.$FileSystem.getChild(this.fileName) as Fil
+    this.file = this.$FileSystem.getChild(this.ui.filePreview) as Fil
     this.name = this.file?.name
 
     // if no file data available, pull encrypted file from textile bucket

--- a/pages/files/browse/index.vue
+++ b/pages/files/browse/index.vue
@@ -58,7 +58,7 @@ export default Vue.extend({
      */
     handle(item: Item) {
       if (item instanceof Fil) {
-        this.$store.commit('ui/setFilePreview', item)
+        this.$store.commit('ui/setFilePreview', item.name)
       }
       if (item instanceof Directory) {
         this.fileSystem.openDirectory(item.name)

--- a/plugins/thirdparty/persist.ts
+++ b/plugins/thirdparty/persist.ts
@@ -37,6 +37,7 @@ const commonProperties = [
   'groups.groupSubscriptions',
   'ui.modals',
   'ui.isScrollOver',
+  'ui.filePreview',
 ]
 
 const propertiesNoStorePin = [

--- a/store/ui/mutations.ts
+++ b/store/ui/mutations.ts
@@ -51,8 +51,8 @@ export default {
   fullscreen(state: UIState, fullscreen: boolean) {
     state.fullscreen = fullscreen
   },
-  setFilePreview(state: UIState, file: Fil | undefined) {
-    state.filePreview = file
+  setFilePreview(state: UIState, name: string) {
+    state.filePreview = name
   },
   setChatImageOverlay(state: UIState, image: ImageMessage | undefined) {
     state.chatImageOverlay = image

--- a/store/ui/types.ts
+++ b/store/ui/types.ts
@@ -1,5 +1,4 @@
 import { TranslateResult } from 'vue-i18n'
-import { Fil } from '~/libraries/Files/Fil'
 import { ImageMessage } from '~/types/textile/mailbox'
 import { FileSortEnum } from '~/libraries/Enums/enums'
 import { Glyph } from '~/types/ui/glyph'
@@ -214,8 +213,8 @@ export interface UIState {
   }
   isLoadingFileIndex: boolean
   renameCurrentName?: string
-  filePreview: Fil | undefined
-  chatImageOverlay: ImageMessage | undefined
+  filePreview?: string
+  chatImageOverlay?: ImageMessage
   fileSort: FileSort
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- if you refresh and then open file, it needs to fetch the blob from textile for download. the way state is handled for this modal crashes. PR fixes this crash
- less overhead in store, only keep track of name rather than full Fil

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
