### PR TITLE
fix(search): switch to static timestamps

### DIFF
--- a/components/views/chat/search/result/item/Item.html
+++ b/components/views/chat/search/result/item/Item.html
@@ -9,7 +9,7 @@
   <div class="content">
     <div class="name-container">
       <div class="username">{{ data.user.name }}</div>
-      <div class="timestamp">{{ timestamp }}</div>
+      <div class="timestamp">{{ test }}</div>
     </div>
     <div class="msg">{{ data.payload }}</div>
   </div>

--- a/components/views/chat/search/result/item/Item.html
+++ b/components/views/chat/search/result/item/Item.html
@@ -9,7 +9,7 @@
   <div class="content">
     <div class="name-container">
       <div class="username">{{ data.user.name }}</div>
-      <div class="timestamp">{{ test }}</div>
+      <div class="timestamp">{{ timestamp }}</div>
     </div>
     <div class="msg">{{ data.payload }}</div>
   </div>

--- a/components/views/chat/search/result/item/Item.vue
+++ b/components/views/chat/search/result/item/Item.vue
@@ -19,10 +19,22 @@ export default Vue.extend({
       return hash ? `${this.$Config.textile.browser}/ipfs/${hash}` : ''
     },
     timestamp(): string {
-      return this.$dayjs(this.data.at)
-        .local()
-        .tz(this.getTimezone)
-        .format('MM/DD/YY hh:mma')
+      const msgTimestamp = this.$dayjs(this.data.at)
+      // if today
+      if (this.$dayjs().isSame(msgTimestamp, 'day')) {
+        return `${this.$t('search.result.today')} ${msgTimestamp
+          .local()
+          .tz(this.getTimezone)
+          .format('LT')}`
+      }
+      // if yesterday
+      if (this.$dayjs().diff(msgTimestamp, 'day') <= 1) {
+        return `${this.$t('search.result.yesterday')} ${msgTimestamp
+          .local()
+          .tz(this.getTimezone)
+          .format('LT')}`
+      }
+      return msgTimestamp.local().tz(this.getTimezone).format('L LT')
     },
   },
 })

--- a/components/views/chat/search/result/item/Item.vue
+++ b/components/views/chat/search/result/item/Item.vue
@@ -16,7 +16,7 @@ export default Vue.extend({
       const hash = this.data.user?.profilePicture
       return hash ? `${this.$Config.textile.browser}/ipfs/${hash}` : ''
     },
-    test(): string {
+    timestamp(): string {
       return this.$dayjs(this.data.at)
         .utc()
         .local()

--- a/components/views/chat/search/result/item/Item.vue
+++ b/components/views/chat/search/result/item/Item.vue
@@ -3,7 +3,6 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue'
 import { SearchResultItem } from '~/types/search/search'
-import { refreshTimestampInterval } from '~/utilities/Messaging'
 
 export default Vue.extend({
   props: {
@@ -12,31 +11,18 @@ export default Vue.extend({
       required: true,
     },
   },
-  data() {
-    return {
-      timestamp: this.$dayjs(this.data.at).fromNow() as string,
-      timestampRefreshInterval: undefined,
-    }
-  },
   computed: {
     src(): string {
       const hash = this.data.user?.profilePicture
       return hash ? `${this.$Config.textile.browser}/ipfs/${hash}` : ''
     },
-  },
-  created() {
-    const setTimestamp = (timePassed: string) => {
-      this.timestamp = timePassed
-    }
-
-    this.$data.timestampRefreshInterval = refreshTimestampInterval(
-      this.data.at,
-      setTimestamp,
-      this.$Config.chat.timestampUpdateInterval,
-    )
-  },
-  beforeDestroy() {
-    clearInterval(this.timestampRefreshInterval)
+    test(): string {
+      return this.$dayjs(this.data.at)
+        .utc()
+        .local()
+        .tz(this.$dayjs.tz.guess())
+        .format('MM/DD/YY hh:mma')
+    },
   },
 })
 </script>

--- a/components/views/chat/search/result/item/Item.vue
+++ b/components/views/chat/search/result/item/Item.vue
@@ -2,6 +2,7 @@
 
 <script lang="ts">
 import Vue, { PropType } from 'vue'
+import { mapGetters } from 'vuex'
 import { SearchResultItem } from '~/types/search/search'
 
 export default Vue.extend({
@@ -12,15 +13,15 @@ export default Vue.extend({
     },
   },
   computed: {
+    ...mapGetters('settings', ['getTimezone']),
     src(): string {
       const hash = this.data.user?.profilePicture
       return hash ? `${this.$Config.textile.browser}/ipfs/${hash}` : ''
     },
     timestamp(): string {
       return this.$dayjs(this.data.at)
-        .utc()
         .local()
-        .tz(this.$dayjs.tz.guess())
+        .tz(this.getTimezone)
         .format('MM/DD/YY hh:mma')
     },
   },

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -561,6 +561,8 @@ export default {
       users: 'Users',
       conversations: 'Conversations',
       select_date: 'Select Date',
+      today: 'today',
+      yesterday: 'yesterday',
     },
   },
   media: {

--- a/plugins/local/dayjs.ts
+++ b/plugins/local/dayjs.ts
@@ -4,11 +4,13 @@ import Vue from 'vue'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import duration from 'dayjs/plugin/duration'
+import localizedFormat from 'dayjs/plugin/localizedFormat'
 import timezone from 'dayjs/plugin/timezone'
 import utc from 'dayjs/plugin/utc'
 
 dayjs.extend(relativeTime)
 dayjs.extend(duration)
+dayjs.extend(localizedFormat)
 dayjs.extend(utc)
 dayjs.extend(timezone)
 

--- a/plugins/local/dayjs.ts
+++ b/plugins/local/dayjs.ts
@@ -4,9 +4,13 @@ import Vue from 'vue'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import duration from 'dayjs/plugin/duration'
+import timezone from 'dayjs/plugin/timezone'
+import utc from 'dayjs/plugin/utc'
 
 dayjs.extend(relativeTime)
 dayjs.extend(duration)
+dayjs.extend(utc)
+dayjs.extend(timezone)
 
 declare module 'vue/types/vue' {
   interface Vue {

--- a/store/settings/getters.ts
+++ b/store/settings/getters.ts
@@ -1,0 +1,9 @@
+import { SettingsState } from './types'
+
+const getters = {
+  getTimezone: (state: SettingsState): string => {
+    return state.timezone
+  },
+}
+
+export default getters


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- switch search timestamps to be static, rather than relative to current time. more in line with figma
  - https://www.figma.com/file/DSRWqZWdeElrEzH64y57qf/Search-Filter?node-id=43%3A1497
- based on timezone in store

**Which issue(s) this PR fixes** 🔨
AP-1359
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
🟢 I like these better than the relative timestamps in chat. Is that open for discussion? Would like to get some other opinions