### PR TITLE
fix(mobile): fix image picker position

### DIFF
--- a/components/views/files/upload/Upload.html
+++ b/components/views/files/upload/Upload.html
@@ -39,13 +39,12 @@
     :type="editable ? `file` : `hidden`"
     id="quick-upload"
     ref="quickUpload"
-    @click="resetFileUpload"
     @change="handleFile"
     multiple
   />
   <label
     v-if="type == 'quick'"
-    for="quick-upload"
+    @click="handleFileClick"
     :data-tooltip="$t('global.upload')"
     :class="`has-tooltip has-tooltip-top has-tooltip-primary upload-label ${editable ? 'active' : 'inactive'}`"
   >
@@ -53,7 +52,7 @@
   </label>
   <div v-if="type =='button'">
     <label
-      for="quick-upload"
+      @click="handleFileClick"
       class="button is-button is-small is-primary is-normal-width"
     >
       <UiGlowingCursorArea>

--- a/components/views/files/upload/Upload.vue
+++ b/components/views/files/upload/Upload.vue
@@ -22,6 +22,7 @@ declare module 'vue/types/vue' {
     finishUploads: () => void
     dispatchFile: (file: UploadDropItemType) => void
     alertNsfwFile: () => void
+    resetFileUpload: () => void
   }
 }
 
@@ -87,6 +88,14 @@ export default Vue.extend({
     async resetFileUpload() {
       if (this.$refs.quickUpload)
         (this.$refs.quickUpload as HTMLFormElement).value = ''
+    },
+    handleFileClick() {
+      this.resetFileUpload()
+
+      setTimeout(() => {
+        if (this.$refs.quickUpload)
+          (this.$refs.quickUpload as HTMLFormElement).click()
+      }, 200)
     },
     /**
      * @method handleFile


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
on the mobile screen, the image picker position is weird because the virtual keyboard is hidden and shows like floating in the middle. fixed by delaying click event and shows image picker after virtual keyboard hide
**Which issue(s) this PR fixes** 🔨
AP-1385
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
