### PR TITLE
fix(mobile): virtual keyboard hide chatbox in chat

### DIFF
--- a/components/views/chat/chatbar/Chatbar.vue
+++ b/components/views/chat/chatbar/Chatbar.vue
@@ -162,7 +162,11 @@ export default Vue.extend({
         from: '',
       })
       this.$store.dispatch('ui/setChatbarContent', { content: message })
-      this.$store.dispatch('ui/setChatbarFocus')
+
+      // in desktop, stay chatbar focused when switching recipient
+      if (this.$device.isDesktop) {
+        this.$store.dispatch('ui/setChatbarFocus')
+      }
     },
   },
   methods: {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
in chat page on mobile(ios), when the user goes in chat page, virtual keyboard hides chatbox, and yup, this PR fixes by setting chatbarFocus flag as false
**Which issue(s) this PR fixes** 🔨
AP-1384
<!--AP-X-->

**Special notes for reviewers** 🗒️
I had to remove line 165 in components\views\chat\chatbar.vue
this.$store.dispatch('ui/setChatbarFocus')
don't know what this line does, but had to remove it to fix this bug.
**Additional comments** 🎤

