### PR TITLE
test(cypress): unskip tests, improvements on tests/commands

### DIFF
--- a/cypress/integration/chat-features.js
+++ b/cypress/integration/chat-features.js
@@ -8,13 +8,13 @@ const recoverySeed =
   'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}'
 let imageURL
 
-describe.skip('Chat Features Tests', () => {
+describe('Chat Features Tests', () => {
   it('Chat - Send message on chat', () => {
     // Import account
     cy.importAccount(randomPIN, recoverySeed)
 
     // Validate profile name displayed
-    cy.get('[data-cy=user-name]', { timeout: 180000 }).should('exist')
+    cy.validateChatPageIsLoaded()
 
     // Validate message is sent
     cy.goToConversation('cypress friend')
@@ -103,7 +103,7 @@ describe.skip('Chat Features Tests', () => {
     cy.get('[data-cy=editable-input]').should('have.text', randomTextToCopy)
   })
 
-  it('Chat - Copy paste images - Test skipped until AP-1080 bug is fixed', () => {
+  it.skip('Chat - Copy paste images - Test skipped until AP-1080 bug is fixed', () => {
     cy.chatFeaturesSendImage(imageLocalPath, 'logo.png')
 
     // Copying the latest image URL sent

--- a/cypress/integration/chat-features.js
+++ b/cypress/integration/chat-features.js
@@ -103,7 +103,7 @@ describe('Chat Features Tests', () => {
     cy.get('[data-cy=editable-input]').should('have.text', randomTextToCopy)
   })
 
-  it.skip('Chat - Copy paste images - Test skipped until AP-1080 bug is fixed', () => {
+  it.skip('Chat - Copy paste images', () => {
     cy.chatFeaturesSendImage(imageLocalPath, 'logo.png')
 
     // Copying the latest image URL sent

--- a/cypress/integration/chat-glyphs-validations.js
+++ b/cypress/integration/chat-glyphs-validations.js
@@ -9,7 +9,7 @@ describe('Chat - Sending Glyphs Tests', () => {
     cy.importAccount(randomPIN, recoverySeed)
 
     //Validate profile name displayed
-    cy.contains('cypress', { timeout: 180000 }).should('be.visible')
+    cy.validateChatPageIsLoaded()
 
     //Validate message is sent
     cy.goToConversation('cypress friend')

--- a/cypress/integration/chat-images-validations.js
+++ b/cypress/integration/chat-images-validations.js
@@ -8,13 +8,13 @@ const jpgImagePath = 'cypress/fixtures/images/jpeg-test.jpg'
 const gifImagePath = 'cypress/fixtures/images/gif-test.gif'
 const invalidImagePath = 'cypress/fixtures/images/incorrect-image.png'
 
-describe.skip('Chat - Sending Images Tests', () => {
+describe('Chat - Sending Images Tests', () => {
   it('PNG image is sent succesfully on chat', () => {
     //Import account
     cy.importAccount(randomPIN, recoverySeed)
 
     //Validate profile name displayed
-    cy.get('[data-cy=user-name]', { timeout: 180000 }).should('exist')
+    cy.validateChatPageIsLoaded()
 
     //Validate message is sent
     cy.goToConversation('cypress friend')

--- a/cypress/integration/chat-pair-features.js
+++ b/cypress/integration/chat-pair-features.js
@@ -13,12 +13,12 @@ const fileLocalPath = 'cypress/fixtures/test-file.txt'
 const textReply = 'This is a reply to the message'
 let glyphURL, imageURL, fileURL
 
-describe.skip('Chat features with two accounts', () => {
+describe('Chat features with two accounts', () => {
   it('Ensure chat window from first account is displayed', () => {
     //Import first account
     cy.importAccount(randomPIN, recoverySeedAccountOne)
     //Validate Chat Screen is loaded
-    cy.contains('Chat User A', { timeout: 240000 }).should('be.visible')
+    cy.validateChatPageIsLoaded()
   })
 
   it('Send message to user B', () => {
@@ -61,7 +61,7 @@ describe.skip('Chat features with two accounts', () => {
     cy.validateOptionNotInContextMenu('[data-cy=chat-image]', 'Edit')
   })
 
-  it.skip('Send file to user B', () => {
+  it('Send file to user B', () => {
     cy.chatFeaturesSendFile(fileLocalPath)
     cy.get('[data-cy=chat-file]')
       .last()
@@ -73,13 +73,13 @@ describe.skip('Chat features with two accounts', () => {
       })
   })
 
-  it.skip('File messages cannot be edited', () => {
+  it('File messages cannot be edited', () => {
     cy.validateOptionNotInContextMenu('[data-cy=chat-file]', 'Edit')
   })
 
   it('Ensure chat window from second account is displayed', () => {
     cy.importAccount(randomPIN, recoverySeedAccountTwo)
-    cy.contains('Chat User B', { timeout: 180000 }).should('be.visible')
+    cy.validateChatPageIsLoaded()
   })
 
   it('Assert message received from user A', () => {
@@ -145,7 +145,7 @@ describe.skip('Chat features with two accounts', () => {
       })
   })
 
-  it.skip('Assert file received from user A', () => {
+  it('Assert file received from user A', () => {
     cy.get('[data-cy=chat-file]')
       .last()
       .scrollIntoView()
@@ -200,7 +200,7 @@ describe.skip('Chat features with two accounts', () => {
   it('Send a message from third account to second account', () => {
     //import Chat User C account
     cy.importAccount(randomPIN, recoverySeedAccountThree)
-    cy.contains('Chat User C', { timeout: 180000 }).should('be.visible')
+    cy.validateChatPageIsLoaded()
     //Send a message to Chat User B
     cy.goToConversation('Chat User B')
     cy.chatFeaturesSendMessage(randomMessage)

--- a/cypress/integration/chat-text-validations.js
+++ b/cypress/integration/chat-text-validations.js
@@ -13,7 +13,7 @@ describe('Chat Text and Sending Links Validations', () => {
     cy.importAccount(randomPIN, recoverySeed)
 
     //Ensure messages are displayed before starting
-    cy.contains('cypress', { timeout: 180000 }).should('be.visible')
+    cy.validateChatPageIsLoaded()
     cy.goToConversation('cypress friend')
     cy.get('[data-cy=editable-input]')
       .should('be.visible')

--- a/cypress/integration/chat-top-toolbar.js
+++ b/cypress/integration/chat-top-toolbar.js
@@ -9,7 +9,7 @@ describe('Chat Toolbar Tests', () => {
     cy.importAccount(randomPIN, recoverySeed)
 
     //Ensure messages are displayed before starting
-    cy.contains('cypress', { timeout: 180000 }).should('be.visible')
+    cy.validateChatPageIsLoaded()
     cy.goToConversation('cypress friend')
     cy.hoverOnActiveIcon('[data-cy=toolbar-enable-audio]')
   })

--- a/cypress/integration/create-account.js
+++ b/cypress/integration/create-account.js
@@ -106,8 +106,6 @@ describe('Create Account Validations', () => {
     cy.createAccountSubmit()
 
     //Validating profile picture is null and default satellite circle is displayed
-    cy.get('[data-cy=user-state]', {
-      timeout: 120000,
-    }).should('exist')
+    cy.validateChatPageIsLoaded()
   })
 })

--- a/cypress/integration/localstorage-validations.js
+++ b/cypress/integration/localstorage-validations.js
@@ -20,9 +20,7 @@ describe('Verify passphrase does not get stored in localstorage', () => {
     cy.createAccount(randomPIN)
 
     //Wait until main page is loaded after creating account
-    cy.get('[data-cy=user-state]', {
-      timeout: 120000,
-    }).should('be.visible')
+    cy.validateChatPageIsLoaded()
 
     // Go to main URL and validate that previous passphrase is not stored in localstorage
     cy.visit('/').then(() => {
@@ -44,7 +42,7 @@ describe('Verify passphrase does not get stored in localstorage', () => {
     cy.importAccount(randomPIN, recoverySeed)
 
     //Wait until main page is loaded after importing account
-    cy.contains('cypress', { timeout: 60000 }).should('be.visible')
+    cy.validateChatPageIsLoaded()
 
     // Go to URL and validate that previous passphrase is not stored in localstorage
     cy.visit('/').then(() => {

--- a/cypress/integration/mobiles-responsiveness.js
+++ b/cypress/integration/mobiles-responsiveness.js
@@ -46,18 +46,15 @@ describe('Run responsiveness tests on several devices', () => {
       cy.viewport(item.width, item.height)
       cy.importAccount(randomPIN, recoverySeed)
       //Validate profile name displayed
-      cy.contains('cypress', { timeout: 240000 }).should('be.visible')
+      cy.validateChatPageIsLoaded(240000)
     })
 
-    it.skip(`Chat Features on ${item.description}`, () => {
+    it(`Chat Features on ${item.description}`, () => {
       //Setting viewport
       cy.viewport(item.width, item.height)
 
       //Go to conversation
-      cy.get('[data-cy=hamburger-button]').click()
-      cy.get('[data-cy=user-connected]', { timeout: 60000 })
-        .should('be.visible')
-        .should('have.text', 'cypress friend')
+      cy.goToConversation('cypress friend', true)
 
       //Validate message and emojis are sent
       cy.chatFeaturesSendMessage(randomMessage)
@@ -67,44 +64,44 @@ describe('Run responsiveness tests on several devices', () => {
       cy.chatFeaturesEditMessage(randomMessage, randomNumber)
     })
 
-    it.skip(`Chat - Marketplace - Coming Soon modal content on ${item.description}`, () => {
+    it(`Chat - Marketplace - Coming Soon modal content on ${item.description}`, () => {
       cy.viewport(item.width, item.height)
       cy.get('[data-cy=toolbar-marketplace]').click()
       cy.validateComingSoonModal()
     })
 
-    it.skip(`Chat - Marketplace - Coming Soon modal button URL on ${item.description}`, () => {
+    it(`Chat - Marketplace - Coming Soon modal button URL on ${item.description}`, () => {
       cy.viewport(item.width, item.height)
       cy.validateURLComingSoonModal()
     })
 
-    it.skip(`Chat - Marketplace - Coming Soon modal can be dismissed on ${item.description}`, () => {
+    it(`Chat - Marketplace - Coming Soon modal can be dismissed on ${item.description}`, () => {
       cy.viewport(item.width, item.height)
       cy.closeModal('[data-cy=modal-cta]')
     })
 
-    it.skip(`Chat - Glyph Pack screen is displayed on ${item.description}`, () => {
+    it(`Chat - Glyph Pack screen is displayed on ${item.description}`, () => {
       cy.viewport(item.width, item.height)
       cy.chatFeaturesSendGlyph()
       cy.goToLastGlyphOnChat().click()
       cy.validateGlyphsModal()
     })
 
-    it.skip(`Chat - Glyph Pack - Coming Soon modal on ${item.description}`, () => {
+    it(`Chat - Glyph Pack - Coming Soon modal on ${item.description}`, () => {
       cy.viewport(item.width, item.height)
       cy.contains('View Glyph Pack').click()
       cy.get('[data-cy=modal-cta]').should('be.visible')
       cy.closeModal('[data-cy=modal-cta]')
     })
 
-    it.skip(`Chat - Glyph Pack screen can be dismissed on ${item.description}`, () => {
+    it(`Chat - Glyph Pack screen can be dismissed on ${item.description}`, () => {
       cy.viewport(item.width, item.height)
       cy.goToLastGlyphOnChat().click()
       cy.get('[data-cy=glyphs-modal]').should('be.visible')
       cy.closeModal('[data-cy=glyphs-modal]')
     })
 
-    it.skip(`Chat - Glyphs Selection - Coming soon modal on ${item.description}`, () => {
+    it(`Chat - Glyphs Selection - Coming soon modal on ${item.description}`, () => {
       cy.viewport(item.width, item.height)
       cy.get('#glyph-toggle').click()
       cy.get('[data-cy=glyphs-marketplace]').click()

--- a/cypress/integration/pin-unlock-validations.js
+++ b/cypress/integration/pin-unlock-validations.js
@@ -16,9 +16,7 @@ describe('Unlock pin should be persisted when store pin is enabled', () => {
     cy.createAccountSubmit()
 
     //Wait until main page is loaded after creating account
-    cy.get('[data-cy=user-state]', {
-      timeout: 120000,
-    }).should('be.visible')
+    cy.validateChatPageIsLoaded()
 
     // Go to main URL again and validate that user is prompt to enter pin again
     cy.visit('/').then(() => {
@@ -26,7 +24,7 @@ describe('Unlock pin should be persisted when store pin is enabled', () => {
     })
   })
 
-  it.skip('Create Account with store pin enabled', () => {
+  it('Create Account with store pin enabled', () => {
     //Go to URL, add a PIN and make sure that toggle for save pin is enabled
     cy.createAccountPINscreen(randomPIN, true, false)
 
@@ -38,15 +36,11 @@ describe('Unlock pin should be persisted when store pin is enabled', () => {
     cy.createAccountSubmit()
 
     //Wait until main page is loaded after creating account
-    cy.get('[data-cy=user-state]', {
-      timeout: 120000,
-    }).should('be.visible')
+    cy.validateChatPageIsLoaded()
 
     // Go to main URL again and validate that user is redirected to chat screen and pin was saved
     cy.visit('/').then(() => {
-      cy.get('#status > .user-state > .is-rounded > .satellite-circle', {
-        timeout: 120000,
-      }).should('be.visible')
+      cy.validateChatPageIsLoaded()
     })
   })
 
@@ -58,9 +52,7 @@ describe('Unlock pin should be persisted when store pin is enabled', () => {
     cy.importAccountEnterPassphrase(userPassphrase)
 
     //Wait until main page is loaded after importing account
-    cy.get('[data-cy=user-state]', {
-      timeout: 120000,
-    }).should('be.visible')
+    cy.validateChatPageIsLoaded()
 
     // Go to main URL again and validate that user is prompt to enter pin again
     cy.visit('/').then(() => {
@@ -76,15 +68,11 @@ describe('Unlock pin should be persisted when store pin is enabled', () => {
     cy.importAccountEnterPassphrase(userPassphrase)
 
     //Wait until main page is loaded after importing account
-    cy.get('[data-cy=user-state]', {
-      timeout: 120000,
-    }).should('be.visible')
+    cy.validateChatPageIsLoaded()
 
     // Go to main URL again and validate that user is redirected to chat screen and pin was saved
     cy.visit('/').then(() => {
-      cy.get('#status > .user-state > .is-rounded > .satellite-circle', {
-        timeout: 120000,
-      }).should('be.visible')
+      cy.validateChatPageIsLoaded()
     })
   })
 })

--- a/cypress/integration/privacy-page-toggles.js
+++ b/cypress/integration/privacy-page-toggles.js
@@ -43,7 +43,7 @@ describe('Privacy Page Toggles Tests', () => {
     })
   })
 
-  it.skip('Privacy page - Verify user can still proceed after adjusting switches', () => {
+  it('Privacy page - Verify user can still proceed after adjusting switches', () => {
     //Click on next
     cy.get('#custom-cursor-area').click()
 
@@ -55,16 +55,14 @@ describe('Privacy Page Toggles Tests', () => {
 
     //Click on button, validate buffering screen and that user is redirected to friends/list
     cy.createAccountSubmit()
-    cy.get('[data-cy=user-state]', {
-      timeout: 120000,
-    }).should('be.visible')
+    cy.validateChatPageIsLoaded()
     //Going to Settings and Privacy screen
     cy.get('[data-tooltip="Settings"] > .is-rounded > svg', {
       timeout: 30000,
     }).click()
   })
 
-  it.skip('Profile - Verify the toggles user added when signing up are on the same status when user goes to settings', () => {
+  it('Profile - Verify the toggles user added when signing up are on the same status when user goes to settings', () => {
     cy.contains('Privacy').click()
     //Storing the values from toggle switches status of Settings screen into an array
     cy.get('.switch-button')
@@ -83,7 +81,7 @@ describe('Privacy Page Toggles Tests', () => {
       })
   })
 
-  it.skip('Profile - Verify user can’t update the register name publicly toggle on settings', () => {
+  it('Profile - Verify user can’t update the register name publicly toggle on settings', () => {
     //Identify the first switch button and ensure that is locked
     cy.get('.switch-button').first().should('have.class', 'locked')
   })

--- a/cypress/integration/snapshots-test.js
+++ b/cypress/integration/snapshots-test.js
@@ -43,7 +43,7 @@ describe.skip('Snapshots Testing', () => {
   })
 
   it('Import account - Main Screen Loaded', () => {
-    cy.contains('Snap QA', { timeout: 60000 })
+    cy.contains('Snap QA', { timeout: 180000 })
     cy.get('body').realClick({ position: 'topLeft' })
     cy.snapshotTestContains('Snap QA')
   })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -414,8 +414,15 @@ Cypress.Commands.add('clickOutside', () => {
   cy.get('body').click(0, 0) //0,0 here are the x and y coordinates
 })
 
-Cypress.Commands.add('goToConversation', (user) => {
+Cypress.Commands.add('validateChatPageIsLoaded', (customTimeout = 180000) => {
+  cy.get('[data-cy=user-name]', { timeout: customTimeout }).should('exist')
+})
+
+Cypress.Commands.add('goToConversation', (user, mobile = false) => {
   cy.get('[data-cy=sidebar-friends]').click()
+  if (mobile === true) {
+    cy.get('[data-cy=hamburger-button]').click()
+  }
   cy.get('[data-cy=friend-name]').contains(user).as('friend')
   cy.get('@friend')
     .parent()
@@ -423,6 +430,10 @@ Cypress.Commands.add('goToConversation', (user) => {
     .find('[data-cy=friend-send-message]')
     .as('friend-message')
   cy.get('@friend-message').click()
+
+  if (mobile === true) {
+    cy.get('[data-cy=hamburger-button]').click()
+  }
   cy.get('[data-cy=user-connected]', { timeout: 60000 })
     .should('be.visible')
     .should('have.text', user)


### PR DESCRIPTION
**What this PR does** 📖
- Unskip cypress tests failing due to textile issue which is now solved
- Added a new cypress command in all chat tests to wait for page loaded
- Improvement on go to conversation cypress command so it can work different for mobile tests, which was causing issues before in this spec
- Change name of the copy image cypress test inside chat-features.js

**Which issue(s) this PR fixes** 🔨
None

**Special notes for reviewers** 🗒️
All specs except the ones skipped are passing:
![image](https://user-images.githubusercontent.com/35935591/162843747-37470e62-6d88-4d50-a6c1-40202138cefd.png)

**Additional comments** 🎤
Mobiles Responsiveness Cypress Video:
https://user-images.githubusercontent.com/35935591/162843704-632c67f1-761b-4d1a-b8e7-12e5be26fa11.mp4
