### PR TITLE
test(cypress): remove privacy toggles screen validations

### DIFF
--- a/components/views/friends/friend/Friend.html
+++ b/components/views/friends/friend/Friend.html
@@ -1,4 +1,4 @@
-<div class="friend">
+<div class="friend" data-cy="friend">
   <UiUserState :user="friend" :src="src" />
   <div class="description">
     <TypographySubtitle :size="6" :text="friend.name" data-cy="friend-name" />

--- a/components/views/user/User.html
+++ b/components/views/user/User.html
@@ -1,12 +1,13 @@
 <div
   class="user"
+  data-cy="sidebar-user"
   v-bind:class="{'is-loading' : isLoading , 'is-selected' : isSelected}"
   @contextmenu="contextMenu"
   v-on:click="navigateToUser"
 >
   <UiUserState :user="user" :isTyping="isTyping" :src="src" />
   <div class="user-info">
-    <TypographyTitle :size="6" :text="user.name" />
+    <TypographyTitle :size="6" data-cy="sidebar-user-name" :text="user.name" />
     <TypographySubtitle :size="6" :text="lastMessage" />
   </div>
   <div class="user-chat-details">

--- a/cypress/integration/chat-features.js
+++ b/cypress/integration/chat-features.js
@@ -8,7 +8,7 @@ const recoverySeed =
   'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}'
 let imageURL
 
-describe.skip('Chat Features Tests', () => {
+describe('Chat Features Tests', () => {
   it('Chat - Send message on chat', () => {
     // Import account
     cy.importAccount(randomPIN, recoverySeed)

--- a/cypress/integration/chat-glyphs-validations.js
+++ b/cypress/integration/chat-glyphs-validations.js
@@ -3,7 +3,7 @@ const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate
 const recoverySeed =
   'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}'
 
-describe.skip('Chat - Sending Glyphs Tests', () => {
+describe('Chat - Sending Glyphs Tests', () => {
   it('Send a glyph on chat', () => {
     //Import account
     cy.importAccount(randomPIN, recoverySeed)

--- a/cypress/integration/chat-images-validations.js
+++ b/cypress/integration/chat-images-validations.js
@@ -8,7 +8,7 @@ const jpgImagePath = 'cypress/fixtures/images/jpeg-test.jpg'
 const gifImagePath = 'cypress/fixtures/images/gif-test.gif'
 const invalidImagePath = 'cypress/fixtures/images/incorrect-image.png'
 
-describe.skip('Chat - Sending Images Tests', () => {
+describe('Chat - Sending Images Tests', () => {
   it('PNG image is sent succesfully on chat', () => {
     //Import account
     cy.importAccount(randomPIN, recoverySeed)

--- a/cypress/integration/chat-pair-features.js
+++ b/cypress/integration/chat-pair-features.js
@@ -13,7 +13,7 @@ const fileLocalPath = 'cypress/fixtures/test-file.txt'
 const textReply = 'This is a reply to the message'
 let glyphURL, imageURL, fileURL
 
-describe.skip('Chat features with two accounts', () => {
+describe('Chat features with two accounts', () => {
   it('Ensure chat window from first account is displayed', () => {
     //Import first account
     cy.importAccount(randomPIN, recoverySeedAccountOne)
@@ -53,7 +53,7 @@ describe.skip('Chat features with two accounts', () => {
     cy.validateOptionNotInContextMenu('[data-cy=chat-glyph]', 'Edit')
   })
 
-  it.skip('Send image to user B', () => {
+  it('Send image to user B', () => {
     cy.chatFeaturesSendImage(imageLocalPath, 'logo.png')
     cy.goToLastImageOnChat()
       .invoke('attr', 'src')
@@ -62,7 +62,7 @@ describe.skip('Chat features with two accounts', () => {
       })
   })
 
-  it.skip('Image messages cannot be edited', () => {
+  it('Image messages cannot be edited', () => {
     cy.validateOptionNotInContextMenu('[data-cy=chat-image]', 'Edit')
   })
 
@@ -142,7 +142,7 @@ describe.skip('Chat features with two accounts', () => {
       })
   })
 
-  it.skip('Assert image received from user A', () => {
+  it('Assert image received from user A', () => {
     cy.goToLastImageOnChat()
       .invoke('attr', 'src')
       .then((imageSecondAccountSrc) => {
@@ -176,7 +176,7 @@ describe.skip('Chat features with two accounts', () => {
     cy.validateChatReaction('@messageToReact', '😄')
   })
 
-  it.skip('Add reactions to image in chat', () => {
+  it('Add reactions to image in chat', () => {
     cy.get('[data-cy=chat-image]').last().as('imageToReact')
     cy.reactToChatElement('@imageToReact', '[title="smile"]')
     cy.validateChatReaction('@imageToReact', '😄')
@@ -205,6 +205,7 @@ describe.skip('Chat features with two accounts', () => {
 
   it('Assert timestamp immediately after sending message', () => {
     //Send a random message
+    cy.get('[data-cy=editable-input]').clear()
     cy.chatFeaturesSendMessage(randomMessageTwo)
 
     //Assert timestamp text immediately

--- a/cypress/integration/chat-text-validations.js
+++ b/cypress/integration/chat-text-validations.js
@@ -7,7 +7,7 @@ let urlToValidate = 'https://www.satellite.im'
 let urlToValidateTwo = 'http://www.satellite.im'
 let urlToValidateThree = 'www.satellite.im'
 
-describe.skip('Chat Text and Sending Links Validations', () => {
+describe('Chat Text and Sending Links Validations', () => {
   it('Message with more than 2048 chars - Counter get reds', () => {
     //Import account
     cy.importAccount(randomPIN, recoverySeed)

--- a/cypress/integration/chat-top-toolbar.js
+++ b/cypress/integration/chat-top-toolbar.js
@@ -3,7 +3,7 @@ const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate
 const recoverySeed =
   'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}'
 
-describe.skip('Chat Toolbar Tests', () => {
+describe('Chat Toolbar Tests', () => {
   it('Chat - Toolbar - Validate audio icon is displayed', () => {
     //Import account
     cy.importAccount(randomPIN, recoverySeed)

--- a/cypress/integration/create-account-negative-tests.js
+++ b/cypress/integration/create-account-negative-tests.js
@@ -21,9 +21,6 @@ describe('Create Account - Negative Tests', () => {
     //Create or Import account selection screen
     cy.createAccountSecondScreen()
 
-    //Privacy Settings screen
-    cy.createAccountPrivacyTogglesGoNext()
-
     //Recovery Seed Screen
     cy.createAccountRecoverySeed()
 
@@ -39,9 +36,6 @@ describe('Create Account - Negative Tests', () => {
 
     //Create or Import account selection screen
     cy.createAccountSecondScreen()
-
-    //Privacy Settings screen
-    cy.createAccountPrivacyTogglesGoNext()
 
     //Recovery Seed Screen
     cy.createAccountRecoverySeed()

--- a/cypress/integration/create-account.js
+++ b/cypress/integration/create-account.js
@@ -9,8 +9,6 @@ const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate
 describe.skip('Create Account Validations', () => {
   Cypress.on('uncaught:exception', (err, runnable) => false) // temporary until AP-48 gets fixed
   it('Create Account', () => {
-    //Testing in a viewport that does not require to scroll
-    cy.viewport(1000, 1200)
     //Enter PIN screen
     cy.createAccountPINscreen(randomPIN, false, false)
 
@@ -20,56 +18,6 @@ describe.skip('Create Account Validations', () => {
     ).should('be.visible')
     cy.get('[data-cy=create-account-button]').should('be.visible')
     cy.createAccountSecondScreen()
-
-    //Privacy Settings screen - Adding text validations below instead of using a command
-    //Title and subtitle are visible
-    cy.contains('Privacy Settings').should('be.visible')
-    cy.contains(
-      'Choose which features to enable to best suit your privacy preferences.',
-    ).should('be.visible')
-    //First toggle and description is visible
-    cy.contains('Register Username Publicly').should('be.visible')
-    cy.contains(
-      'Publicly associate your account ID with a human readable username. Anyone can see this association.',
-    ).should('be.visible')
-    //Second toggle and description is visible
-    cy.contains('Store Account Pin').should('be.visible')
-    cy.contains(
-      "Store your account pin locally so you don't have to enter it manually every time. This is not recommended.",
-    ).should('be.visible')
-    //Third toggle and description is visible
-    cy.contains('Enable External Embeds').should('be.visible')
-    cy.contains(
-      'Allow Satellite to fetch data from external sites in order to expand links like Spotify, YouTube, and more.',
-    ).should('be.visible')
-    //Fourth toggle and description is visible
-    cy.contains('Display Current Activity').should('be.visible')
-    cy.contains(
-      "Allow Satellite to see what games you're playing and show them off on your profile so friends can jump in.",
-    ).should('be.visible')
-    //Fifth toggle and description is visible
-    cy.contains('Consents to having files scanned').should('be.visible')
-    cy.contains(
-      'In order to share files/use the encrypted file storage I consent to having my files auto-scanned against the Microsoft PhotoDNA service to help prevent the spread of sexual abuse material',
-    ).should('be.visible')
-    //Option for Signaling Servers
-    cy.contains('Signaling Servers').should('be.visible')
-    cy.contains(
-      "Choose which signaling server group you want to use. If you use 'Satellite + Public Signaling Servers', you are using public servers and Satellite hosted servers to connect with your friends. We do not track connections. We only track server utilization (memory and cpu usage) to know if we need to turn on more signaling servers. If you opt to use 'Only Public Signaling Servers', those are totally outside of Satellite control, so we can not see or have any insight into their operation, logging, or data sharing practices, and you may experience difficulties connecting with friends if the signaling servers are overloaded.",
-    ).should('be.visible')
-
-    cy.get('.switch-button')
-      .should('be.visible')
-      .each(($btn, index, $List) => {
-        if (!$btn.hasClass('locked')) {
-          if ($btn.hasClass('enabled')) {
-            cy.wrap($btn).click().should('not.have.class', 'enabled')
-          } else {
-            cy.wrap($btn).click().should('have.class', 'enabled')
-          }
-        }
-      })
-    cy.get('[data-cy=privacy-continue-button]').should('be.visible').click()
 
     //Recovery Seed Screen
     cy.get('.title').should('be.visible').should('contain', 'Recovery Seed')
@@ -106,7 +54,6 @@ describe.skip('Create Account Validations', () => {
 
     //Clicking on buttons to continue to user data screen
     cy.createAccountSecondScreen()
-    cy.createAccountPrivacyTogglesGoNext()
     cy.createAccountRecoverySeed()
 
     //Adding random data in user input fields
@@ -140,7 +87,6 @@ describe.skip('Create Account Validations', () => {
     //Clicking on buttons to continue to user data screen
 
     cy.createAccountSecondScreen()
-    cy.createAccountPrivacyTogglesGoNext()
     cy.createAccountRecoverySeed()
 
     //Adding random data in user input fields
@@ -167,13 +113,12 @@ describe.skip('Create Account Validations', () => {
     ).should('not.exist')
   })
 
-  it.skip('Create account without image after attempting to add an invalid image file', () => {
+  it('Create account without image after attempting to add an invalid image file', () => {
     //Creating pin
     cy.createAccountPINscreen(randomPIN)
 
     //Clicking on buttons to continue to user data screen
     cy.createAccountSecondScreen()
-    cy.createAccountPrivacyTogglesGoNext()
     cy.createAccountRecoverySeed()
 
     //Adding random data in user input fields
@@ -184,7 +129,7 @@ describe.skip('Create Account Validations', () => {
     cy.createAccountAddImage(invalidImagePath)
     cy.get('[data-cy=error-message]', { timeout: 60000 }).should(
       'have.text',
-      'Unable to upload, invalid file.',
+      'Please upload a valid image type such as JPG, PNG or SVG',
     )
 
     //User is still able to sign in and invalid image will not be loaded
@@ -206,7 +151,6 @@ describe.skip('Create Account Validations', () => {
 
     //Clicking on buttons to continue to user data screen
     cy.createAccountSecondScreen()
-    cy.createAccountPrivacyTogglesGoNext()
     cy.createAccountRecoverySeed()
 
     //Adding random data in user input fields
@@ -217,7 +161,7 @@ describe.skip('Create Account Validations', () => {
     cy.createAccountAddImage(invalidImagePath)
     cy.get('[data-cy=error-message]', { timeout: 60000 }).should(
       'have.text',
-      'Unable to upload, invalid file.',
+      'Please upload a valid image type such as JPG, PNG or SVG',
     )
 
     //Now adding a valid image and validating user can pass to next step

--- a/cypress/integration/mobiles-responsiveness.js
+++ b/cypress/integration/mobiles-responsiveness.js
@@ -21,9 +21,6 @@ describe('Run responsiveness tests on several devices', () => {
       //Create or Import account selection screen
       cy.createAccountSecondScreen()
 
-      //Privacy Settings screen
-      cy.createAccountPrivacyTogglesGoNext()
-
       //Recovery Seed Screen
       cy.createAccountRecoverySeed()
 
@@ -48,17 +45,14 @@ describe('Run responsiveness tests on several devices', () => {
       cy.importAccount(randomPIN, recoverySeed)
       //Validate profile name displayed
       cy.validateChatPageIsLoaded()
-    })
-
-    it.skip(`Chat Features on ${item.description}`, () => {
-      //Setting viewport
-      cy.viewport(item.width, item.height)
-
-      //Validate profile name displayed
-      cy.validateChatPageIsLoaded()
 
       //Go to conversation
       cy.goToConversation('cypress friend', true)
+    })
+
+    it(`Chat Features on ${item.description}`, () => {
+      //Setting viewport
+      cy.viewport(item.width, item.height)
 
       //Validate message and emojis are sent
       cy.chatFeaturesSendMessage(randomMessage)
@@ -66,47 +60,48 @@ describe('Run responsiveness tests on several devices', () => {
 
       //Validate message can be edited
       cy.chatFeaturesEditMessage(randomMessage, randomNumber)
-    })
 
-    it.skip(`Chat - Marketplace - Coming Soon modal content on ${item.description}`, () => {
-      cy.viewport(item.width, item.height)
+      //Chat - Marketplace - Coming Soon modal content
+      cy.log(
+        `Chat - Marketplace - Coming Soon modal content on ${item.description}`,
+      )
       cy.get('[data-cy=toolbar-marketplace]').click()
       cy.validateComingSoonModal()
-    })
 
-    it.skip(`Chat - Marketplace - Coming Soon modal button URL on ${item.description}`, () => {
-      cy.viewport(item.width, item.height)
+      //Chat - Marketplace - Coming Soon modal button URL
+      cy.log(
+        `Chat - Marketplace - Coming Soon modal button URL on ${item.description}`,
+      )
       cy.validateURLComingSoonModal()
-    })
 
-    it.skip(`Chat - Marketplace - Coming Soon modal can be dismissed on ${item.description}`, () => {
-      cy.viewport(item.width, item.height)
+      //Chat - Marketplace - Coming Soon modal can be dismissed
+      cy.log(
+        `Chat - Marketplace - Coming Soon modal can be dismissed on ${item.description}`,
+      )
       cy.closeModal('[data-cy=modal-cta]')
-    })
 
-    it.skip(`Chat - Glyph Pack screen is displayed on ${item.description}`, () => {
-      cy.viewport(item.width, item.height)
+      //Chat - Glyph Pack screen is displayed
+      cy.log(`Chat - Glyph Pack screen is displayed on ${item.description}`)
       cy.chatFeaturesSendGlyph()
       cy.goToLastGlyphOnChat().click()
       cy.validateGlyphsModal()
-    })
 
-    it.skip(`Chat - Glyph Pack - Coming Soon modal on ${item.description}`, () => {
-      cy.viewport(item.width, item.height)
+      //Chat - Glyph Pack - Coming Soon modal
+      cy.log(`Chat - Glyph Pack - Coming Soon modal on ${item.description}`)
       cy.contains('View Glyph Pack').click()
       cy.get('[data-cy=modal-cta]').should('be.visible')
       cy.closeModal('[data-cy=modal-cta]')
-    })
 
-    it.skip(`Chat - Glyph Pack screen can be dismissed on ${item.description}`, () => {
-      cy.viewport(item.width, item.height)
+      //Chat - Glyph Pack screen can be dismissed
+      cy.log(`Chat - Glyph Pack screen can be dismissed on ${item.description}`)
       cy.goToLastGlyphOnChat().click()
       cy.get('[data-cy=glyphs-modal]').should('be.visible')
       cy.closeModal('[data-cy=glyphs-modal]')
-    })
 
-    it.skip(`Chat - Glyphs Selection - Coming soon modal on ${item.description}`, () => {
-      cy.viewport(item.width, item.height)
+      //Chat - Glyphs Selection - Coming soon modal
+      cy.log(
+        `Chat - Glyphs Selection - Coming soon modal on ${item.description}`,
+      )
       cy.get('#glyph-toggle').click()
       cy.get('[data-cy=glyphs-marketplace]').click()
       cy.get('[data-cy=modal-cta]').should('be.visible')

--- a/cypress/integration/pin-unlock-validations.js
+++ b/cypress/integration/pin-unlock-validations.js
@@ -3,14 +3,13 @@ const userPassphrase =
   'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower'
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 
-describe.skip('Unlock pin should be persisted when store pin is enabled', () => {
+describe('Unlock pin should be persisted when store pin is enabled', () => {
   it.skip('Create Account with store pin disabled', () => {
     //Go to URL, add a PIN and make sure that toggle for save pin is disabled
     cy.createAccountPINscreen(randomPIN, false, false)
 
     //Follow the next steps to create an account
     cy.createAccountSecondScreen()
-    cy.createAccountPrivacyTogglesGoNext()
     cy.createAccountRecoverySeed()
     cy.validateUserInputIsDisplayed()
     cy.createAccountUserInput()
@@ -31,7 +30,6 @@ describe.skip('Unlock pin should be persisted when store pin is enabled', () => 
 
     //Follow the next steps to create an account
     cy.createAccountSecondScreen()
-    cy.createAccountPrivacyTogglesGoNext()
     cy.createAccountRecoverySeed()
     cy.validateUserInputIsDisplayed()
     cy.createAccountUserInput()

--- a/cypress/integration/pin-unlock-validations.js
+++ b/cypress/integration/pin-unlock-validations.js
@@ -3,8 +3,8 @@ const userPassphrase =
   'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower'
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 
-describe('Unlock pin should be persisted when store pin is enabled', () => {
-  it.skip('Create Account with store pin disabled', () => {
+describe.skip('Unlock pin should be persisted when store pin is enabled', () => {
+  it('Create Account with store pin disabled', () => {
     //Go to URL, add a PIN and make sure that toggle for save pin is disabled
     cy.createAccountPINscreen(randomPIN, false, false)
 
@@ -24,7 +24,7 @@ describe('Unlock pin should be persisted when store pin is enabled', () => {
     })
   })
 
-  it.skip('Create Account with store pin enabled', () => {
+  it('Create Account with store pin enabled', () => {
     //Go to URL, add a PIN and make sure that toggle for save pin is enabled
     cy.createAccountPINscreen(randomPIN, true, false)
 

--- a/cypress/integration/privacy-page-toggles.js
+++ b/cypress/integration/privacy-page-toggles.js
@@ -7,49 +7,18 @@ const randomStatus = faker.lorem.word() // generate random status
 let toggleStatusSaved = []
 let toggleStatusProfile = []
 
-describe.skip('Privacy Page Toggles Tests', () => {
+describe.skip('Privacy Settings Page - Toggles Tests', () => {
   Cypress.on('uncaught:exception', (err, runnable) => false) // to bypass Module build failed: Error: ENOENT: No such file or directory issue randomly presented
 
-  it('Privacy page - Verify all non-locked toggles switches work as should', () => {
+  it('Privacy Page - Validate existing toggles', () => {
+    //Setting a viewport visible for all toggles
+    cy.viewport(1200, 1200)
+
     //Adding pin to continue to toggles switches screen
     cy.createAccountPINscreen(randomPIN)
 
     //Create or Import account selection screen
     cy.createAccountSecondScreen()
-    //Validating each toggle, checking status is correct after clicking them.
-    //Finally, saving values into an array for later comparison
-    cy.get('[data-cy=switch-button]', { timeout: 30000 }).each(
-      ($btn, index, $List) => {
-        if (!$btn.hasClass('locked')) {
-          if ($btn.hasClass('enabled')) {
-            cy.wrap($btn).click().should('not.have.class', 'enabled')
-            toggleStatusSaved.push(false)
-          } else {
-            cy.wrap($btn).click().should('have.class', 'enabled')
-            toggleStatusSaved.push(true)
-          }
-        }
-      },
-    )
-  })
-
-  it('Privacy page - Verify register publicly toggle is locked and disabled', () => {
-    cy.get('[data-cy=switch-button]', { timeout: 30000 }).each(
-      ($btn, index, $List) => {
-        if ($btn.hasClass('locked')) {
-          expect($btn).to.not.have.class('enabled')
-          expect($btn).to.have.class('locked')
-          cy.wrap($btn).realHover()
-          // Move back cursor to top left again
-          cy.get('body').realHover({ position: 'topLeft' })
-        }
-      },
-    )
-  })
-
-  it.skip('Privacy page - Verify user can still proceed after adjusting switches', () => {
-    //Click on next
-    cy.get('[data-cy=privacy-continue-button]').click()
 
     //Recovery Seed Screen
     cy.createAccountRecoverySeed()
@@ -63,38 +32,84 @@ describe.skip('Privacy Page Toggles Tests', () => {
     cy.validateChatPageIsLoaded()
     //Going to Settings and Privacy screen
     cy.get('[data-cy=settings]', { timeout: 30000 }).click()
-  })
 
-  it.skip('Profile - Verify the toggles user added when signing up are on the same status when user goes to settings', () => {
+    //Click on 'Privacy'
     cy.contains('Privacy').click()
-    //Storing the values from toggle switches status of Settings screen into an array
-    cy.get('[data-cy=switch-button]')
-      .each(($btn, index, $List) => {
-        if (!$btn.hasClass('locked')) {
-          if ($btn.hasClass('enabled')) {
-            toggleStatusProfile.push(true)
-          } else {
-            toggleStatusProfile.push(false)
-          }
-        }
-      })
-      .then(() => {
-        //Comparison of both arrays to ensure that are deep equal
-        expect(toggleStatusProfile).to.deep.equal(toggleStatusSaved)
-      })
+
+    //Validate contents on screen
+    cy.contains('Privacy Settings').should('be.visible')
+    cy.contains(
+      'Choose which features to enable to best suit your privacy preferences.',
+    ).should('be.visible')
+
+    cy.contains('Register Username Publicly').should('be.visible')
+    cy.contains(
+      'Publicly associate your account ID with a human readable username. Anyone can see this association.',
+    ).should('be.visible')
+
+    cy.contains('Store Account Pin').should('be.visible')
+    cy.contains(
+      "Store your account pin locally so you don't have to enter it manually every time. This is not recommended.",
+    ).should('be.visible')
+
+    cy.contains('Enable External Embeds').should('be.visible')
+    cy.contains(
+      'Allow Satellite to fetch data from external sites in order to expand links like Spotify, YouTube, and more.',
+    ).should('be.visible')
+
+    cy.contains('Display Current Activity').should('be.visible')
+    cy.contains(
+      "Allow Satellite to see what games you're playing and show them off on your profile so friends can jump in.",
+    ).should('be.visible')
+
+    cy.contains('Consent to File Scanning').should('be.visible')
+    cy.contains(
+      'In order to share files/use the encrypted file storage I consent to having my files auto-scanned against the Microsoft PhotoDNA service to help prevent the spread of sexual abuse material',
+    ).should('be.visible')
+
+    cy.contains('Block NSFW content').should('be.visible')
+    cy.contains('If selected, NSFW content will be obscured.').should(
+      'be.visible',
+    )
+
+    cy.contains('Signaling Servers').should('be.visible')
+    cy.contains(
+      "Choose which signaling server group you want to use. If you use 'Satellite + Public Signaling Servers', you are using public servers and Satellite hosted servers to connect with your friends. We do not track connections. We only track server utilization (memory and cpu usage) to know if we need to turn on more signaling servers. If you opt to use 'Only Public Signaling Servers', those are totally outside of Satellite control, so we can not see or have any insight into their operation, logging, or data sharing practices, and you may experience difficulties connecting with friends if the signaling servers are overloaded.",
+    ).should('be.visible')
   })
 
-  it.skip('Profile - Verify user can’t update the register name publicly toggle on settings', () => {
-    //Identify the first switch button and ensure that is locked
-    cy.get('[data-cy=switch-button]').first().should('have.class', 'locked')
+  it('Privacy Page - Default values after account creation', () => {
+    //Setting a viewport visible for all toggles
+    cy.viewport(1200, 1200)
+
+    //Validate default values for toggles are selected after creating an account
+    cy.privacyToggleValidateValue('Register Username Publicly', false)
+    cy.privacyToggleValidateValue('Store Account Pin', false)
+    cy.privacyToggleValidateValue('Enable External Embeds', true)
+    cy.privacyToggleValidateValue('Display Current Activity', true)
+    cy.privacyToggleValidateValue('Consent to File Scanning', false)
+    cy.privacyToggleValidateValue('Block NSFW content', true)
+    cy.validateSignalingServersValue('Satellite + Public Signaling Servers')
+  })
+
+  it('Privacy Page - Verify register publicly toggle is locked and disabled', () => {
+    //Setting a viewport visible for all toggles
+    cy.viewport(1200, 1200)
+
+    cy.get('[data-cy=switch-button]').each(($btn, index, $List) => {
+      if ($btn.hasClass('locked')) {
+        expect($btn).to.not.have.class('enabled')
+        expect($btn).to.have.class('locked')
+        cy.wrap($btn).realHover()
+        // Move back cursor to top left again
+        cy.get('body').realHover({ position: 'topLeft' })
+      }
+    })
   })
 
   it('Privacy page - Verify all non-locked toggles can be switched to enable', () => {
-    //Adding pin to continue to toggles switches screen
-    cy.createAccountPINscreen(randomPIN)
-
-    //Create or Import account selection screen
-    cy.createAccountSecondScreen()
+    //Setting a viewport visible for all toggles
+    cy.viewport(1200, 1200)
 
     //Switch all non-locked switched to enabled
     cy.get('[data-cy=switch-button]').each(($btn, index, $List) => {
@@ -109,6 +124,9 @@ describe.skip('Privacy Page Toggles Tests', () => {
   })
 
   it('Privacy page - Verify all non-locked toggles can be switched to disabled', () => {
+    //Setting a viewport visible for all toggles
+    cy.viewport(1200, 1200)
+
     //Switch all non-locked switched to disabled
     cy.get('[data-cy=switch-button]').each(($btn, index, $List) => {
       if (!$btn.hasClass('locked')) {
@@ -121,94 +139,36 @@ describe.skip('Privacy Page Toggles Tests', () => {
     })
   })
 
-  it('Privacy page - Signup with Consents to having files scanned deactivated toggle', () => {
-    //Switch toggle to disabled
-    cy.privacyToggleClick('Consents to having files scanned', false)
-  })
-
-  it('Privacy page - Signup with Satellite and Public Signaling Servers', () => {
-    //Keep default option of using Satellite and Public Signaling Servers selected
-    cy.get('[data-cy=custom-select]').should('be.visible')
-    cy.validateSignalingServersValue('Satellite + Public Signaling Servers')
-  })
-
-  it.skip('Settings - Consents to having files scanned toggle should be deactivated', () => {
-    //Click on next
-    cy.get('[data-cy=privacy-continue-button]').click()
-
-    //Recovery Seed Screen
-    cy.createAccountRecoverySeed()
-
-    //Username and Status Input
-    cy.validateUserInputIsDisplayed()
-    cy.createAccountUserInput(randomName, randomStatus)
-
-    //Click on button, validate buffering screen and that user is redirected to friends/list
-    cy.createAccountSubmit()
-    cy.validateChatPageIsLoaded()
-    //Going to Settings and Privacy screen
-    cy.get('[data-cy=settings]', { timeout: 30000 }).click()
-
-    //Click on 'Privacy'
-    cy.contains('Privacy').click()
-
-    //Validate value from toggle is deactivated
-    cy.privacyToggleValidateValue('Consents to having files scanned', false)
-  })
-
-  it.skip('Settings - Satellite and Public Signaling Servers should be selected', () => {
+  it('Privacy page - Change to only Public Signaling Servers', () => {
+    //Setting a viewport visible for all toggles
     cy.viewport(1200, 1200)
-    //Validate value selected is Satellite and Public Signaling Servers
-    cy.validateSignalingServersValue('Satellite + Public Signaling Servers')
-  })
 
-  it('Privacy page - Signup with Consents to having files scanned activated toggle', () => {
-    //Adding pin to continue to toggles switches screen
-    cy.createAccountPINscreen(randomPIN)
-
-    //Create or Import account selection screen
-    cy.createAccountSecondScreen()
-
-    //Switch toggle to enabled
-    cy.privacyToggleClick('Consents to having files scanned', true)
-  })
-
-  it('Privacy page - Signup with only Public Signaling Servers', () => {
-    //Change option of to use only Public Signaling Servers
+    //Change option to use only Public Signaling Servers
     cy.get('[data-cy=custom-select]').should('be.visible').click()
     cy.get('[data-cy=custom-select-option-text]')
       .contains('Only Public Signaling Servers')
       .click()
     cy.validateSignalingServersValue('Only Public Signaling Servers')
+    cy.get('.close-button').click()
   })
 
-  it.skip('Settings - Consents to having files scanned toggle should be enabled', () => {
-    //Click on next
-    cy.get('[data-cy=privacy-continue-button]').scrollIntoView().click()
+  it('Privacy page - Validate that last values selected were saved correcty', () => {
+    //Setting a viewport visible for all toggles
+    cy.viewport(1200, 1200)
 
-    //Recovery Seed Screen
-    cy.createAccountRecoverySeed()
-
-    //Username and Status Input
-    cy.validateUserInputIsDisplayed()
-    cy.createAccountUserInput(randomName, randomStatus)
-
-    //Click on button, validate buffering screen and that user is redirected to friends/list
-    cy.createAccountSubmit()
-    cy.validateChatPageIsLoaded()
     //Going to Settings and Privacy screen
     cy.get('[data-cy=settings]', { timeout: 30000 }).click()
 
     //Click on 'Privacy'
     cy.contains('Privacy').click()
 
-    //Validate value from toggle is deactivated
-    cy.privacyToggleValidateValue('Consents to having files scanned', true)
-  })
-
-  it.skip('Settings - Only Public Signaling Servers should be selected', () => {
-    cy.viewport(1200, 1200)
-    //Validate value selected is Only Public Signaling Servers
+    //Validate default values for toggles are selected after creating an account
+    cy.privacyToggleValidateValue('Register Username Publicly', false)
+    cy.privacyToggleValidateValue('Store Account Pin', false)
+    cy.privacyToggleValidateValue('Enable External Embeds', false)
+    cy.privacyToggleValidateValue('Display Current Activity', false)
+    cy.privacyToggleValidateValue('Consent to File Scanning', false)
+    cy.privacyToggleValidateValue('Block NSFW content', false)
     cy.validateSignalingServersValue('Only Public Signaling Servers')
   })
 })

--- a/cypress/integration/snapshots-test.js
+++ b/cypress/integration/snapshots-test.js
@@ -147,11 +147,6 @@ describe.skip('Snapshots Testing', () => {
     cy.createAccountSecondScreen()
   })
 
-  it('Create Account - Privacy Settings screen', () => {
-    cy.snapshotTestContains('Privacy Settings')
-    cy.createAccountPrivacyTogglesGoNext()
-  })
-
   it('Create Account - User Input Screen', () => {
     //Recovery Seed Screen then User Input Snapshot
     cy.createAccountRecoverySeed().then(() => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -439,12 +439,9 @@ Cypress.Commands.add('goToConversation', (user, mobile = false) => {
     }
   })
 
-  //Click on Friends button only if its not already selected
-  cy.get('[data-cy=sidebar-friends]').then(($btn) => {
-    if ($btn.hasClass('is-dark')) {
-      cy.wrap($btn).click()
-    }
-  })
+  //Click first on Files and then on Friends button
+  cy.get('[data-cy=sidebar-files]').click()
+  cy.get('[data-cy=sidebar-friends]').click()
 
   //On mobile viewports, we need to click on hamburger button to see the chat selected
   if (mobile === true) {


### PR DESCRIPTION
**What this PR does** 📖
- Updates of privacy toggles validations due to the removal of Privacy Settings screen during account creation. Applied the proper updates to create account scenarios existing in our test suite
- Unskip cypress chat tests using accounts imported, which should work correctly now
- Added data-cy attributes for sidebar friends used in cypress commands
- Refactored mobiles-responsiveness tests to avoid switching viewport for each it block
- Improvement of goToConversation cypress command to work correctly for mobiles and standard viewports
- Update of the validation of glyph modal cypress command to match with the current DOM elements

**Which issue(s) this PR fixes** 🔨
AP-1441 and AP-1450

**Special notes for reviewers** 🗒️
Keeping skipped the ones for chat creation since Linking Satellites screen displayed after Recovery Seed screen takes more time than normally to be passed

**Additional comments** 🎤
No Cypress Videos for now, since all account creation related tests are still skipped
