### PR TITLE
fix(ui): image preview stretch issue

### DIFF
--- a/components/ui/Chat/Image/Overlay/Overlay.less
+++ b/components/ui/Chat/Image/Overlay/Overlay.less
@@ -4,7 +4,8 @@
 
   .is-image-in-mask {
     &:extend(.round-corners);
-    height: 80vh;
+    max-height: 80vh;
+    height: auto;
     max-width: 80vw;
     justify-content: center;
     align-self: center;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
depending on the size of the image, when previewed, the image is stretched
**Which issue(s) this PR fixes** 🔨
AP-1337
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
