### PR TITLE
fix(locales): add punctuation

### DIFF
--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -224,7 +224,7 @@ export default {
       consentScan: {
         title: 'Consent to File Scanning',
         subtitle:
-          'In order to share files/use the encrypted file storage I consent to have the hash of my files compared against the Microsoft PhotoDNA service to help prevent the spread of sexual abuse material',
+          'In order to share files/use the encrypted file storage I consent to have the hash of my files compared against the Microsoft PhotoDNA service to help prevent the spread of sexual abuse material.',
       },
       nsfw: {
         title: 'Block NSFW content',


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖

Adds a "." to the end of description for consent for file scanning in Settings

**Which issue(s) this PR fixes** 🔨



**Special notes for reviewers** 🗒️

When testing Navigate into Settings/Privacy verify that the description for Consent to File Sharing has a "." at the end of it

**Additional comments** 🎤
