### PR TITLE
feat(csam): add toggle for csam scan and save info to textile

### DIFF
--- a/components/views/settings/pages/privacy/Privacy.html
+++ b/components/views/settings/pages/privacy/Privacy.html
@@ -33,7 +33,14 @@
       <InteractablesSwitch v-model="displayCurrentActivity" />
     </SettingsUnit>
   </div>
-
+  <div class="columns is-desktop">
+    <SettingsUnit
+      :title="$t('pages.privacy.consentsScan.title')"
+      :text="$t('pages.privacy.consentsScan.subtitle')"
+    >
+      <InteractablesSwitch v-model="consentsScan" />
+    </SettingsUnit>
+  </div>
   <div class="columns is-desktop">
     <SettingsUnit
       :title="$t('pages.privacy.serverType.title')"

--- a/components/views/settings/pages/privacy/Privacy.html
+++ b/components/views/settings/pages/privacy/Privacy.html
@@ -35,10 +35,10 @@
   </div>
   <div class="columns is-desktop">
     <SettingsUnit
-      :title="$t('pages.privacy.consentsScan.title')"
-      :text="$t('pages.privacy.consentsScan.subtitle')"
+      :title="$t('pages.privacy.consentScan.title')"
+      :text="$t('pages.privacy.consentScan.subtitle')"
     >
-      <InteractablesSwitch v-model="consentsScan" />
+      <InteractablesSwitch v-model="consentScan" />
     </SettingsUnit>
   </div>
   <div class="columns is-desktop">

--- a/components/views/settings/pages/privacy/index.vue
+++ b/components/views/settings/pages/privacy/index.vue
@@ -76,6 +76,14 @@ export default Vue.extend({
         return this.settings.embeddedLinks
       },
     },
+    consentsScan: {
+      set(state) {
+        this.$store.commit('settings/setConsentsScan', state)
+      },
+      get() {
+        return this.settings.consentsScan
+      },
+    },
     displayCurrentActivity: {
       set(state) {
         this.$store.commit('settings/displayCurrentActivity', state)

--- a/components/views/settings/pages/privacy/index.vue
+++ b/components/views/settings/pages/privacy/index.vue
@@ -76,12 +76,12 @@ export default Vue.extend({
         return this.settings.embeddedLinks
       },
     },
-    consentsScan: {
+    consentScan: {
       set(state) {
-        this.$store.commit('settings/setConsentsScan', state)
+        this.$store.commit('settings/setConsentScan', state)
       },
       get() {
-        return this.settings.consentsScan
+        return this.settings.consentScan
       },
     },
     displayCurrentActivity: {

--- a/components/views/settings/pages/privacy/index.vue
+++ b/components/views/settings/pages/privacy/index.vue
@@ -78,7 +78,7 @@ export default Vue.extend({
     },
     consentScan: {
       set(state) {
-        this.$store.commit('settings/setConsentScan', state)
+        this.$store.dispatch('settings/setConsentScan', state)
       },
       get() {
         return this.settings.consentScan

--- a/libraries/Textile/TextileManager.ts
+++ b/libraries/Textile/TextileManager.ts
@@ -1,5 +1,6 @@
 import { Bucket } from '../Files/remote/textile/Bucket'
 import { MetadataManager } from './MetadataManager'
+import { UserInfoManager } from './UserManager'
 import IdentityManager from '~/libraries/Textile/IdentityManager'
 import { MailboxManager } from '~/libraries/Textile/MailboxManager'
 import {
@@ -19,6 +20,7 @@ export default class TextileManager {
   bucket?: Bucket
   groupChatManager?: GroupChatManager
   metadataManager?: MetadataManager
+  userInfoManager?: UserInfoManager
 
   constructor() {
     this.identityManager = new IdentityManager()
@@ -89,6 +91,10 @@ export default class TextileManager {
     // MetadataManager initializes itself during the creation
     this.metadataManager = new MetadataManager(textile)
     await this.metadataManager.init()
+
+    // UserInfoManager initializes itself during the creation
+    this.userInfoManager = new UserInfoManager(textile)
+    await this.userInfoManager.init()
   }
 
   /**

--- a/libraries/Textile/UserManager.ts
+++ b/libraries/Textile/UserManager.ts
@@ -1,0 +1,121 @@
+import { Query, ThreadID } from '@textile/hub'
+import { userinfoSchema } from './schema'
+import { TextileInitializationData } from '~/types/textile/manager'
+import Crypto from '~/libraries/Crypto/Crypto'
+import { UserdataFromThread } from '~/types/textile/user'
+
+const CollectionName = 'userInfo'
+
+export class UserInfoManager {
+  textile: TextileInitializationData
+  private _threadID?: ThreadID
+
+  constructor(textile: TextileInitializationData) {
+    this.textile = textile
+  }
+
+  /**
+   * @method init
+   * Initialize the userinfo manager
+   */
+  async init() {
+    this._threadID = await this.getThreadID()
+    await this.createCollection()
+  }
+
+  /**
+   * @method threadID
+   * Get the thread id of the user data for current user
+   * @returns returns the thread id of the user data for the current user
+   */
+  get threadID(): ThreadID {
+    if (!this._threadID) {
+      throw new Error('User info manager is not initialized.')
+    }
+    return this._threadID
+  }
+
+  /**
+   * @method createCollection
+   * Create a collection for managing users
+   */
+  async createCollection(): Promise<void> {
+    try {
+      await this.textile.client.newCollection(this.threadID, {
+        name: CollectionName,
+        schema: userinfoSchema,
+      })
+    } catch (error) {}
+  }
+
+  /**
+   * Find the current user consent info
+   * @returns returns the current user's info
+   */
+  private async _findRecord(): Promise<UserdataFromThread | null> {
+    const query = Query.where('user_address').eq(this.textile.wallet.address)
+    const records = await this.textile.client.find<UserdataFromThread>(
+      this.threadID,
+      CollectionName,
+      query,
+    )
+
+    if (records.length === 0) {
+      return null
+    }
+    const [record] = records
+    return record
+  }
+
+  async getConsentData(): Promise<UserdataFromThread | null> {
+    return await this._findRecord()
+  }
+
+  /**
+   * @method setConsent
+   * Set consent data for csam
+   */
+  async setConsent({
+    consentScan,
+    consentDate,
+  }: {
+    consentScan: boolean
+    consentDate: Number
+  }): Promise<void> {
+    const record = await this._findRecord()
+    if (record) {
+      record.consent_scan = consentScan
+      record.consent_date = consentDate
+      await this.textile.client.save(this.threadID, CollectionName, [record])
+      return
+    }
+    await this.textile.client.create(this.threadID, CollectionName, [
+      {
+        user_address: this.textile.wallet.address,
+        created_at: Date.now(),
+        consent_scan: consentScan,
+        consent_date: consentDate,
+      },
+    ])
+  }
+
+  async getThreadName(): Promise<string> {
+    const crypto = new Crypto()
+    const name = crypto.signMessageWithKey(
+      this.textile.wallet.keypair.secretKey,
+      `csam`,
+    )
+
+    return crypto.hash(name)
+  }
+
+  async getThreadID(): Promise<ThreadID> {
+    const name = await this.getThreadName()
+    try {
+      const thread = await this.textile.client.getThread(name)
+      return ThreadID.fromString(thread.id)
+    } catch (e) {
+      return await this.textile.client.newDB(undefined, name)
+    }
+  }
+}

--- a/libraries/Textile/UserManager.ts
+++ b/libraries/Textile/UserManager.ts
@@ -75,7 +75,7 @@ export class UserInfoManager {
     consentDate,
   }: {
     consentScan: boolean
-    consentDate: Number
+    consentDate: number
   }): Promise<void> {
     const record = await this._findRecord()
     if (record) {

--- a/libraries/Textile/UserManager.ts
+++ b/libraries/Textile/UserManager.ts
@@ -54,17 +54,12 @@ export class UserInfoManager {
    */
   private async _findRecord(): Promise<UserdataFromThread | null> {
     const query = Query.where('user_address').eq(this.textile.wallet.address)
-    const records = await this.textile.client.find<UserdataFromThread>(
+    const [record] = await this.textile.client.find<UserdataFromThread>(
       this.threadID,
       CollectionName,
       query,
     )
-
-    if (records.length === 0) {
-      return null
-    }
-    const [record] = records
-    return record
+    return record || null
   }
 
   async getConsentData(): Promise<UserdataFromThread | null> {

--- a/libraries/Textile/schema.ts
+++ b/libraries/Textile/schema.ts
@@ -28,3 +28,16 @@ export const metadataSchema = {
     _mod: { type: 'number' },
   },
 }
+
+export const userinfoSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  title: 'Userinfo',
+  type: 'object',
+  properties: {
+    _id: { type: 'string' },
+    created_at: { type: 'number' },
+    user_address: { type: 'string' },
+    consent_scan: { type: 'boolean' },
+    consent_date: { type: 'number' },
+  },
+}

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -207,7 +207,7 @@ export default {
         subtitle:
           "Choose which signaling server group you want to use. If you use 'Satellite + Public Signaling Servers', you are using public servers and Satellite hosted servers to connect with your friends. We do not track connections. We only track server utilization (memory and cpu usage) to know if we need to turn on more signaling servers. If you opt to use 'Only Public Signaling Servers', those are totally outside of Satellite control, so we can not see or have any insight into their operation, logging, or data sharing practices, and you may experience difficulties connecting with friends if the signaling servers are overloaded.",
       },
-      consentsScan: {
+      consentScan: {
         title: 'Consents to having files scanned',
         subtitle:
           'In order to share files/use the encrypted file storage I consent to having my files auto-scanned against the Microsoft PhotoDNA service to help prevent the spread of sexual abuse material',

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -207,6 +207,11 @@ export default {
         subtitle:
           "Choose which signaling server group you want to use. If you use 'Satellite + Public Signaling Servers', you are using public servers and Satellite hosted servers to connect with your friends. We do not track connections. We only track server utilization (memory and cpu usage) to know if we need to turn on more signaling servers. If you opt to use 'Only Public Signaling Servers', those are totally outside of Satellite control, so we can not see or have any insight into their operation, logging, or data sharing practices, and you may experience difficulties connecting with friends if the signaling servers are overloaded.",
       },
+      consentsScan: {
+        title: 'Consents to having files scanned',
+        subtitle:
+          'In order to share files/use the encrypted file storage I consent to having my files auto-scanned against the Microsoft PhotoDNA service to help prevent the spread of sexual abuse material',
+      },
       ownInfo: {
         title: 'Set my own Signaling Server',
         subtitle:

--- a/store/settings/actions.ts
+++ b/store/settings/actions.ts
@@ -27,7 +27,7 @@ export default {
       const $TextileManager: TextileManager = Vue.prototype.$TextileManager
 
       if (!$TextileManager.userInfoManager) {
-        throw new Error(TextileError.METADATA_MANAGER_NOT_FOUND)
+        throw new Error(TextileError.USERINFO_MANAGER_NOT_FOUND)
       }
       const $UserInfoManager: UserInfoManager = $TextileManager.userInfoManager
       $UserInfoManager.setConsent({

--- a/store/settings/actions.ts
+++ b/store/settings/actions.ts
@@ -1,4 +1,8 @@
+import Vue from 'vue'
+import { TextileError } from '../textile/types'
 import { db } from '~/libraries/SatelliteDB/SatelliteDB'
+import TextileManager from '~/libraries/Textile/TextileManager'
+import { UserInfoManager } from '~/libraries/Textile/UserManager'
 import { SettingsError, SettingsState } from '~/store/settings/types'
 import { ActionsArguments } from '~/types/store/store'
 
@@ -12,5 +16,24 @@ export default {
     } catch (e) {
       throw new Error(SettingsError.DATABASE_NOT_CLEARED)
     }
+  },
+  async setConsentScan(
+    { commit }: ActionsArguments<SettingsState>,
+    consentScan: boolean,
+  ) {
+    try {
+      commit('setConsentScan', consentScan)
+
+      const $TextileManager: TextileManager = Vue.prototype.$TextileManager
+
+      if (!$TextileManager.userInfoManager) {
+        throw new Error(TextileError.METADATA_MANAGER_NOT_FOUND)
+      }
+      const $UserInfoManager: UserInfoManager = $TextileManager.userInfoManager
+      $UserInfoManager.setConsent({
+        consentScan,
+        consentDate: Date.now(),
+      })
+    } catch (e) {}
   },
 }

--- a/store/settings/mutations.ts
+++ b/store/settings/mutations.ts
@@ -39,6 +39,9 @@ const mutations = {
     // will not react to deep values
     state.embeddedLinks = value
   },
+  setConsentsScan(state: SettingsState, value: boolean) {
+    state.consentsScan = value
+  },
   displayCurrentActivity(state: SettingsState, value: boolean) {
     state.displayCurrentActivity = value
   },

--- a/store/settings/mutations.ts
+++ b/store/settings/mutations.ts
@@ -39,8 +39,8 @@ const mutations = {
     // will not react to deep values
     state.embeddedLinks = value
   },
-  setConsentsScan(state: SettingsState, value: boolean) {
-    state.consentsScan = value
+  setConsentScan(state: SettingsState, value: boolean) {
+    state.consentScan = value
   },
   displayCurrentActivity(state: SettingsState, value: boolean) {
     state.displayCurrentActivity = value

--- a/store/settings/state.ts
+++ b/store/settings/state.ts
@@ -14,6 +14,7 @@ const InitialSettingsState = (): SettingsState => ({
   userDeniedAudioAccess: false,
   keybinds: KeybindTypes,
   embeddedLinks: true,
+  consentsScan: false,
   displayCurrentActivity: true,
   removeState: false,
   serverType: 'satellite',

--- a/store/settings/state.ts
+++ b/store/settings/state.ts
@@ -14,7 +14,7 @@ const InitialSettingsState = (): SettingsState => ({
   userDeniedAudioAccess: false,
   keybinds: KeybindTypes,
   embeddedLinks: true,
-  consentsScan: false,
+  consentScan: false,
   displayCurrentActivity: true,
   removeState: false,
   serverType: 'satellite',

--- a/store/settings/types.ts
+++ b/store/settings/types.ts
@@ -28,6 +28,7 @@ export interface SettingsState {
   userDeniedAudioAccess: boolean
   keybinds: object
   embeddedLinks: boolean
+  consentsScan: boolean
   displayCurrentActivity: boolean
   timezone: string
   removeState: boolean

--- a/store/settings/types.ts
+++ b/store/settings/types.ts
@@ -28,7 +28,7 @@ export interface SettingsState {
   userDeniedAudioAccess: boolean
   keybinds: object
   embeddedLinks: boolean
-  consentsScan: boolean
+  consentScan: boolean
   displayCurrentActivity: boolean
   timezone: string
   removeState: boolean

--- a/store/textile/actions.ts
+++ b/store/textile/actions.ts
@@ -60,6 +60,13 @@ export default {
       const $FileSystem: FilSystem = Vue.prototype.$FileSystem
       await $FileSystem.import(fsExport)
     }
+    const consentData = await $TextileManager.userInfoManager?.getConsentData()
+    /* Log CSAM Consent Data for future ticket as Hogan requested */
+    Vue.prototype.$Logger.log('CSAM Consent Data', 'CSAM', consentData)
+    if (consentData)
+      commit('settings/setConsentScan', consentData.consent_scan, {
+        root: true,
+      })
     return textilePublicKey
   },
   /**

--- a/store/textile/actions.ts
+++ b/store/textile/actions.ts
@@ -61,12 +61,13 @@ export default {
       await $FileSystem.import(fsExport)
     }
     const consentData = await $TextileManager.userInfoManager?.getConsentData()
-    /* Log CSAM Consent Data for future ticket as Hogan requested */
-    Vue.prototype.$Logger.log('CSAM Consent Data', 'CSAM', consentData)
-    if (consentData)
+    if (consentData) {
+      /* Log CSAM Consent Data for future ticket as Hogan requested */
+      Vue.prototype.$Logger.log('CSAM Consent Data', 'CSAM', consentData)
       commit('settings/setConsentScan', consentData.consent_scan, {
         root: true,
       })
+    }
     return textilePublicKey
   },
   /**

--- a/store/textile/types.ts
+++ b/store/textile/types.ts
@@ -39,4 +39,5 @@ export enum TextileError {
   MAILBOX_MANAGER_NOT_FOUND = 'errors.textile.mailbox_manager_not_found',
   MAILBOX_MANAGER_NOT_INITIALIZED = 'errors.textile.mailbox_manager_not_initialized',
   METADATA_MANAGER_NOT_FOUND = 'errors.textile.metadata_manager_not_found',
+  USERINFO_MANAGER_NOT_FOUND = 'errors.textile.userinfo_manager_not_found',
 }

--- a/types/textile/user.ts
+++ b/types/textile/user.ts
@@ -1,0 +1,7 @@
+export interface UserdataFromThread {
+  _id: string
+  created_at: Number
+  user_address: string
+  consent_scan: boolean
+  consent_date: Number
+}

--- a/types/textile/user.ts
+++ b/types/textile/user.ts
@@ -1,7 +1,7 @@
 export interface UserdataFromThread {
   _id: string
-  created_at: Number
+  created_at: number
   user_address: string
   consent_scan: boolean
-  consent_date: Number
+  consent_date: number
 }


### PR DESCRIPTION
**What this PR does** 📖
- This is rebased PR based on https://github.com/Satellite-im/Core-PWA/pull/2780
- add a toggle for can scan and save info to textile
- add textile manager for saving user consent data

**Which issue(s) this PR fixes** 🔨

AP-1332

**Special notes for reviewers** 🗒️
- This is already reviewed by devs on old PR... This is just new PR with rebase dev.
