### PR TITLE
feat(textile): configure textile via env

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -6,8 +6,11 @@ export const Config = {
   textile: {
     localURI: 'http://localhost:6007',
     key: process.env.NUXT_ENV_TEXTILE_API_KEY,
-    browser: process.env.NUXT_ENV_TEXTILE_BROWSER || 'https://hub.textile.io',
-    apiUrl: process.env.NUXT_ENV_TEXTILE_API_URL,
+    browser:
+      process.env.NUXT_ENV_TEXTILE_BROWSER || 'https://hub.edge.satellite.one',
+    apiUrl:
+      process.env.NUXT_ENV_TEXTILE_API_URL ||
+      'https://webapi.hub.edge.satellite.one',
     groupChatThreadID:
       'bafkv7ordeargenxdutqdltvlo6sbfcfdhuvmocrt4qe6kpohrdbrbdi',
     fsTable: 'sat.json',

--- a/config.ts
+++ b/config.ts
@@ -6,7 +6,8 @@ export const Config = {
   textile: {
     localURI: 'http://localhost:6007',
     key: process.env.NUXT_ENV_TEXTILE_API_KEY,
-    browser: 'https://hub.textile.io',
+    browser: process.env.NUXT_ENV_TEXTILE_BROWSER || 'https://hub.textile.io',
+    apiUrl: process.env.NUXT_ENV_TEXTILE_API_URL,
     groupChatThreadID:
       'bafkv7ordeargenxdutqdltvlo6sbfcfdhuvmocrt4qe6kpohrdbrbdi',
     fsTable: 'sat.json',

--- a/libraries/Files/remote/textile/Bucket.ts
+++ b/libraries/Files/remote/textile/Bucket.ts
@@ -42,7 +42,10 @@ export class Bucket extends RFM implements RFMInterface {
       throw new Error('Textile key not found')
     }
 
-    this._buckets = await Buckets.withKeyInfo({ key: Config.textile.key })
+    this._buckets = await Buckets.withKeyInfo(
+      { key: Config.textile.key },
+      { host: Config.textile.apiUrl },
+    )
     await this._buckets.getToken(this._textile.identity)
 
     const result = await this._buckets.getOrCreate(name, { encrypted: true })

--- a/libraries/Textile/BucketManager.ts
+++ b/libraries/Textile/BucketManager.ts
@@ -42,7 +42,10 @@ export default class BucketManager {
     if (!Config.textile.key) {
       throw new Error('Textile key not found')
     }
-    this.buckets = await Buckets.withKeyInfo({ key: Config.textile.key })
+    this.buckets = await Buckets.withKeyInfo(
+      { key: Config.textile.key },
+      { host: Config.textile.apiUrl },
+    )
     await this.buckets.getToken(this.identity)
     const result = await this.buckets.getOrCreate(
       `hub.textile.io/ipfs/${this.identity}/${this.prefix}`,

--- a/libraries/Textile/IdentityManager.ts
+++ b/libraries/Textile/IdentityManager.ts
@@ -124,11 +124,15 @@ export default class IdentityManager {
       throw new Error('Textile key not found')
     }
 
-    this.client = await Client.withKeyInfo({ key: Config.textile.key })
+    this.client = await Client.withKeyInfo(
+      { key: Config.textile.key },
+      Config.textile.apiUrl,
+    )
 
-    this.users = await Users.withKeyInfo({
-      key: Config.textile.key,
-    })
+    this.users = await Users.withKeyInfo(
+      { key: Config.textile.key },
+      { host: Config.textile.apiUrl },
+    )
 
     await this.users.getToken(identity)
 


### PR DESCRIPTION
**What this PR does** 📖
Connect new textile deployment to CORE via env vars

**Which issue(s) this PR fixes** 🔨
AP-1512

**Special notes for reviewers** 🗒️
Add to `.env` two vars with new textile deployment urls: `NUXT_ENV_TEXTILE_BROWSER` and `NUXT_ENV_TEXTILE_API_URL`. Also you need new api key. By default `textile.io` based addresses will be used

**Additional comments** 🎤
