### PR TITLE
chore(script): add script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint:js": "eslint --ext \".js,.ts,.vue\" --ignore-path .gitignore .",
     "lint": "yarn lint:js",
     "test": "jest",
+    "summary": "jest test --coverage --coverageReporters=text-summary",
     "cy:run": "cypress run --browser chrome headless",
     "cy:first": "cypress run --config-file cypress-first-user.json",
     "cy:second": "cypress run --config-file cypress-second-user.json",


### PR DESCRIPTION
**What this PR does** 📖

Adds script - `yarn summary` to get the summary status of the Jest tests

<img width="600" alt="Captura de ecrã 2022-04-29, às 00 24 35" src="https://user-images.githubusercontent.com/29093946/165863407-1fe330e0-91f7-4155-8457-a2545661c997.png">

so instead of running 

`yarn test --coverage --coverageReporters=text-summary`

you can just run

`yarn summary`

and will return the above stats
