### PR TITLE
feat(textile): release the ui asap

### DIFF
--- a/components/views/navigation/mobile/sidebar/sidebar.vue
+++ b/components/views/navigation/mobile/sidebar/sidebar.vue
@@ -52,7 +52,10 @@
             <users-icon size="1.2x" />
           </InteractablesButton>
           <span
-            v-if="friends.incomingRequests.length"
+            v-if="
+              friends.incomingRequests.length &&
+              dataState.friends === DataStateType.Ready
+            "
             :class="
               $route.path.includes('/friends/list')
                 ? 'label tag-inverted'
@@ -89,9 +92,12 @@
         class="scrolling hidden-scroll users"
       >
         <UiScroll vertical-scroll scrollbar-visibility="scroll" enable-wrap>
-          <div
-            v-if="dataState.friends !== DataStateType.Loading && users.length"
-          >
+          <UiLoadersAddress
+            v-if="dataState.friends === DataStateType.Loading"
+            :count="4"
+            inverted
+          />
+          <div v-else-if="users && users.length">
             <UiInlineNotification
               v-if="ui.unreadMessage.length"
               :text="$t('messaging.new_messages')"
@@ -119,19 +125,22 @@
               <user-plus-icon size="1.2x" />
             </InteractablesButton>
           </div>
-          <UiLoadersAddress v-else :count="4" inverted />
         </UiScroll>
       </div>
       <div v-else v-scroll-lock="true" class="scrolling hidden-scroll">
         <UiScroll vertical-scroll scrollbar-visibility="scroll" enable-wrap>
-          <div v-if="dataState.friends !== DataStateType.Loading">
+          <UiLoadersAddress
+            v-if="dataState.friends === DataStateType.Loading"
+            :count="4"
+            inverted
+          />
+          <div v-else-if="groups && groups.length">
             <GroupAside
               v-for="group in groups"
               :key="group.address"
               :selected-group="group"
             />
           </div>
-          <UiLoadersAddress v-else :count="4" inverted />
         </UiScroll>
       </div>
       <div class="new-chat-container">

--- a/components/views/navigation/sidebar/Sidebar.html
+++ b/components/views/navigation/sidebar/Sidebar.html
@@ -41,7 +41,7 @@
           <users-icon size="1.2x" />
         </InteractablesButton>
         <span
-          v-if="friends.incomingRequests.length"
+          v-if="friends.incomingRequests.length && dataState.friends === DataStateType.Ready"
           :class="$route.path.includes('/friends/list') ? 'label tag-inverted' : 'label'"
         >
           {{friends.incomingRequests.length}}
@@ -93,9 +93,12 @@
       v-if="ui.showSidebarUsers"
     >
       <UiScroll verticalScroll scrollbarVisibility="scroll" enableWrap>
-        <div
-          v-if="dataState.friends !== DataStateType.Loading && users && users.length"
-        >
+        <UiLoadersAddress
+          v-if="dataState.friends === DataStateType.Loading"
+          :count="4"
+          inverted
+        />
+        <div v-else-if="users && users.length">
           <UiInlineNotification
             :text="$t('messaging.new_messages')"
             v-if="ui.unreadMessage.length"

--- a/components/views/navigation/sidebar/Sidebar.vue
+++ b/components/views/navigation/sidebar/Sidebar.vue
@@ -19,6 +19,7 @@ import { User } from '~/types/ui/user'
 import { Conversation } from '~/store/textile/types'
 import GroupInvite from '~/components/views/group/invite/Invite.vue'
 import { Group } from '~/store/groups/types'
+import { RootState } from '~/types/store/store'
 
 declare module 'vue/types/vue' {
   interface Vue {
@@ -57,7 +58,11 @@ export default Vue.extend({
   },
   computed: {
     DataStateType: () => DataStateType,
-    ...mapState(['ui', 'dataState', 'media', 'friends', 'textile', 'groups']),
+    ...mapState(['ui', 'dataState', 'media', 'friends', 'groups']),
+    ...mapState({
+      conversations: (state) =>
+        (state as RootState).textile.conversations || [],
+    }),
     toggleView: {
       get() {
         return this.ui.showSidebarUsers
@@ -75,7 +80,7 @@ export default Vue.extend({
     },
   },
   watch: {
-    'textile.conversations': {
+    conversations: {
       handler(newValue) {
         this.sortUserList(newValue)
       },

--- a/components/views/navigation/slimbar/Slimbar.html
+++ b/components/views/navigation/slimbar/Slimbar.html
@@ -16,7 +16,10 @@
       </UiCircle>
     </div>
     <UiScroll verticalScroll v-if="!horizontal">
-      <div id="list-container">
+      <div class="slimbar-spinner" v-if="friendsDS === DataStateType.Loading">
+        <UiLoadersSpinner :spinning="true" />
+      </div>
+      <div id="list-container" v-else>
         <UiHorizontalRule v-if="unreads.length > 0" />
         <div class="unreads" v-for="user in unreads">
           <Unread

--- a/components/views/navigation/slimbar/Slimbar.less
+++ b/components/views/navigation/slimbar/Slimbar.less
@@ -57,6 +57,16 @@
     position: relative;
     pointer-events: auto;
   }
+
+  .slimbar-spinner {
+    width: 40px;
+    height: 40px;
+    margin-top: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+  }
 }
 
 #servers-horizontal-list {

--- a/components/views/navigation/slimbar/Slimbar.vue
+++ b/components/views/navigation/slimbar/Slimbar.vue
@@ -8,6 +8,7 @@ import { ModalWindows } from '~/store/ui/types'
 import { User } from '~/types/ui/user'
 import Unread from '~/components/ui/Unread/Unread.vue'
 import { Sounds } from '~/libraries/SoundManager/SoundManager'
+import { DataStateType } from '~/store/dataState/types'
 
 declare module 'vue/types/vue' {
   interface Vue {
@@ -45,7 +46,11 @@ export default Vue.extend({
     },
   },
   computed: {
+    DataStateType: () => DataStateType,
     ...mapState(['ui']),
+    ...mapState({
+      friendsDS: (state) => state.dataState.friends,
+    }),
     ModalWindows: () => ModalWindows,
   },
   created() {

--- a/components/views/settings/pages/profile/Profile.html
+++ b/components/views/settings/pages/profile/Profile.html
@@ -26,13 +26,13 @@
         
         <div class="columns is-mobile">
           <div class="column profile-photo-column">
-            <div class="profile-photo">
+            <div :class="['profile-photo', !getInitialized ? 'profile-photo-loading' : '']">
               <input ref="file" class="input-file" type="file" @change="selectProfileImage" accept="image/*"></input>
               <UiCircle :type="croppedImage || accounts.details.profilePicture ? 'image' : 'random' " :source="src" seed="0x0000000000000000000000000000000000000000" :size="isSmallScreen ? 55 : 75"/>
               <UiCircle 
                 type="icon" 
                 @click="openFileDialog"
-                icon="plus" 
+                icon="plus"
                 color="#000" 
                 :size="18"
                 class="plus-button" />

--- a/components/views/settings/pages/profile/Profile.less
+++ b/components/views/settings/pages/profile/Profile.less
@@ -69,6 +69,10 @@
       position: absolute;
       color: #fff;
     }
+
+    &-loading {
+      cursor: progress;
+    }
   }
 }
 

--- a/components/views/settings/pages/profile/index.vue
+++ b/components/views/settings/pages/profile/index.vue
@@ -2,7 +2,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import { mapState } from 'vuex'
+import { mapState, mapGetters } from 'vuex'
 
 import { EditIcon } from 'satellite-lucide-icons'
 import { sampleProfileInfo } from '~/mock/profile'
@@ -29,6 +29,7 @@ export default Vue.extend({
   },
   computed: {
     ...mapState(['accounts', 'ui']),
+    ...mapGetters('textile', ['getInitialized']),
     isSmallScreen(): Boolean {
       // @ts-ignore
       if (this.$mq === 'sm' || (this.ui.settingsSideBar && this.$mq === 'md'))
@@ -64,6 +65,8 @@ export default Vue.extend({
      * @example
      */
     openFileDialog() {
+      if (!this.getInitialized) return
+
       const fileInput = this.$refs.file as HTMLElement
       fileInput.click()
     },

--- a/components/views/user/profile/About.vue
+++ b/components/views/user/profile/About.vue
@@ -10,7 +10,9 @@
     </div>
     <div>
       <TypographyTitle :text="$t('modal.profile.about.add_note')" :size="6" />
+      <TypographyText v-if="!getInitialized" :text="note" class="loading" />
       <InteractablesClickToEdit
+        v-show="getInitialized"
         ref="noteRef"
         v-model="note"
         data-cy="profile-add-note"
@@ -22,7 +24,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import { mapState } from 'vuex'
+import { mapState, mapGetters } from 'vuex'
 
 export default Vue.extend({
   data() {
@@ -32,9 +34,13 @@ export default Vue.extend({
   },
   computed: {
     ...mapState(['friends', 'ui']),
+    ...mapGetters('textile', ['getInitialized']),
     note: {
       get(): string {
-        return this.ui?.userProfile?.metadata?.note ?? ''
+        return (
+          this.ui?.userProfile?.metadata?.note ??
+          this.$t('modal.profile.about.click_note')
+        )
       },
       set(note: string) {
         const { userProfile } = this.ui
@@ -89,5 +95,9 @@ export default Vue.extend({
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(256px, 1fr));
   gap: @normal-spacing;
+}
+
+.loading {
+  cursor: progress;
 }
 </style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -7,15 +7,11 @@
     </v-style>
   </div>
 </template>
-<script lang="ts">
-import Vue from 'vue'
+
+<script setup lang="ts">
 import useMeta from '~/components/compositions/useMeta'
 
-export default Vue.extend({
-  setup() {
-    useMeta()
-  },
-})
+useMeta()
 </script>
 <style lang="less">
 @import 'bulma/css/bulma.css';

--- a/libraries/Textile/TextileManager.ts
+++ b/libraries/Textile/TextileManager.ts
@@ -1,6 +1,9 @@
 import { Bucket } from '../Files/remote/textile/Bucket'
 import { MetadataManager } from './MetadataManager'
 import { UserInfoManager } from './UserManager'
+import { Config } from '~/config'
+import BucketManager from '~/libraries/Textile/BucketManager'
+import { GroupChatManager } from '~/libraries/Textile/GroupChatManager'
 import IdentityManager from '~/libraries/Textile/IdentityManager'
 import { MailboxManager } from '~/libraries/Textile/MailboxManager'
 import {
@@ -8,9 +11,6 @@ import {
   TextileConfig,
   TextileInitializationData,
 } from '~/types/textile/manager'
-import BucketManager from '~/libraries/Textile/BucketManager'
-import { GroupChatManager } from '~/libraries/Textile/GroupChatManager'
-import { Config } from '~/config'
 
 export default class TextileManager {
   creds?: Creds

--- a/middleware/authenticated.ts
+++ b/middleware/authenticated.ts
@@ -1,8 +1,8 @@
 import { NuxtRouteConfig } from '@nuxt/types/config/router'
+import memoize from 'lodash/memoize'
 // TODO: verify why we got the import/named error for RawLocation import AP-394
 // eslint-disable-next-line import/named
 import { RawLocation } from 'vue-router'
-import memoize from 'lodash/memoize'
 import { Config } from '~/config'
 import { RootStore } from '~/types/store/store'
 interface Arguments {

--- a/pages/chat/direct/Direct.html
+++ b/pages/chat/direct/Direct.html
@@ -2,6 +2,6 @@
   <UiChatEncrypted v-if="$route.params.address" />
   <Conversation
     :messages="groupedMessages"
-    :loading="$store.state.textile.conversationLoading"
+    :loading="$store.state.textile.conversationLoading || !getInitialized"
   />
 </div>

--- a/pages/chat/direct/Direct.html
+++ b/pages/chat/direct/Direct.html
@@ -2,6 +2,6 @@
   <UiChatEncrypted v-if="$route.params.address" />
   <Conversation
     :messages="groupedMessages"
-    :loading="$store.state.textile.conversationLoading || !getInitialized"
+    :loading="$store.state.textile.conversationLoading || (!getInitialized && friendsExist)"
   />
 </div>

--- a/pages/chat/direct/_address.vue
+++ b/pages/chat/direct/_address.vue
@@ -2,6 +2,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import { mapGetters } from 'vuex'
 import { groupMessages } from '~/utilities/Messaging'
 import { ConsoleWarning } from '~/utilities/ConsoleWarning'
 
@@ -9,6 +10,7 @@ export default Vue.extend({
   name: 'DirectMessages',
   layout: 'chat',
   computed: {
+    ...mapGetters('textile', ['getInitialized']),
     groupedMessages() {
       const { address } = this.$route.params
       const conversation = this.$typedStore.state.textile.conversations[address]
@@ -22,25 +24,31 @@ export default Vue.extend({
       return groupMessages(messages, replies, reactions)
     },
   },
-  mounted() {
-    // This information can be useful for users to help us find and report bugs.
-    ConsoleWarning(this.$config.clientVersion, this.$store.state)
-    const { address } = this.$route.params
-    const { friends } = this.$store.state
-    if (address) {
-      if (
-        this.$Hounddog &&
-        this.$Hounddog.findFriendByAddress(address, friends)
-      ) {
-        this.$store.dispatch('textile/fetchMessages', { address })
-        return
-      }
-    }
-    if (friends && friends.all && friends.all.length > 0) {
-      this.$router.replace(`/chat/direct/${friends.all[0].address}`)
-      return
-    }
-    this.$router.replace('/friends/list')
+  watch: {
+    getInitialized: {
+      handler(nextValue) {
+        if (nextValue) {
+          const { address } = this.$route.params
+          const { friends } = this.$store.state
+          if (address) {
+            if (
+              this.$Hounddog &&
+              this.$Hounddog.findFriendByAddress(address, friends)
+            ) {
+              this.$store.dispatch('textile/fetchMessages', { address })
+              return
+            }
+          }
+
+          if (friends && friends.all && friends.all.length > 0) {
+            this.$router.replace(`/chat/direct/${friends.all[0].address}`)
+            return
+          }
+          this.$router.replace('/friends/list')
+        }
+      },
+      immediate: true,
+    },
   },
 })
 </script>

--- a/pages/chat/groups/Group.html
+++ b/pages/chat/groups/Group.html
@@ -2,7 +2,7 @@
   <UiChatEncrypted />
   <Conversation
     :messages="groupedMessages"
-    :loading="$store.state.textile.conversationLoading"
+    :loading="$store.state.textile.conversationLoading || !getInitialized"
     :groupId="groupID"
   />
 </div>

--- a/pages/chat/groups/_id.vue
+++ b/pages/chat/groups/_id.vue
@@ -2,7 +2,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import { mapState } from 'vuex'
+import { mapState, mapGetters } from 'vuex'
 import { groupMessages } from '~/utilities/Messaging'
 
 export default Vue.extend({
@@ -17,6 +17,7 @@ export default Vue.extend({
   },
   computed: {
     ...mapState(['media']),
+    ...mapGetters('textile', ['getInitialized']),
     groupedMessages() {
       const { id } = this.$route.params
       const conversation = this.$typedStore.state.textile.conversations[id]
@@ -30,11 +31,18 @@ export default Vue.extend({
       return groupMessages(messages, replies, reactions)
     },
   },
-  mounted() {
-    const { id } = this.$route.params
-    this.getMessages(id)
-    this.subscribeToGroup(id)
-    this.fetchGroupMembers(id)
+  watch: {
+    getInitialized: {
+      handler(nextValue) {
+        if (nextValue) {
+          const { id } = this.$route.params
+          this.getMessages(id)
+          this.subscribeToGroup(id)
+          this.fetchGroupMembers(id)
+        }
+      },
+      immediate: true,
+    },
   },
   methods: {
     async getMessages(id: string) {

--- a/pages/files/browse/Browse.html
+++ b/pages/files/browse/Browse.html
@@ -15,8 +15,9 @@
         :changeView="changeView"
         @forceRender="forceRender"
       />
+      <UiLoadersGenericContent :count="3" v-if="!getInitialized" />
       <TypographyText
-        v-if="!directory.length"
+        v-else-if="!directory.length"
         :text="$t('pages.files.empty')"
       />
       <FilesList

--- a/pages/files/browse/index.vue
+++ b/pages/files/browse/index.vue
@@ -2,6 +2,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import { mapGetters } from 'vuex'
 import { Item } from '~/libraries/Files/abstracts/Item.abstract'
 import { Directory } from '~/libraries/Files/Directory'
 import { Fil } from '~/libraries/Files/Fil'
@@ -20,6 +21,7 @@ export default Vue.extend({
     }
   },
   computed: {
+    ...mapGetters('textile', ['getInitialized']),
     sort: {
       set(value: FileSort) {
         this.$store.commit('ui/setFileSort', value)

--- a/pages/friends/list/FriendsList.html
+++ b/pages/friends/list/FriendsList.html
@@ -11,7 +11,11 @@
         <!-- Friends Add -->
         <FriendsAdd />
         <!-- Friend Requests -->
-        <template v-if="friends.incomingRequests.length">
+        <UiLoadersFriend
+          :count="1"
+          v-if="dataState.friends === DataStateType.Loading"
+        />
+        <template v-else-if="friends.incomingRequests.length">
           <div class="padded_divider">
             <TypographyHorizontalRuleText
               plaintext
@@ -33,7 +37,11 @@
           />
         </template>
         <!-- Outgoing Requests -->
-        <template v-if="friends.outgoingRequests.length">
+        <UiLoadersFriend
+          :count="1"
+          v-if="dataState.friends === DataStateType.Loading"
+        />
+        <template v-else-if="friends.outgoingRequests.length">
           <div class="padded_divider">
             <TypographyHorizontalRuleText
               plaintext
@@ -63,7 +71,10 @@
         >
           <TypographyHorizontalRuleText plaintext :value="$t('friends.all')" />
         </div>
-        <div v-if="dataState.friends !== DataStateType.Loading">
+        <div v-if="dataState.friends === DataStateType.Loading">
+          <UiLoadersFriend :count="5" />
+        </div>
+        <div v-else>
           <div v-for="entry in Object.entries(alphaSortedFriends)">
             <span class="alpha-divider">{{entry[0].toUpperCase()}}</span>
             <FriendsFriend
@@ -78,9 +89,6 @@
           >
             <UiLoadersUpdating />
           </div>
-        </div>
-        <div v-else>
-          <UiLoadersFriend :count="5" />
         </div>
         <div
           v-if="Object.entries($mock.blocked).length && featureReadyToShow"

--- a/pages/friends/mobile/add/index.vue
+++ b/pages/friends/mobile/add/index.vue
@@ -10,7 +10,6 @@
             full-width
             @click="goBack"
           />
-
           <TypographyTitle :text="$t('friends.add')" :size="5" />
         </div>
         <div class="column is-half-desktop">

--- a/pages/friends/mobile/incoming/index.vue
+++ b/pages/friends/mobile/incoming/index.vue
@@ -31,7 +31,11 @@
                 :text="$t('friends.received')"
               />
             </div>
-            <template v-if="searchIncomingFriends.length">
+            <UiLoadersFriend
+              v-if="dataState.friends === DataStateType.Loading"
+              :count="1"
+            />
+            <template v-else-if="searchIncomingFriends.length">
               <FriendsFriend
                 v-for="friend in searchIncomingFriends"
                 :key="friend.from"
@@ -45,7 +49,7 @@
                 request
               />
             </template>
-            <div v-if="friends.incomingRequests.length === 0">
+            <div v-else>
               <TypographyText
                 size="6"
                 plaintext
@@ -53,7 +57,11 @@
               />
             </div>
             <!-- Outgoing Requests -->
-            <template v-if="searchOutgoingFriends.length">
+            <UiLoadersFriend
+              v-if="dataState.friends === DataStateType.Loading"
+              :count="1"
+            />
+            <template v-else-if="searchOutgoingFriends.length">
               <div class="typography-container">
                 <TypographyText size="6" plaintext :text="$t('friends.sent')" />
               </div>
@@ -80,12 +88,11 @@
 <script lang="ts">
 import Vue from 'vue'
 import { mapState } from 'vuex'
-import { cloneDeep } from 'lodash'
 import { ArrowLeftIcon } from 'satellite-lucide-icons'
 
 import { DataStateType } from '~/store/dataState/types'
 
-import { OutgoingRequest, FriendRequest } from '~/types/ui/friends'
+import { FriendRequest } from '~/types/ui/friends'
 
 type Route = 'active' | 'requests' | 'blocked' | 'add'
 declare module 'vue/types/vue' {

--- a/store/getters.ts
+++ b/store/getters.ts
@@ -2,11 +2,7 @@ import { RootState } from '~/types/store/store'
 
 const getters = {
   allPrerequisitesReady: (state: RootState): boolean => {
-    return (
-      Boolean(state.accounts.active) &&
-      state.textile.initialized &&
-      state.webrtc.initialized
-    )
+    return Boolean(state.accounts.active) && state.webrtc.initialized
   },
 }
 

--- a/store/textile/actions.ts
+++ b/store/textile/actions.ts
@@ -1,31 +1,30 @@
-import { resourceLimits } from 'worker_threads'
 import Vue from 'vue'
-import { TextileState, TextileError } from './types'
-import { ActionsArguments, RootState } from '~/types/store/store'
-import TextileManager from '~/libraries/Textile/TextileManager'
-import { TextileConfig } from '~/types/textile/manager'
-import { MailboxManager } from '~/libraries/Textile/MailboxManager'
-import { MessageRouteEnum, PropCommonEnum } from '~/libraries/Enums/enums'
+import { TextileError, TextileState } from './types'
 import { Config } from '~/config'
-import { MailboxSubscriptionType, Message } from '~/types/textile/mailbox'
-import { UploadDropItemType } from '~/types/files/file'
+import { MessageRouteEnum, PropCommonEnum } from '~/libraries/Enums/enums'
+import { FilSystem } from '~/libraries/Files/FilSystem'
 import {
   db,
   DexieConversation,
   DexieMessage,
 } from '~/libraries/SatelliteDB/SatelliteDB'
-import { GroupChatManager } from '~/libraries/Textile/GroupChatManager'
-import { FilSystem } from '~/libraries/Files/FilSystem'
-import { AccountsError } from '~/store/accounts/types'
 import GroupChatsProgram from '~/libraries/Solana/GroupChatsProgram/GroupChatsProgram'
 import SolanaManager from '~/libraries/Solana/SolanaManager/SolanaManager'
+import { GroupChatManager } from '~/libraries/Textile/GroupChatManager'
+import { MailboxManager } from '~/libraries/Textile/MailboxManager'
+import TextileManager from '~/libraries/Textile/TextileManager'
+import { AccountsError } from '~/store/accounts/types'
 import { Group } from '~/store/groups/types'
+import { UploadDropItemType } from '~/types/files/file'
 import {
-  UISearchResult,
   QueryOptions,
   SearchOrderType,
+  UISearchResult,
   UISearchResultData,
 } from '~/types/search/search'
+import { ActionsArguments, RootState } from '~/types/store/store'
+import { MailboxSubscriptionType, Message } from '~/types/textile/mailbox'
+import { TextileConfig } from '~/types/textile/manager'
 
 const getGroupChatProgram = (): GroupChatsProgram => {
   const $SolanaManager: SolanaManager = Vue.prototype.$SolanaManager
@@ -56,7 +55,6 @@ export default {
 
     const textilePublicKey = $TextileManager.getIdentityPublicKey()
 
-    commit('textileInitialized', true)
     commit('accounts/updateTextilePubkey', textilePublicKey, { root: true })
 
     const fsExport = $TextileManager.bucket?.index
@@ -95,7 +93,7 @@ export default {
     const $TextileManager: TextileManager = Vue.prototype.$TextileManager
 
     if (!$TextileManager.mailboxManager?.isInitialized()) {
-      throw new Error(TextileError.EDIT_HOT_KEY_ERROR)
+      throw new Error(TextileError.MAILBOX_MANAGER_NOT_FOUND)
     }
 
     const friend = rootState.friends.all.find((fr) => fr.address === address)
@@ -685,7 +683,6 @@ export default {
     if (MailboxManager.isSubscribed(MailboxSubscriptionType.sentbox)) {
       return
     }
-
     if (!$TextileManager.groupChatManager?.isInitialized()) {
       throw new Error(TextileError.EDIT_HOT_KEY_ERROR)
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Release the UI asap without waiting for Textile to init:
* the initial loader is released only once Solana and Webrtc are init;
* friends should be visibile almost immediately, they depend only on Solana;
* groups and files depends also on Textile, so loaders are put as placeholders;
* registration with an image depends on Textile so this step is still slow in this case;
* ui actions depend on Textile are disabled while it loads, if u find something not working while textile is initializing lmk.

**Which issue(s) this PR fixes** 🔨
AP-1480

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
Dont test it if you dont want to go too fast
