### PR TITLE
fix(chat): hide action icons if message is editing status

### DIFF
--- a/components/views/chat/message/Message.html
+++ b/components/views/chat/message/Message.html
@@ -23,7 +23,7 @@
       <TypographyText :text="timestamp" />
     </div>
     <MessageActions
-      v-if="!hideActions"
+      v-if="!hideActions && !messageEdit"
       :setReplyChatbarContent="setReplyChatbarContent"
       :emojiReaction="emojiReaction"
       :editMessage="editMessage"


### PR DESCRIPTION
**What this PR does** 📖
hide action icons if message is editing status
**Which issue(s) this PR fixes** 🔨

AP-1358
