### PR TITLE
fix(files): persistent files upload status

### DIFF
--- a/components/views/files/controls/Controls.html
+++ b/components/views/files/controls/Controls.html
@@ -48,8 +48,12 @@
       multiple
     />
   </div>
-  <TypographyText v-if="status" class="status" :text="status" :size="6" />
-  <UiProgress v-if="progress < 100" :progress="progress" />
+  <TypographyText
+    v-if="ui.filesUploadStatus"
+    class="status"
+    :text="ui.filesUploadStatus"
+    :size="6"
+  />
   <div class="error-container" v-if="errors.length">
     <alert-triangle-icon size="1.3x" />
     <div>

--- a/components/views/files/controls/Controls.less
+++ b/components/views/files/controls/Controls.less
@@ -22,8 +22,7 @@
     }
   }
 
-  .status,
-  .progress {
+  .status {
     margin-bottom: @normal-spacing;
   }
 

--- a/components/views/files/controls/Controls.vue
+++ b/components/views/files/controls/Controls.vue
@@ -33,8 +33,6 @@ export default Vue.extend({
     return {
       text: '' as string,
       errors: [] as Array<string | TranslateResult>,
-      status: '' as string | TranslateResult,
-      progress: 100 as number,
     }
   },
   computed: {
@@ -151,7 +149,10 @@ export default Vue.extend({
       }
       for (const file of files) {
         try {
-          this.status = this.$t('pages.files.controls.upload', [file.name])
+          this.$store.commit(
+            'ui/setFilesUploadStatus',
+            this.$t('pages.files.controls.upload', [file.name]),
+          )
           await this.$FileSystem.uploadFile(file, this.setProgress)
         } catch (e: any) {
           this.errors.push(e?.message ?? '')
@@ -160,12 +161,15 @@ export default Vue.extend({
 
       // only update index if files have been updated
       if (files.length) {
-        this.status = this.$t('pages.files.controls.index')
+        this.$store.commit(
+          'ui/setFilesUploadStatus',
+          this.$t('pages.files.controls.index'),
+        )
         await this.$TextileManager.bucket?.updateIndex(this.$FileSystem.export)
       }
 
       this.$store.commit('ui/setIsLoadingFileIndex', false)
-      this.status = ''
+      this.$store.commit('ui/setFilesUploadStatus', '')
 
       // re-render so new files show up
       this.$emit('forceRender')
@@ -189,8 +193,13 @@ export default Vue.extend({
      * @param num current progress in bytes
      * @param size total file size in bytes
      */
-    setProgress(num: number, size: number) {
-      this.progress = Math.floor((num / size) * 100)
+    setProgress(num: number, size: number, name: string) {
+      this.$store.commit(
+        'ui/setFilesUploadStatus',
+        this.$t('pages.files.controls.upload', [
+          `${name} - ${Math.floor((num / size) * 100)}%`,
+        ]),
+      )
     },
   },
 })

--- a/components/views/files/controls/Controls.vue
+++ b/components/views/files/controls/Controls.vue
@@ -190,6 +190,7 @@ export default Vue.extend({
     /**
      * @method setProgress
      * @description set progress (% out of 100) while file is being pushed to textile bucket. passed as a callback
+     * we encountered a bug where % was getting set to 105, math.min fixes that
      * @param num current progress in bytes
      * @param size total file size in bytes
      */
@@ -197,7 +198,7 @@ export default Vue.extend({
       this.$store.commit(
         'ui/setFilesUploadStatus',
         this.$t('pages.files.controls.upload', [
-          `${name} - ${Math.floor((num / size) * 100)}%`,
+          `${name} - ${Math.min(Math.floor((num / size) * 100), 100)}%`,
         ]),
       )
     },

--- a/libraries/Files/remote/textile/Bucket.ts
+++ b/libraries/Files/remote/textile/Bucket.ts
@@ -126,7 +126,7 @@ export class Bucket extends RFM implements RFMInterface {
       },
       {
         progress: (num) => {
-          progressCallback(num, file.size)
+          progressCallback(num, file.size, file.name)
         },
       },
     )

--- a/plugins/thirdparty/persist.ts
+++ b/plugins/thirdparty/persist.ts
@@ -38,6 +38,7 @@ const commonProperties = [
   'ui.modals',
   'ui.isScrollOver',
   'ui.filePreview',
+  'ui.filesUploadStatus',
 ]
 
 const propertiesNoStorePin = [

--- a/store/ui/__snapshots__/state.test.ts.snap
+++ b/store/ui/__snapshots__/state.test.ts.snap
@@ -34,6 +34,7 @@ Object {
     "asc": true,
     "category": "modified",
   },
+  "filesUploadStatus": "",
   "fullscreen": false,
   "glyphMarketplaceView": Object {
     "shopId": null,

--- a/store/ui/mutations.ts
+++ b/store/ui/mutations.ts
@@ -368,4 +368,7 @@ export default {
   setSwiperSlideIndex(state: UIState, index: number) {
     state.swiperSlideIndex = index
   },
+  setFilesUploadStatus(state: UIState, value: string) {
+    state.filesUploadStatus = value
+  },
 }

--- a/store/ui/state.ts
+++ b/store/ui/state.ts
@@ -74,6 +74,7 @@ const InitialUIState = (): UIState => ({
     flair: Flairs[0],
   },
   isLoadingFileIndex: false,
+  filesUploadStatus: '',
   renameCurrentName: undefined,
   filePreview: undefined,
   chatImageOverlay: undefined,

--- a/store/ui/types.ts
+++ b/store/ui/types.ts
@@ -213,6 +213,7 @@ export interface UIState {
     flair: Flair
   }
   isLoadingFileIndex: boolean
+  filesUploadStatus: string
   renameCurrentName?: string
   filePreview?: string
   chatImageOverlay?: ImageMessage


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- remove file upload progress bar in favor of percentage in status message. more consistent ui, less jarring than seeing the progress bar appear & disappear. Liz also said we don't use progress bars, so this is more cohesive with the rest of the app
- upload status will remain if you navigate away from this page and come back

**Which issue(s) this PR fixes** 🔨
AP-1395
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
I made a ticket for these
- since we're using store, I'd like to add status updates for other file operations (rename, remove, favorite) after this
- could probably also clean up store, switching to this rather than the boolean for keeping track of active files operations