### PR TITLE
test(cypress): more timeout for conversation load

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -503,7 +503,7 @@ Cypress.Commands.add('goToConversation', (user) => {
   cy.get('[data-cy=hamburger-button]').click()
 
   //Wait until conversation is fully loaded
-  cy.get('[data-cy=user-connected]', { timeout: 120000 })
+  cy.get('[data-cy=user-connected]', { timeout: 150000 })
     .should('be.visible')
     .should('have.text', user)
 })


### PR DESCRIPTION
**What this PR does** 📖
- Add more timeout to wait for goToConversation cypress command to wait on user-connected to be displayed when loading a chat conversation

**Which issue(s) this PR fixes** 🔨
None

**Special notes for reviewers** 🗒️
- This should avoid failures on chat-features.js cypress test

**Additional comments** 🎤
