### PR TITLE
chore(jest): increase coverage on store/textile/getters.test.ts

### DIFF
--- a/store/textile/__snapshots__/getters.test.ts.snap
+++ b/store/textile/__snapshots__/getters.test.ts.snap
@@ -1,3 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`getters.default.getConversation 0 1`] = `[Function]`;
+
+exports[`getters.default.getConversation 1 1`] = `[Function]`;
+
+exports[`getters.default.getConversation 2 1`] = `[Function]`;
+
+exports[`getters.default.getConversationMessages 0 1`] = `[Function]`;
+
+exports[`getters.default.getInitialized 0 1`] = `true`;
+
 exports[`init should return the initialized variable of the state 1`] = `false`;

--- a/store/textile/getters.test.ts
+++ b/store/textile/getters.test.ts
@@ -24,3 +24,77 @@ describe('init', () => {
     expect(result).not.toEqual({})
   })
 })
+
+describe('getters.default.getInitialized', () => {
+  test('0', () => {
+    const result: any = getters.default.getInitialized({
+      initialized: true,
+      activeConversation: 'da7588892',
+      conversations: {},
+      conversationLoading: true,
+      messageLoading: false,
+      uploadProgress: {
+        key0: { progress: 300, finished: false, name: 'Pierre Edouard' },
+        key1: { progress: 0.0, finished: true, name: 'Michael' },
+        key2: { progress: 0.0, finished: true, name: 'Jean-Philippe' },
+      },
+    })
+    expect(result).toMatchSnapshot()
+  })
+})
+
+describe('getters.default.getConversationMessages', () => {
+  test('0', () => {
+    const result: any = getters.default.getConversationMessages({
+      initialized: true,
+      activeConversation: '',
+      conversations: {},
+      conversationLoading: false,
+      messageLoading: false,
+      uploadProgress: {
+        key0: { progress: NaN, finished: false, name: '' },
+        key1: { progress: NaN, finished: false, name: '' },
+        key2: { progress: NaN, finished: true, name: '' },
+      },
+    })
+    expect(result).toMatchSnapshot()
+  })
+})
+
+describe('getters.default.getConversation', () => {
+  test('0', () => {
+    const result: any = getters.default.getConversation({
+      initialized: true,
+      activeConversation: '9876',
+      conversations: {},
+      conversationLoading: false,
+      messageLoading: true,
+      uploadProgress: {},
+    })
+    expect(result).toMatchSnapshot()
+  })
+
+  test('1', () => {
+    const result: any = getters.default.getConversation({
+      initialized: false,
+      activeConversation: 'bc23a9d531064583ace8f67dad60f6bb',
+      conversations: {},
+      conversationLoading: true,
+      messageLoading: false,
+      uploadProgress: {},
+    })
+    expect(result).toMatchSnapshot()
+  })
+
+  test('2', () => {
+    const result: any = getters.default.getConversation({
+      initialized: false,
+      activeConversation: '',
+      conversations: {},
+      conversationLoading: true,
+      messageLoading: true,
+      uploadProgress: {},
+    })
+    expect(result).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION

**What this PR does** 📖

- Increase coverage on store/textile/getters.test.ts

before

<img width="976" alt="Captura de ecrã 2022-04-19, às 18 10 18" src="https://user-images.githubusercontent.com/29093946/164059557-a652ee83-2e62-404b-b0b8-0b40304591d7.png">

after

<img width="974" alt="Captura de ecrã 2022-04-19, às 18 13 57" src="https://user-images.githubusercontent.com/29093946/164059565-212d10bb-df64-4430-aae1-e606a7d25929.png">

