### PR TITLE
fix(files): store cleanup and additional files status messages

### DIFF
--- a/components/views/files/controls/Controls.html
+++ b/components/views/files/controls/Controls.html
@@ -23,7 +23,7 @@
       :text="$t('pages.files.controls.new_file')"
       size="small"
       :action="addFile"
-      :loading="ui.isLoadingFileIndex"
+      :loading="isFilesIndexLoading"
     >
       <file-plus-icon size="1.3x" />
     </InteractablesButton>
@@ -34,8 +34,8 @@
       type="primary"
       :action="addFolder"
       :placeholder="$t('pages.files.controls.name_folder')"
-      :loading="ui.isLoadingFileIndex"
-      :disabled="ui.isLoadingFileIndex"
+      :loading="isFilesIndexLoading"
+      :disabled="isFilesIndexLoading"
     >
       <folder-plus-icon size="1.3x" />
     </InteractablesInputGroup>

--- a/components/views/files/file/File.html
+++ b/components/views/files/file/File.html
@@ -1,7 +1,7 @@
 <div
   class="file"
-  :class="{'disabled' : ui.isLoadingFileIndex}"
-  v-on="ui.isLoadingFileIndex ? {} : {click: click, contextmenu: contextMenu}"
+  :class="{'disabled' : isFilesIndexLoading}"
+  v-on="isFilesIndexLoading ? {} : {click: click, contextmenu: contextMenu}"
   @mouseover="fileHover=true"
   @mouseleave="fileHover=false"
 >

--- a/components/views/files/file/File.html
+++ b/components/views/files/file/File.html
@@ -27,6 +27,7 @@
       class="image-preview"
       :class="{'blur-image' : item.nsfw && blockNsfw}"
       :src="item.thumbnail"
+      draggable="false"
     />
   </div>
   <div v-else class="icon-container">

--- a/components/views/files/file/File.vue
+++ b/components/views/files/file/File.vue
@@ -1,7 +1,7 @@
 <template src="./File.html"></template>
 <script lang="ts">
 import Vue, { PropType } from 'vue'
-import { mapState } from 'vuex'
+import { mapState, mapGetters } from 'vuex'
 import {
   LinkIcon,
   HeartIcon,
@@ -52,6 +52,7 @@ export default Vue.extend({
       ui: (state) => (state as RootState).ui,
       blockNsfw: (state) => (state as RootState).settings.blockNsfw,
     }),
+    ...mapGetters('ui', ['isFilesIndexLoading']),
     /**
      * @returns {string} if directory, child count. if file, size
      */

--- a/components/views/files/filepath/Filepath.html
+++ b/components/views/files/filepath/Filepath.html
@@ -2,8 +2,8 @@
   <ul>
     <li>
       <a
-        @click="!ui.isLoadingFileIndex && goBackToDirectory('root')"
-        :class="{'disabled' : ui.isLoadingFileIndex }"
+        @click="!isFilesIndexLoading && goBackToDirectory('root')"
+        :class="{'disabled' : isFilesIndexLoading }"
         style="display: flex"
       >
         <home-icon size="1.5x" />
@@ -11,8 +11,8 @@
     </li>
     <li
       v-for="name,i in path"
-      @click="!ui.isLoadingFileIndex && goBackToDirectory(name)"
-      :class="{'is-active' : i === path.length - 1, 'disabled' : ui.isLoadingFileIndex}"
+      @click="!isFilesIndexLoading && goBackToDirectory(name)"
+      :class="{'is-active' : i === path.length - 1, 'disabled' : isFilesIndexLoading}"
     >
       <a> {{ name }} </a>
     </li>

--- a/components/views/files/filepath/Filepath.vue
+++ b/components/views/files/filepath/Filepath.vue
@@ -1,7 +1,7 @@
 <template src="./Filepath.html"></template>
 <script lang="ts">
 import Vue from 'vue'
-import { mapState } from 'vuex'
+import { mapGetters } from 'vuex'
 import { HomeIcon } from 'satellite-lucide-icons'
 
 export default Vue.extend({
@@ -9,7 +9,7 @@ export default Vue.extend({
     HomeIcon,
   },
   computed: {
-    ...mapState(['ui']),
+    ...mapGetters('ui', ['isFilesIndexLoading']),
     /**
      * @returns string array of file paths to current directory (not including root)
      */

--- a/components/views/files/list/List.html
+++ b/components/views/files/list/List.html
@@ -1,4 +1,4 @@
-<table class="table" :class="{'disabled' : ui.isLoadingFileIndex}">
+<table class="table" :class="{'disabled' : isFilesIndexLoading}">
   <thead>
     <th @click="setSort(FileSortEnum.NAME)">
       {{ $t('pages.files.browse.name') }}

--- a/components/views/files/list/List.vue
+++ b/components/views/files/list/List.vue
@@ -1,7 +1,7 @@
 <template src="./List.html"></template>
 <script lang="ts">
 import Vue, { PropType } from 'vue'
-import { mapState } from 'vuex'
+import { mapGetters } from 'vuex'
 import { ChevronDownIcon, ChevronUpIcon } from 'satellite-lucide-icons'
 import { FileSortEnum } from '~/libraries/Enums/enums'
 import { Item } from '~/libraries/Files/abstracts/Item.abstract'
@@ -38,7 +38,7 @@ export default Vue.extend({
     }
   },
   computed: {
-    ...mapState(['ui']),
+    ...mapGetters('ui', ['isFilesIndexLoading']),
     FileSortEnum: () => FileSortEnum,
   },
   mounted() {

--- a/components/views/files/rename/Rename.html
+++ b/components/views/files/rename/Rename.html
@@ -5,8 +5,8 @@
     type="primary"
     v-model="text"
     :action="rename"
-    :loading="ui.isLoadingFileIndex"
-    :disabled="ui.isLoadingFileIndex"
+    :loading="isFilesIndexLoading"
+    :disabled="isFilesIndexLoading"
     ref="inputGroup"
   >
     <save-icon size="1.3x" />

--- a/components/views/files/rename/Rename.vue
+++ b/components/views/files/rename/Rename.vue
@@ -2,7 +2,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import { mapState } from 'vuex'
+import { mapState, mapGetters } from 'vuex'
 import { SaveIcon } from 'satellite-lucide-icons'
 
 export default Vue.extend({
@@ -23,6 +23,7 @@ export default Vue.extend({
   },
   computed: {
     ...mapState(['ui']),
+    ...mapGetters('ui', ['isFilesIndexLoading']),
   },
   mounted() {
     this.text = this.ui.renameCurrentName
@@ -54,10 +55,12 @@ export default Vue.extend({
         return
       }
       this.closeModal()
-      this.$store.commit('ui/setIsLoadingFileIndex', true)
+      this.$store.commit(
+        'ui/setFilesUploadStatus',
+        this.$t('pages.files.status.index'),
+      )
       await this.$TextileManager.bucket?.updateIndex(this.$FileSystem.export)
-      this.$store.commit('ui/setIsLoadingFileIndex', false)
-      this.$toast.show(this.$t('pages.files.rename') as string)
+      this.$store.commit('ui/setFilesUploadStatus', '')
     },
   },
 })

--- a/components/views/files/row/Row.html
+++ b/components/views/files/row/Row.html
@@ -1,6 +1,6 @@
 <tr
   ref="row"
-  v-on="ui.isLoadingFileIndex ? {} : { click: handle, contextmenu: contextMenu }"
+  v-on="isFilesIndexLoading ? {} : { click: handle, contextmenu: contextMenu }"
 >
   <td class="filename">
     <template v-if="!$device.isMobile">
@@ -20,7 +20,7 @@
   <td
     @mouseover="menuHover=true"
     @mouseleave="menuHover=false"
-    v-on="ui.isLoadingFileIndex ? {} : { click: contextMenu }"
+    v-on="isFilesIndexLoading ? {} : { click: contextMenu }"
   >
     <more-vertical-icon size="1x" />
   </td>

--- a/components/views/files/row/Row.vue
+++ b/components/views/files/row/Row.vue
@@ -1,7 +1,7 @@
 <template src="./Row.html"></template>
 <script lang="ts">
 import Vue, { PropType } from 'vue'
-import { mapState } from 'vuex'
+import { mapState, mapGetters } from 'vuex'
 import {
   FolderIcon,
   ArchiveIcon,
@@ -41,6 +41,7 @@ export default Vue.extend({
   },
   computed: {
     ...mapState(['ui']),
+    ...mapGetters('ui', ['isFilesIndexLoading']),
     /**
      * @returns {boolean} if item has discrete MIME type of image
      */

--- a/components/views/files/view/View.html
+++ b/components/views/files/view/View.html
@@ -23,8 +23,8 @@
       <a
         :data-tooltip="$t('controls.share_link')"
         class="has-tooltip has-tooltip-primary has-tooltip-bottom control"
-        :class="{'disabled' : ui.isLoadingFileIndex}"
-        v-on="ui.isLoadingFileIndex ? {} : {click: share}"
+        :class="{'disabled' : isFilesIndexLoading}"
+        v-on="isFilesIndexLoading ? {} : {click: share}"
       >
         <link-icon size="1x" />
       </a>

--- a/components/views/files/view/View.vue
+++ b/components/views/files/view/View.vue
@@ -1,7 +1,7 @@
 <template src="./View.html"></template>
 <script lang="ts">
 import Vue from 'vue'
-import { mapState } from 'vuex'
+import { mapState, mapGetters } from 'vuex'
 import {
   FileIcon,
   DownloadIcon,
@@ -32,6 +32,7 @@ export default Vue.extend({
       ui: (state) => (state as RootState).ui,
       blockNsfw: (state) => (state as RootState).settings.blockNsfw,
     }),
+    ...mapGetters('ui', ['isFilesIndexLoading']),
     isDownloading(): boolean {
       return this.ui.fileDownloadList.includes(this.file?.name)
     },

--- a/layouts/files.vue
+++ b/layouts/files.vue
@@ -106,7 +106,7 @@ export default Vue.extend({
   },
   computed: {
     ...mapState(['friends', 'settings']),
-    ...mapGetters('ui', ['showSidebar', 'getFilesIndexLoading']),
+    ...mapGetters('ui', ['showSidebar', 'isFilesIndexLoading']),
     flairColor(): string {
       return this.$store.state.ui.theme.flair.value
     },
@@ -163,7 +163,7 @@ export default Vue.extend({
       }
 
       // if already uploading, return to prevent bucket fast-forward crash
-      if (this.getFilesIndexLoading) {
+      if (this.isFilesIndexLoading) {
         this.$toast.show(this.$t('pages.files.errors.in_progress') as string)
         return
       }

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -139,12 +139,15 @@ export default {
       add_favorite: 'Added to favorites',
       remove_favorite: 'Removed from favorites',
       link_copied: 'Link copied to clipboard',
-      rename: 'Rename is complete',
+      status: {
+        prepare: 'Preparing files for upload',
+        upload: 'Uploading {0}',
+        delete: 'Deleting {0}',
+        index: 'Updating remote index',
+      },
       controls: {
         new_file: 'New File',
         name_folder: 'Name Folder...',
-        upload: 'Uploading {0}',
-        index: 'Updating remote index',
       },
       browse: {
         files: 'Files',

--- a/pages/files/browse/index.vue
+++ b/pages/files/browse/index.vue
@@ -68,13 +68,16 @@ export default Vue.extend({
      * @param {Item} item
      */
     async like(item: Item) {
-      this.$store.commit('ui/setIsLoadingFileIndex', true)
       item.toggleLiked()
+      this.$store.commit(
+        'ui/setFilesUploadStatus',
+        this.$t('pages.files.status.index'),
+      )
       await this.$TextileManager.bucket?.updateIndex(this.$FileSystem.export)
       item.liked
         ? this.$toast.show(this.$t('pages.files.add_favorite') as string)
         : this.$toast.show(this.$t('pages.files.remove_favorite') as string)
-      this.$store.commit('ui/setIsLoadingFileIndex', false)
+      this.$store.commit('ui/setFilesUploadStatus', '')
       this.forceRender()
     },
     /**
@@ -83,13 +86,21 @@ export default Vue.extend({
      * @param {Item} item
      */
     async remove(item: Item) {
-      this.$store.commit('ui/setIsLoadingFileIndex', true)
       if (item instanceof Fil) {
+        this.$store.commit(
+          'ui/setFilesUploadStatus',
+          this.$t('pages.files.status.delete', [item.name]),
+        )
         await this.$FileSystem.removeFile(item.id)
       }
       this.$FileSystem.removeChild(item.name)
+      this.$store.commit(
+        'ui/setFilesUploadStatus',
+        this.$t('pages.files.status.index'),
+      )
       await this.$TextileManager.bucket?.updateIndex(this.$FileSystem.export)
-      this.$store.commit('ui/setIsLoadingFileIndex', false)
+      this.$store.commit('ui/setFilesUploadStatus', '')
+
       this.forceRender()
     },
     /**

--- a/plugins/thirdparty/persist.ts
+++ b/plugins/thirdparty/persist.ts
@@ -31,7 +31,6 @@ const commonProperties = [
   'webrtc.incomingCall',
   'ui.replyChatbarContent',
   'ui.editMessage',
-  'ui.isLoadingFileIndex',
   'chat.files',
   'groups.inviteSubscription',
   'groups.groupSubscriptions',

--- a/store/ui/__snapshots__/getters.test.ts.snap
+++ b/store/ui/__snapshots__/getters.test.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`init should return the isFilesIndexLoading property of the initial state 1`] = `false`;
+
 exports[`init should return the showSidebar property of the initial state 1`] = `true`;
 
 exports[`init should return the swiperSlideIndex property of the initial state 1`] = `0`;

--- a/store/ui/__snapshots__/getters.test.ts.snap
+++ b/store/ui/__snapshots__/getters.test.ts.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`init should return the isLoadingFileIndex property of the initial state 1`] = `false`;
-
 exports[`init should return the showSidebar property of the initial state 1`] = `true`;
 
 exports[`init should return the swiperSlideIndex property of the initial state 1`] = `0`;

--- a/store/ui/__snapshots__/state.test.ts.snap
+++ b/store/ui/__snapshots__/state.test.ts.snap
@@ -43,7 +43,6 @@ Object {
   },
   "glyphModalPack": "",
   "hoveredGlyphInfo": undefined,
-  "isLoadingFileIndex": false,
   "isReacted": false,
   "isScrollOver": false,
   "isTyping": false,

--- a/store/ui/getters.test.ts
+++ b/store/ui/getters.test.ts
@@ -9,8 +9,8 @@ describe('init', () => {
     inst = getters.default
   })
 
-  it('should return the isLoadingFileIndex property of the initial state', () => {
-    const result: any = inst.getFilesIndexLoading(InitialUIState())
+  it('should return the isFilesIndexLoading property of the initial state', () => {
+    const result: any = inst.isFilesIndexLoading(InitialUIState())
     expect(result).toBeFalsy()
     expect(result).toMatchSnapshot()
   })

--- a/store/ui/getters.ts
+++ b/store/ui/getters.ts
@@ -13,8 +13,8 @@ const getters = {
   swiperSlideIndex: (state: UIState) => {
     return state.swiperSlideIndex
   },
-  getFilesIndexLoading: (state: UIState) => {
-    return state.isLoadingFileIndex
+  isFilesIndexLoading: (state: UIState): boolean => {
+    return Boolean(state.filesUploadStatus)
   },
 }
 

--- a/store/ui/mutations.test.ts
+++ b/store/ui/mutations.test.ts
@@ -3098,11 +3098,6 @@ describe('mutations', () => {
     mutations.default.setChatbarFocus(localizedState, true)
     expect(localizedState.chatbarFocus).toBeTruthy()
   })
-  test('setIsLoadingFileIndex', () => {
-    const localizedState = { ...initialState }
-    mutations.default.setIsLoadingFileIndex(localizedState, false)
-    expect(localizedState.isLoadingFileIndex).toBeFalsy()
-  })
   test('setRenameItem', () => {
     const localizedState = { ...initialState }
     mutations.default.setRenameItem(localizedState, 'new name')

--- a/store/ui/mutations.ts
+++ b/store/ui/mutations.ts
@@ -347,9 +347,6 @@ export default {
   setChatbarFocus(state: UIState, status: boolean) {
     state.chatbarFocus = status
   },
-  setIsLoadingFileIndex(state: UIState, status: boolean) {
-    state.isLoadingFileIndex = status
-  },
   setRenameItem(state: UIState, name: string) {
     state.renameCurrentName = name
   },

--- a/store/ui/state.ts
+++ b/store/ui/state.ts
@@ -72,7 +72,6 @@ const InitialUIState = (): UIState => ({
     base: Themes[0],
     flair: Flairs[0],
   },
-  isLoadingFileIndex: false,
   filesUploadStatus: '',
   renameCurrentName: undefined,
   filePreview: undefined,

--- a/store/ui/types.ts
+++ b/store/ui/types.ts
@@ -201,7 +201,6 @@ export interface UIState {
     base: Theme
     flair: Flair
   }
-  isLoadingFileIndex: boolean
   filesUploadStatus: string
   renameCurrentName?: string
   filePreview?: string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- only new functionality is adding status message to rename, delete. mostly under the hood changes
- fixes redundancy in store keeping track of bucket updates. added a getter which casts status string to boolean
- remove toast after rename is done. no longer needed since the status message makes it clear enough

**Which issue(s) this PR fixes** 🔨
AP-1421, AP-1396

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- when testing, please make sure the upload ui gets disabled for every files operation (upload, rename, delete, favorite)