### PR TITLE
chore(jest): add more coverage on SolanaManager.test.ts

### DIFF
--- a/libraries/Solana/SolanaManager/SolanaManager.test.ts
+++ b/libraries/Solana/SolanaManager/SolanaManager.test.ts
@@ -292,3 +292,159 @@ describe('SolanaManager.default.requestAirdrop', () => {
     await inst2.requestAirdrop()
   })
 })
+
+describe('SolanaManager.default.generateDerivedPublicKey', () => {
+  let inst10: any
+  let inst9: any
+  let inst8: any
+  let inst7: any
+  let inst6: any
+  let inst4: any
+  let inst3: any
+  let inst: any
+  let inst2: any
+
+  beforeEach(() => {
+    inst10 = new SolanaManager.default()
+    inst9 = new SolanaManager.default()
+    inst8 = new SolanaManager.default()
+    inst7 = new SolanaManager.default()
+    inst6 = new SolanaManager.default()
+    inst4 = new SolanaManager.default()
+    inst3 = new SolanaManager.default()
+    inst = new SolanaManager.default()
+    inst2 = new SolanaManager.default()
+  })
+
+  test('0', async () => {
+    const param2: any = new web3.PublicKey(1000)
+    const param4: any = new web3.PublicKey(1)
+    await inst3.generateDerivedPublicKey(
+      'Jean-Philippe',
+      param2,
+      'foo bar',
+      param4,
+    )
+  })
+
+  test('1', async () => {
+    const param2: any = new web3.PublicKey(1000)
+    const param4: any = new web3.PublicKey(1000)
+    await inst4.generateDerivedPublicKey(
+      'Pierre Edouard',
+      param2,
+      'Foo bar',
+      param4,
+    )
+  })
+
+  describe('SolanaManager.default.generateNewAccount', () => {
+    let inst2: any
+
+    beforeEach(() => {
+      inst2 = new SolanaManager.default()
+    })
+
+    test('0', async () => {
+      await inst2.generateNewAccount()
+    })
+  })
+
+  describe('SolanaManager.default.initializeFromKeypair', () => {
+    let inst2: any
+
+    beforeEach(() => {
+      inst2 = new SolanaManager.default()
+    })
+
+    test('0', async () => {
+      await inst2.initializeFromKeypair(web3.Keypair.generate())
+    })
+  })
+
+  describe('SolanaManager.default.isInitialized', () => {
+    let inst2: any
+
+    beforeEach(() => {
+      inst2 = new SolanaManager.default()
+    })
+
+    test('0', () => {
+      const result: any = inst2.isInitialized()
+      expect(result).toMatchSnapshot()
+    })
+  })
+
+  describe('SolanaManager.default.initializeFromSolanaWallet', () => {
+    let inst9: any
+    let inst8: any
+    let inst7: any
+    let inst6: any
+    let inst5: any
+    let inst4: any
+    let inst3: any
+    let inst: any
+    let inst2: any
+
+    beforeEach(() => {
+      inst9 = new SolanaManager.default()
+      inst8 = new SolanaManager.default()
+      inst7 = new SolanaManager.default()
+      inst6 = new SolanaManager.default()
+      inst5 = new SolanaManager.default()
+      inst4 = new SolanaManager.default()
+      inst3 = new SolanaManager.default()
+      inst = new SolanaManager.default()
+      inst2 = new SolanaManager.default()
+    })
+
+    test('0', async () => {
+      await inst9.initializeFromSolanaWallet({
+        mnemonic: undefined,
+        keypair: web3.Keypair.generate(),
+        path: undefined,
+        address: '',
+      })
+    })
+  })
+
+  describe('SolanaManager.default.getAllAccounts', () => {
+    let inst2: any
+
+    beforeEach(() => {
+      inst2 = new SolanaManager.default()
+    })
+
+    test('0', () => {
+      const result: any = inst2.getAllAccounts()
+      expect(result).toMatchSnapshot()
+    })
+  })
+
+  describe('SolanaManager.default.getAccount', () => {
+    let inst3: any
+    let inst: any
+    let inst2: any
+
+    beforeEach(() => {
+      inst3 = new SolanaManager.default()
+      inst = new SolanaManager.default()
+      inst2 = new SolanaManager.default()
+    })
+
+    test('0', () => {
+      const result: any = inst2.getAccount('0.0.0.0')
+      expect(result).toMatchSnapshot()
+    })
+
+    test('1', () => {
+      const result: any = inst.getAccount('192.168.1.5')
+      expect(result).toMatchSnapshot()
+    })
+
+    test('2', () => {
+      const result: any = inst3.getAccount('')
+      expect(result).toMatchSnapshot()
+    })
+  })
+})

--- a/libraries/Solana/SolanaManager/__snapshots__/SolanaManager.test.ts.snap
+++ b/libraries/Solana/SolanaManager/__snapshots__/SolanaManager.test.ts.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SolanaManager.default.generateDerivedPublicKey SolanaManager.default.getAccount 0 1`] = `undefined`;
+
+exports[`SolanaManager.default.generateDerivedPublicKey SolanaManager.default.getAccount 1 1`] = `undefined`;
+
+exports[`SolanaManager.default.generateDerivedPublicKey SolanaManager.default.getAccount 2 1`] = `undefined`;
+
+exports[`SolanaManager.default.generateDerivedPublicKey SolanaManager.default.getAllAccounts 0 1`] = `Array []`;
+
+exports[`SolanaManager.default.generateDerivedPublicKey SolanaManager.default.isInitialized 0 1`] = `false`;
+
 exports[`SolanaManager.default.getAccount 0 1`] = `undefined`;
 
 exports[`SolanaManager.default.getAccount 1 1`] = `undefined`;


### PR DESCRIPTION

**What this PR does** 📖

- Adds more coverage on libraries/Solana/SolanaManager/SolanaManager.test.ts

before

<img width="855" alt="Captura de ecrã 2022-04-12, às 21 52 02" src="https://user-images.githubusercontent.com/29093946/163052914-a53efedc-6e62-4e90-b60f-bffc6fa1316c.png">


after

<img width="847" alt="Captura de ecrã 2022-04-12, às 21 52 34" src="https://user-images.githubusercontent.com/29093946/163052903-ab739e69-397c-4531-b15d-a63a2493c0fa.png">

