### PR TITLE
test(cypress): add tests for invalid image on account creation

### DIFF
--- a/components/ui/Circle/Circle.html
+++ b/components/ui/Circle/Circle.html
@@ -8,11 +8,13 @@
     v-if="type === 'image' && source"
     alt="Circle Image"
     :class="`${square ? 'is-square' : 'is-rounded'} image`"
+    data-cy="circle-has-picture"
   />
   <UiSatelliteCircle
     v-else-if="type === 'random'"
     :address="seed"
     :name="name"
+    data-cy="circle-without-picture"
   />
   <UiDynamicIcon size="1x" :icon="icon" v-else-if="icon" />
   <slot></slot>

--- a/components/ui/User/State/State.vue
+++ b/components/ui/User/State/State.vue
@@ -5,6 +5,7 @@
     :style="`width:${size}px; height:${size}px`"
   >
     <UiCircle
+      data-cy="satellite-circle-profile"
       :type="src ? 'image' : 'random'"
       :seed="user.address"
       :size="size"


### PR DESCRIPTION
**What this PR does** 📖
- Add cypress tests for account creation when attempting to upload an invalid image as profile picture
- Added small validation at the end of NSFW image last test to ensure that profile picture is a satellite circle without profile picture
- Add data-cy locators used for satellite circles in profile

**Which issue(s) this PR fixes** 🔨
AP-1138

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
Create Account Cypress Video:
https://user-images.githubusercontent.com/35935591/163029569-e8845091-8c21-4c71-89e1-cd9bbce0caec.mp4
