### PR TITLE
chore(glyphs): removes description

### DIFF
--- a/components/views/glyphs/Glyphs.html
+++ b/components/views/glyphs/Glyphs.html
@@ -8,7 +8,7 @@
     />
   </div>
   <GlyphsSample :glyphUrls="samplePackUrls" />
-  <TypographyText :text="selectedPack.description" />
+  <TypographyText v-if="featureReadyToShow" :text="selectedPack.description " />
   <InteractablesButton
     class="button"
     size="small"

--- a/components/views/glyphs/Glyphs.html
+++ b/components/views/glyphs/Glyphs.html
@@ -8,7 +8,6 @@
     />
   </div>
   <GlyphsSample :glyphUrls="samplePackUrls" />
-  <TypographyText v-if="featureReadyToShow" :text="selectedPack.description" />
   <InteractablesButton
     class="button"
     size="small"

--- a/components/views/glyphs/Glyphs.html
+++ b/components/views/glyphs/Glyphs.html
@@ -8,7 +8,7 @@
     />
   </div>
   <GlyphsSample :glyphUrls="samplePackUrls" />
-  <TypographyText v-if="featureReadyToShow" :text="selectedPack.description " />
+  <TypographyText v-if="featureReadyToShow" :text="selectedPack.description" />
   <InteractablesButton
     class="button"
     size="small"

--- a/components/views/glyphs/Glyphs.vue
+++ b/components/views/glyphs/Glyphs.vue
@@ -4,7 +4,8 @@ import Vue from 'vue'
 import { mapState } from 'vuex'
 import { findKey, shuffle } from 'lodash'
 import { ShoppingBagIcon } from 'satellite-lucide-icons'
-import { ModalWindows } from '~/store/ui/types'
+// import { marketGlyphs } from '~/mock/marketplace'
+import { GlyphMarketViewStatus, ModalWindows } from '~/store/ui/types'
 
 export default Vue.extend({
   components: {

--- a/components/views/glyphs/Glyphs.vue
+++ b/components/views/glyphs/Glyphs.vue
@@ -34,7 +34,6 @@ export default Vue.extend({
       this.$store.commit('ui/toggleModal', {
         name: ModalWindows.CALLTOACTION,
         state: !this.ui.modals[ModalWindows.CALLTOACTION],
-        featureReadyToShow: false,
       })
       /* refactor - AP-1104
        const marketInfo = find(marketGlyphs, ({ glyph }) => {

--- a/components/views/glyphs/Glyphs.vue
+++ b/components/views/glyphs/Glyphs.vue
@@ -4,8 +4,7 @@ import Vue from 'vue'
 import { mapState } from 'vuex'
 import { findKey, shuffle } from 'lodash'
 import { ShoppingBagIcon } from 'satellite-lucide-icons'
-import { marketGlyphs } from '~/mock/marketplace'
-import { GlyphMarketViewStatus, ModalWindows } from '~/store/ui/types'
+import { ModalWindows } from '~/store/ui/types'
 
 export default Vue.extend({
   components: {
@@ -35,15 +34,16 @@ export default Vue.extend({
       this.$store.commit('ui/toggleModal', {
         name: ModalWindows.CALLTOACTION,
         state: !this.ui.modals[ModalWindows.CALLTOACTION],
+        featureReadyToShow: false,
       })
-      // refactor - AP-1104
-      // const marketInfo = find(marketGlyphs, ({ glyph }) => {
-      //   return glyph.name === this.selectedPack.name
-      // })
-      // this.$store.commit('ui/setGlyphMarketplaceView', {
-      //   view: GlyphMarketViewStatus.SHOP_DETAIL,
-      //   shopId: marketInfo?.id,
-      // })
+      /* refactor - AP-1104
+       const marketInfo = find(marketGlyphs, ({ glyph }) => {
+         return glyph.name === this.selectedPack.name
+       })
+       this.$store.commit('ui/setGlyphMarketplaceView', {
+         view: GlyphMarketViewStatus.SHOP_DETAIL,
+         shopId: marketInfo?.id,
+       }) */
     },
   },
 })


### PR DESCRIPTION
**What this PR does** 📖

- Removes mock description on glyphs modal

before

<img width="577" alt="Captura de ecrã 2022-04-14, às 00 36 36" src="https://user-images.githubusercontent.com/29093946/163287000-2ef9c920-bbbf-41af-b5fa-8153ae924145.png">

after

<img width="599" alt="Captura de ecrã 2022-04-14, às 00 36 28" src="https://user-images.githubusercontent.com/29093946/163287009-0c5235b6-51e7-4f67-ae93-a10611c644d9.png">

- Removes not used imports
- Adds multi line comment on existing commented out code