### PR TITLE
fix(mobile): hide virtual keyboard when scroll

### DIFF
--- a/components/ui/Chat/Scroll/Scroll.html
+++ b/components/ui/Chat/Scroll/Scroll.html
@@ -1,7 +1,7 @@
 <div
   :class="classObject"
   ref="scrollRef"
-  v-on:scroll="onScrolled"
+  v-on:scroll="onScrolled(); hideKeyboard();"
   v-scroll-lock="true"
 >
   <div ref="scrollContent" class="chat-scroll-content">

--- a/components/ui/Chat/Scroll/Scroll.vue
+++ b/components/ui/Chat/Scroll/Scroll.vue
@@ -102,6 +102,13 @@ export default Vue.extend({
       }
     },
     /**
+     * @method hideKeyboard
+     * @description hide virtual keyboard on mobile
+     */
+    hideKeyboard() {
+      document.activeElement.blur()
+    },
+    /**
      * @method onScrolled DocsTODO
      * @description
      * @example


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
with mobile on the chat page, when the user scrolls, the virtual keyboard will be hidden.
**Which issue(s) this PR fixes** 🔨
AP-1309
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
