### PR TITLE
feat(jest): 95% coverage for store/webrtc/mutations

### DIFF
--- a/store/webrtc/mutations.test.ts
+++ b/store/webrtc/mutations.test.ts
@@ -1,104 +1,38 @@
 import { expect } from '@jest/globals'
 import * as WebRTC from '~/store/webrtc/mutations'
+import * as TracksManager from '~/libraries/WebRTC/TracksManager'
+import * as Call from '~/libraries/WebRTC/Call'
 
 describe('Mutate WebRTC by setting', () => {
   let inst: any
   const state: any = {
-    webrtc: {
-      initialized: true,
-      incomingCall: '',
-      activeCall: '',
-      connectedPeers: [],
-      streaming: true,
-      activeStream: {
-        createdAt: 123,
+    initialized: true,
+    incomingCall: '',
+    activeCall: '',
+    connectedPeers: [],
+    streaming: true,
+    activeStream: {
+      createdAt: 123,
+    },
+    remoteTracks: {
+      audio: {
+        id: '',
+        muted: true,
       },
-      remoteTracks: {
-        audio: {
-          id: '',
-          muted: true,
-        },
-        video: {
-          id: '',
-          muted: true,
-        },
-      },
-      localTracks: {
-        audio: {
-          id: '',
-          muted: true,
-        },
-        video: {
-          id: '',
-          muted: true,
-        },
+      video: {
+        id: '',
+        muted: true,
       },
     },
-    friends: {
-      incomingRequests: [
-        {
-          requestId: '',
-          account: {
-            accountId: '',
-            from: '',
-            status: 123,
-            fromMailboxId: '',
-            toMailboxId: '',
-            to: '',
-          },
-          pending: true,
-          from: '',
-          userInfo: {
-            name: '',
-            servers: {},
-            status: '',
-            photoHash: '',
-          },
-        },
-      ],
-      outgoingRequests: [
-        {
-          to: '',
-          requestId: '',
-          account: {
-            accountId: '',
-            from: '',
-            status: 123,
-            fromMailboxId: '',
-            toMailboxId: '',
-            to: '',
-          },
-          pending: true,
-        },
-      ],
-      all: [
-        {
-          publicKey: 'NoWiFi4you',
-          typingState: 'NOT_TYPING',
-          item: {},
-          pending: true,
-          activeChat: true,
-          encryptedTextilePubkey: '',
-          name: 'Taurus Nix',
-          address: '0xdf9eb223bafbe5c5271415c75aecd68c21fe3d7f',
-          account: {
-            accountId: 'Checking Account',
-            from: '.',
-            status: 429,
-            fromMailboxId: '12345',
-            toMailboxId: 'v4.0.0-rc.4',
-            to: './path/to/file',
-          },
-          textilePubkey: 'https://accounts.google.com/o/oauth2/revoke?token=%s',
-          status: '',
-          state: 'idle',
-          unreadCount: 123,
-          profilePicture: '',
-          badge: 'community',
-          userAccount: '',
-          mailboxId: '',
-        },
-      ],
+    localTracks: {
+      audio: {
+        id: '',
+        muted: true,
+      },
+      video: {
+        id: '',
+        muted: true,
+      },
     },
   }
 
@@ -141,106 +75,66 @@ describe('Mutate WebRTC by setting', () => {
       connectedPeers: ['0x0', '0x1', '0x2'],
     })
   })
+
+  it.skip('should set peer call', () => {
+    // Skipped due to the bug explained in the comment below.
+    const localStateForUnitTest = { ...state }
+    const tmState: any = {
+      // Abbreviation for TrackManager's State
+      contentHint: 'contentHint',
+      enabled: true,
+      id: 'track1',
+      kind: 'kind',
+      label: 'label',
+      muted: true,
+    }
+
+    const TracksManagerConstructor = TracksManager.TracksManager
+    const tmInst = new TracksManagerConstructor()
+    const localTmStateForUnitTest = { ...tmState }
+
+    tmInst.addTrack(localTmStateForUnitTest)
+
+    expect(tmInst.tracks[localTmStateForUnitTest.id]).toMatchObject(
+      localTmStateForUnitTest,
+    )
+
+    // const CallConstructor = Call.Call
+    // const callInst = new CallConstructor('1x1')
+    // insert mutation function (setPeerCall) here later, after bug above is fixed
+  })
 })
 
 describe('Mutate WebRTC by updating', () => {
   let inst: any
   const state: any = {
-    webrtc: {
-      initialized: true,
-      incomingCall: '',
-      activeCall: '',
-      connectedPeers: [],
-      streaming: true,
-      activeStream: {
-        createdAt: 123,
+    initialized: true,
+    incomingCall: '',
+    activeCall: '',
+    connectedPeers: [],
+    streaming: true,
+    activeStream: {
+      createdAt: 123,
+    },
+    remoteTracks: {
+      audio: {
+        id: '',
+        muted: true,
       },
-      remoteTracks: {
-        audio: {
-          id: '',
-          muted: true,
-        },
-        video: {
-          id: '',
-          muted: true,
-        },
-      },
-      localTracks: {
-        audio: {
-          id: '',
-          muted: true,
-        },
-        video: {
-          id: '',
-          muted: true,
-        },
+      video: {
+        id: '',
+        muted: true,
       },
     },
-    friends: {
-      incomingRequests: [
-        {
-          requestId: '',
-          account: {
-            accountId: '',
-            from: '',
-            status: 123,
-            fromMailboxId: '',
-            toMailboxId: '',
-            to: '',
-          },
-          pending: true,
-          from: '',
-          userInfo: {
-            name: '',
-            servers: {},
-            status: '',
-            photoHash: '',
-          },
-        },
-      ],
-      outgoingRequests: [
-        {
-          to: '',
-          requestId: '',
-          account: {
-            accountId: '',
-            from: '',
-            status: 123,
-            fromMailboxId: '',
-            toMailboxId: '',
-            to: '',
-          },
-          pending: true,
-        },
-      ],
-      all: [
-        {
-          publicKey: 'NoWiFi4you',
-          typingState: 'NOT_TYPING',
-          item: {},
-          pending: true,
-          activeChat: true,
-          encryptedTextilePubkey: '',
-          name: 'Taurus Nix',
-          address: '0xdf9eb223bafbe5c5271415c75aecd68c21fe3d7f',
-          account: {
-            accountId: 'Checking Account',
-            from: '.',
-            status: 429,
-            fromMailboxId: '12345',
-            toMailboxId: 'v4.0.0-rc.4',
-            to: './path/to/file',
-          },
-          textilePubkey: 'https://accounts.google.com/o/oauth2/revoke?token=%s',
-          status: '',
-          state: 'idle',
-          unreadCount: 123,
-          profilePicture: '',
-          badge: 'community',
-          userAccount: '',
-          mailboxId: '',
-        },
-      ],
+    localTracks: {
+      audio: {
+        id: '',
+        muted: true,
+      },
+      video: {
+        id: '',
+        muted: true,
+      },
     },
   }
 
@@ -325,19 +219,42 @@ describe('Mutate WebRTC by updating', () => {
   })
 
   it('should update time of creation', () => {
-    /*
-     * This particular test suite somehow has an error: TypeError: Cannot set properties of undefined (setting 'createdAt')
-     * How we bypassed it is by passing `state.webrtc` instead of just plainly `state` like in the other unit test
-     */
-
     const localStateForUnitTest = { ...state }
     const dummyDate = Date.now()
-    inst.updateCreatedAt(localStateForUnitTest.webrtc, dummyDate)
+    inst.updateCreatedAt(localStateForUnitTest, dummyDate)
 
-    expect(localStateForUnitTest.webrtc).toMatchObject({
+    expect(localStateForUnitTest).toMatchObject({
       activeStream: {
         createdAt: dummyDate,
       },
+    })
+  })
+
+  it('should add connected peer', () => {
+    const localStateForUnitTest = { ...state }
+    const argument = '0x3'
+    inst.addConnectedPeer(localStateForUnitTest, argument)
+
+    expect(localStateForUnitTest.connectedPeers).toContain(argument)
+  })
+
+  it('should remove connected peer', () => {
+    const localStateForUnitTest = { ...state }
+    const argument = '0x3'
+
+    inst.addConnectedPeer(localStateForUnitTest, argument)
+    expect(localStateForUnitTest.connectedPeers).toContain(argument)
+
+    // Add a peer first, and then we remove it.
+    // Reason we are doing this is because if we only remove in this unit test (the `it` block)
+    // The array will only be [], Hence the filter part in the mutations.ts file will not be covered.
+
+    inst.removeConnectedPeer(localStateForUnitTest, argument)
+
+    expect(localStateForUnitTest.connectedPeers).not.toContain(argument)
+    expect(localStateForUnitTest.connectedPeers).toEqual([])
+    expect(localStateForUnitTest).toMatchObject({
+      connectedPeers: [],
     })
   })
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖

Self-explanatory, though there is one catch. The skipped tests is due to something I cannot yet figure out related to LibP2P's call:

<img width="767" alt="image" src="https://user-images.githubusercontent.com/34530026/166650397-95a0581c-6be8-4f7c-98f7-64c3627937ef.png">

We would need the constructor to be successfully called to later use it to mutate the state. Though for now, I am abandoning that particular test that is skipped before any fix comes to mind. The code that is causing the errors (the constructor):

<img width="424" alt="image" src="https://user-images.githubusercontent.com/34530026/166650706-a309f51d-d617-4c69-8caa-1af2b0f66605.png">


**Which issue(s) this PR fixes** 🔨

AP-588

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
