### PR TITLE
fix(search): refine search match criterion

### DIFF
--- a/components/views/chat/search/input/Input.vue
+++ b/components/views/chat/search/input/Input.vue
@@ -15,14 +15,8 @@ import {
   SearchRecommend,
   SearchRecommendResultItem,
   SearchOption,
+  SearchCommandMeta,
 } from '~/types/search/search'
-
-declare module 'vue/types/vue' {
-  interface Vue {
-    isEmpty: Boolean
-    isFocus: Boolean
-  }
-}
 
 export default Vue.extend({
   components: {
@@ -58,7 +52,7 @@ export default Vue.extend({
      * @description
      * @returns
      */
-    searchOptions() {
+    searchOptions(): SearchCommandMeta[] {
       return SearchUtil.getCommandMetaList()
     },
 
@@ -77,7 +71,7 @@ export default Vue.extend({
      * @description
      * @returns
      */
-    isEmptyCommand() {
+    isEmptyCommand(): boolean {
       if (
         this.current != null &&
         this.current.command === '' &&
@@ -93,7 +87,7 @@ export default Vue.extend({
      * @description
      * @returns
      */
-    isOption() {
+    isOption(): boolean {
       if (this.isFocus && (this.isEmpty || this.isHas || this.isEmptyCommand)) {
         return true
       }
@@ -105,7 +99,7 @@ export default Vue.extend({
      * @description
      * @returns
      */
-    isHas() {
+    isHas(): boolean {
       if (this.current == null || this.current.value !== '') {
         return false
       }
@@ -120,7 +114,7 @@ export default Vue.extend({
      * @description
      * @returns
      */
-    isDate() {
+    isDate(): boolean {
       if (this.current == null || this.current.value !== '') {
         return false
       }
@@ -139,7 +133,7 @@ export default Vue.extend({
      * @description
      * @returns
      */
-    isSearch() {
+    isSearch(): boolean {
       if (this.isEmpty || !this.isFocus || this.current == null) {
         return false
       }

--- a/components/views/chat/search/result/Result.vue
+++ b/components/views/chat/search/result/Result.vue
@@ -11,6 +11,7 @@ import {
   SearchResultGroupType,
   QueryOptions,
   UISearchResult,
+  MatchTypesEnum,
 } from '~/types/search/search'
 import { DataStateType } from '~/store/dataState/types'
 
@@ -126,10 +127,12 @@ export default Vue.extend({
         accounts: [...this.friends.all, this.accounts.details],
         queryString: this.searchQuery,
       }
+      // currently only fetch payload matches, can be refactored later
       this.result = await this.$store.dispatch('textile/searchConversations', {
         query: this.queryOptions,
         page: this.page,
         orderBy: this.orderBy,
+        matchType: [MatchTypesEnum.PAYLOAD],
       })
       this.isLoading = DataStateType.Ready
     },

--- a/components/views/chat/search/result/Result.vue
+++ b/components/views/chat/search/result/Result.vue
@@ -132,7 +132,7 @@ export default Vue.extend({
         query: this.queryOptions,
         page: this.page,
         orderBy: this.orderBy,
-        matchType: [MatchTypesEnum.PAYLOAD],
+        fields: [MatchTypesEnum.PAYLOAD],
       })
       this.isLoading = DataStateType.Ready
     },

--- a/libraries/SatelliteDB/SearchIndex.ts
+++ b/libraries/SatelliteDB/SearchIndex.ts
@@ -1,4 +1,4 @@
-import MiniSearch, { Options } from 'minisearch'
+import MiniSearch, { Options, Suggestion } from 'minisearch'
 import type { SearchOptions } from 'minisearch'
 import { UISearchResultData } from '~/types/search/search'
 
@@ -84,7 +84,10 @@ export default class SearchIndex {
       .map((doc) => ({ ...doc, ...this.getById(doc[this.idField]) }))
   }
 
-  autoSuggest(query: string, options?: SearchOptions | undefined) {
+  autoSuggest(
+    query: string,
+    options?: SearchOptions | undefined,
+  ): Suggestion[] {
     return this.index.autoSuggest(query, options)
   }
 

--- a/store/textile/actions.ts
+++ b/store/textile/actions.ts
@@ -939,12 +939,12 @@ export default {
       query,
       page,
       orderBy,
-      matchType,
+      fields,
     }: {
       query: QueryOptions
       page: number
       orderBy: SearchOrderType
-      matchType: MatchTypesEnum[]
+      fields: MatchTypesEnum[]
     },
   ): Promise<UISearchResult> {
     const { queryString, accounts, dateRange, perPage } = query
@@ -967,7 +967,7 @@ export default {
       }`,
       {
         fuzzy: 0.3,
-        fields: matchType,
+        fields,
       },
     )
 

--- a/store/textile/actions.ts
+++ b/store/textile/actions.ts
@@ -21,6 +21,7 @@ import {
   SearchOrderType,
   UISearchResult,
   UISearchResultData,
+  MatchTypesEnum,
 } from '~/types/search/search'
 import { ActionsArguments, RootState } from '~/types/store/store'
 import { MailboxSubscriptionType, Message } from '~/types/textile/mailbox'
@@ -938,10 +939,12 @@ export default {
       query,
       page,
       orderBy,
+      matchType,
     }: {
       query: QueryOptions
       page: number
       orderBy: SearchOrderType
+      matchType: MatchTypesEnum[]
     },
   ): Promise<UISearchResult> {
     const { queryString, accounts, dateRange, perPage } = query
@@ -964,6 +967,7 @@ export default {
       }`,
       {
         fuzzy: 0.3,
+        fields: matchType,
       },
     )
 

--- a/types/search/search.ts
+++ b/types/search/search.ts
@@ -164,3 +164,14 @@ export type QueryOptions = {
   dateRange: DateOptions | null
   perPage: number
 }
+
+export enum MatchTypesEnum {
+  ID = 'id',
+  CONVERSATION = 'conversation',
+  FROM = 'from',
+  TO = 'to',
+  AT = 'at',
+  READAT = 'readAt',
+  TYPE = 'type',
+  PAYLOAD = 'payload',
+}

--- a/types/search/search.ts
+++ b/types/search/search.ts
@@ -171,7 +171,7 @@ export enum MatchTypesEnum {
   FROM = 'from',
   TO = 'to',
   AT = 'at',
-  READAT = 'readAt',
+  READ_AT = 'readAt',
   TYPE = 'type',
   PAYLOAD = 'payload',
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- only show search match if term matches payload. setup in a way that can be refined later when we add different search criteria (sender, etc..)
- previously, any message would hit a `conversation` match if the conversation ID was passed as the search query
- add return types to some computed props

**Which issue(s) this PR fixes** 🔨
AP-1333
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
