### PR TITLE
chore(cypress): update github action

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   cypress-run:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION


**What this PR does** 📖

- Updates Cypress Github Action to run using ubuntu-16.04 due to

https://github.com/cypress-io/github-action/blob/263091cab1962eea06e293a19146e9d0241a1c32/README.md#important
