### PR TITLE
test(cypress): new accounts and unskipping tests

### DIFF
--- a/cypress/fixtures/test-data-accounts.json
+++ b/cypress/fixtures/test-data-accounts.json
@@ -1,0 +1,51 @@
+{
+  "dataRecovery": {
+    "accounts": [
+      {
+        "id": 1,
+        "description": "Chat User A",
+        "recoverySeed": "entry soccer evoke oak bomb joke ugly safe spend arrest bacon remove"
+      },
+      {
+        "id": 2,
+        "description": "Chat User B",
+        "recoverySeed": "youth expand artefact absent clown tattoo skill resist interest pill unit rude"
+      },
+      {
+        "id": 3,
+        "description": "Chat User C",
+        "recoverySeed": "short loop typical worth force tragic huge rigid despair tree roast hurdle"
+      },
+      {
+        "id": 4,
+        "description": "cypress",
+        "recoverySeed": "slice manual beyond few there among solar melody lizard phone rent steel"
+      },
+      {
+        "id": 5,
+        "description": "cypress friend",
+        "recoverySeed": "scrub harsh trip extend retreat denial seed ritual win whale clown employ"
+      },
+      {
+        "id": 6,
+        "description": "Snap QA",
+        "recoverySeed": "crane hand goat scorpion crime service cloud traffic kid culture left cover"
+      },
+      {
+        "id": 7,
+        "description": "Snap Friend",
+        "recoverySeed": "tired because mansion fabric found opera fantasy disease solve sure neglect job"
+      },
+      {
+        "id": 8,
+        "description": "Chat Pair A",
+        "recoverySeed": "opera sphere measure dice ripple female vessel proof topic music actual metal"
+      },
+      {
+        "id": 9,
+        "description": "Chat Pair B",
+        "recoverySeed": "metal humor they buyer fan year north habit abuse regret hunt luggage"
+      }
+    ]
+  }
+}

--- a/cypress/integration-pair-chat/chat-first-user.js
+++ b/cypress/integration-pair-chat/chat-first-user.js
@@ -1,6 +1,10 @@
+import { dataRecovery } from '../fixtures/test-data-accounts.json'
+
 const faker = require('faker')
 const recoverySeed =
-  'actress wave guitar resist pretty rifle agree hand assault guess vocal speed{enter}'
+  dataRecovery.accounts
+    .filter((item) => item.description === 'Chat Pair A')
+    .map((item) => item.recoverySeed) + '{enter}'
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 
 describe('Chat features with two accounts at the same time - First User', () => {

--- a/cypress/integration-pair-chat/chat-second-user.js
+++ b/cypress/integration-pair-chat/chat-second-user.js
@@ -1,6 +1,10 @@
+import { dataRecovery } from '../fixtures/test-data-accounts.json'
+
 const faker = require('faker')
 const recoverySeed =
-  'sword dad network author move fault web mimic develop drill cancel warfare{enter}'
+  dataRecovery.accounts
+    .filter((item) => item.description === 'Chat Pair B')
+    .map((item) => item.recoverySeed) + '{enter}'
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 const longMessage = faker.lorem.words(250) // generate random sentence
 

--- a/cypress/integration/chat-features.js
+++ b/cypress/integration/chat-features.js
@@ -1,11 +1,14 @@
+import { dataRecovery } from '../fixtures/test-data-accounts.json'
+
 const faker = require('faker')
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 const randomNumber = faker.datatype.number() // generate random number
 const randomMessage = faker.lorem.sentence() // generate random sentence
 const imageLocalPath = 'cypress/fixtures/images/logo.png'
-const randomTextToCopy = faker.lorem.sentence() // generate random sentence
 const recoverySeed =
-  'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}'
+  dataRecovery.accounts
+    .filter((item) => item.description === 'cypress')
+    .map((item) => item.recoverySeed) + '{enter}'
 let imageURL
 let randomTextEdited = randomMessage + randomNumber
 

--- a/cypress/integration/chat-glyphs-validations.js
+++ b/cypress/integration/chat-glyphs-validations.js
@@ -1,9 +1,13 @@
+import { dataRecovery } from '../fixtures/test-data-accounts.json'
+
 const faker = require('faker')
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 const recoverySeed =
-  'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}'
+  dataRecovery.accounts
+    .filter((item) => item.description === 'cypress')
+    .map((item) => item.recoverySeed) + '{enter}'
 
-describe.skip('Chat - Sending Glyphs Tests', () => {
+describe('Chat - Sending Glyphs Tests', () => {
   it('Send a glyph on chat', () => {
     //Import account
     cy.importAccount(randomPIN, recoverySeed)

--- a/cypress/integration/chat-images-validations.js
+++ b/cypress/integration/chat-images-validations.js
@@ -1,14 +1,17 @@
+import { dataRecovery } from '../fixtures/test-data-accounts.json'
+
 const faker = require('faker')
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 const recoverySeed =
-  'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}'
-
+  dataRecovery.accounts
+    .filter((item) => item.description === 'cypress')
+    .map((item) => item.recoverySeed) + '{enter}'
 const pngImagePath = 'cypress/fixtures/images/logo.png'
 const jpgImagePath = 'cypress/fixtures/images/jpeg-test.jpg'
 const gifImagePath = 'cypress/fixtures/images/gif-test.gif'
 const invalidImagePath = 'cypress/fixtures/images/incorrect-image.png'
 
-describe.skip('Chat - Sending Images Tests', () => {
+describe('Chat - Sending Images Tests', () => {
   it('PNG image is sent successfully on chat', () => {
     //Import account
     cy.importAccount(randomPIN, recoverySeed)

--- a/cypress/integration/chat-pair-features.js
+++ b/cypress/integration/chat-pair-features.js
@@ -1,10 +1,18 @@
+import { dataRecovery } from '../fixtures/test-data-accounts.json'
+
 const faker = require('faker')
 const recoverySeedAccountOne =
-  'memory cherry add return that phrase suit plate ladder earth people gravity{enter}'
+  dataRecovery.accounts
+    .filter((item) => item.description === 'Chat User A')
+    .map((item) => item.recoverySeed) + '{enter}'
 const recoverySeedAccountTwo =
-  'position few settle fold sister transfer song speed million congress acoustic version{enter}'
+  dataRecovery.accounts
+    .filter((item) => item.description === 'Chat User B')
+    .map((item) => item.recoverySeed) + '{enter}'
 const recoverySeedAccountThree =
-  'emerge cat innocent buddy install shy topic goddess legend leisure mutual bitter{enter}'
+  dataRecovery.accounts
+    .filter((item) => item.description === 'Chat User C')
+    .map((item) => item.recoverySeed) + '{enter}'
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 const randomMessage = faker.lorem.sentence() // generate random sentence
 const randomMessageTwo = faker.lorem.sentence() // generate random sentence
@@ -13,7 +21,7 @@ const fileLocalPath = 'cypress/fixtures/test-file.txt'
 const textReply = 'This is a reply to the message'
 let glyphURL, imageURL, fileURL
 
-describe.skip('Chat features with two accounts', () => {
+describe('Chat features with two accounts', () => {
   it('Ensure chat window from first account is displayed', () => {
     //Import first account
     cy.importAccount(randomPIN, recoverySeedAccountOne)
@@ -73,7 +81,7 @@ describe.skip('Chat features with two accounts', () => {
     cy.validateOptionNotInContextMenu('[data-cy=chat-glyph]', 'Edit')
   })
 
-  it.skip('Send image to user B', () => {
+  it('Send image to user B', () => {
     cy.chatFeaturesSendImage(imageLocalPath, 'logo.png')
     cy.goToLastImageOnChat()
       .invoke('attr', 'src')
@@ -82,13 +90,13 @@ describe.skip('Chat features with two accounts', () => {
       })
   })
 
-  it.skip('Context Menu Options - Image Message', () => {
+  it('Context Menu Options - Image Message', () => {
     let optionsImage = ['Add Reaction', 'Reply', 'Copy Image', 'Save Image']
     cy.get('[data-cy=chat-image]').last().as('lastImage')
     cy.validateAllOptionsInContextMenu('@lastImage', optionsImage)
   })
 
-  it.skip('Image messages cannot be edited', () => {
+  it('Image messages cannot be edited', () => {
     cy.validateOptionNotInContextMenu('[data-cy=chat-image]', 'Edit')
   })
 
@@ -184,7 +192,7 @@ describe.skip('Chat features with two accounts', () => {
       })
   })
 
-  it.skip('Assert image received from user A', () => {
+  it('Assert image received from user A', () => {
     cy.goToLastImageOnChat()
       .invoke('attr', 'src')
       .then((imageSecondAccountSrc) => {
@@ -221,7 +229,7 @@ describe.skip('Chat features with two accounts', () => {
     cy.validateChatReaction('@messageToReact', '😄')
   })
 
-  it.skip('Add reactions to image in chat', () => {
+  it('Add reactions to image in chat', () => {
     cy.get('[data-cy=chat-image]').last().as('imageToReact')
     cy.reactToChatElement('@imageToReact', '[title="smile"]')
     cy.validateChatReaction('@imageToReact', '😄')
@@ -321,7 +329,7 @@ describe.skip('Chat features with two accounts', () => {
     cy.get('@reactionToMessage').should(
       'have.css',
       'background-image',
-      'linear-gradient(40deg, rgb(39, 97, 253) 0%, rgb(40, 109, 254) 100%)',
+      'linear-gradient(40deg, rgb(39, 97, 253) 0%, rgb(39, 97, 253) 100%)',
     )
   })
 })

--- a/cypress/integration/chat-text-validations.js
+++ b/cypress/integration/chat-text-validations.js
@@ -1,7 +1,11 @@
+import { dataRecovery } from '../fixtures/test-data-accounts.json'
+
 const faker = require('faker')
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 const recoverySeed =
-  'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}'
+  dataRecovery.accounts
+    .filter((item) => item.description === 'cypress')
+    .map((item) => item.recoverySeed) + '{enter}'
 let longMessage = faker.random.alphaNumeric(2060) // generate random alphanumeric text with 2060 chars
 const randomMessage = faker.lorem.sentence() // generate random sentence
 const randomURL = faker.internet.url() // generate random url
@@ -9,7 +13,7 @@ let urlToValidate = 'https://www.satellite.im'
 let urlToValidateTwo = 'http://www.satellite.im'
 let urlToValidateThree = 'www.satellite.im'
 
-describe.skip('Chat Text and Sending Links Validations', () => {
+describe('Chat Text and Sending Links Validations', () => {
   it('Message with more than 2048 chars - Counter get reds', () => {
     //Import account
     cy.importAccount(randomPIN, recoverySeed)

--- a/cypress/integration/chat-top-toolbar.js
+++ b/cypress/integration/chat-top-toolbar.js
@@ -1,9 +1,13 @@
+import { dataRecovery } from '../fixtures/test-data-accounts.json'
+
 const faker = require('faker')
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 const recoverySeed =
-  'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}'
+  dataRecovery.accounts
+    .filter((item) => item.description === 'cypress')
+    .map((item) => item.recoverySeed) + '{enter}'
 
-describe.skip('Chat Toolbar Tests', () => {
+describe('Chat Toolbar Tests', () => {
   it('Chat - Toolbar - Validate audio icon is displayed', () => {
     //Import account
     cy.importAccount(randomPIN, recoverySeed)

--- a/cypress/integration/create-account.js
+++ b/cypress/integration/create-account.js
@@ -79,7 +79,7 @@ describe('Create Account Validations', () => {
     cy.createAccountSubmit()
   })
 
-  it.skip('Create account successfully without image after attempting to add a NSFW picture', () => {
+  it('Create account successfully without image after attempting to add a NSFW picture', () => {
     //Creating pin
     cy.createAccountPINscreen(randomPIN)
 
@@ -112,7 +112,7 @@ describe('Create Account Validations', () => {
     ).should('not.exist')
   })
 
-  it.skip('Create account without image after attempting to add an invalid image file', () => {
+  it('Create account without image after attempting to add an invalid image file', () => {
     //Creating pin
     cy.createAccountPINscreen(randomPIN)
 
@@ -144,7 +144,7 @@ describe('Create Account Validations', () => {
     ).should('not.exist')
   })
 
-  it.skip('Create account with valid image after attempting to add an invalid image file', () => {
+  it('Create account with valid image after attempting to add an invalid image file', () => {
     //Creating pin
     cy.createAccountPINscreen(randomPIN)
 

--- a/cypress/integration/files-features.js
+++ b/cypress/integration/files-features.js
@@ -1,10 +1,14 @@
+import { dataRecovery } from '../fixtures/test-data-accounts.json'
+
 const faker = require('faker')
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 const randomNumber = faker.datatype.number() // generate random number
 const recoverySeed =
-  'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}'
+  dataRecovery.accounts
+    .filter((item) => item.description === 'cypress')
+    .map((item) => item.recoverySeed) + '{enter}'
 
-describe.skip('Files Features Tests', () => {
+describe('Files Features Tests', () => {
   it('Chat - Files - Rename Folder', () => {
     // Import account
     cy.importAccount(randomPIN, recoverySeed)

--- a/cypress/integration/import-account.js
+++ b/cypress/integration/import-account.js
@@ -1,3 +1,8 @@
+import { dataRecovery } from '../fixtures/test-data-accounts.json'
+const recoverySeed =
+  dataRecovery.accounts
+    .filter((item) => item.description === 'cypress')
+    .map((item) => item.recoverySeed) + '{enter}'
 const faker = require('faker')
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 
@@ -23,11 +28,7 @@ describe('Import Account Validations', () => {
     cy.get('[data-cy=add-passphrase]')
       .should('be.visible')
       .click()
-      .type(
-        'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}',
-        { log: false },
-        { force: true },
-      )
+      .type(recoverySeed + '{enter}', { log: false }, { force: true })
     cy.contains('Recover Account').should('be.visible').click()
   })
 })

--- a/cypress/integration/localstorage-validations.js
+++ b/cypress/integration/localstorage-validations.js
@@ -1,7 +1,11 @@
+import { dataRecovery } from '../fixtures/test-data-accounts.json'
+
 const faker = require('faker')
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 const recoverySeed =
-  'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}'
+  dataRecovery.accounts
+    .filter((item) => item.description === 'cypress')
+    .map((item) => item.recoverySeed) + '{enter}'
 
 describe('Verify passphrase does not get stored in localstorage', () => {
   before(() => {

--- a/cypress/integration/mobiles-responsiveness.js
+++ b/cypress/integration/mobiles-responsiveness.js
@@ -1,3 +1,4 @@
+import { dataRecovery } from '../fixtures/test-data-accounts.json'
 import { data } from '../fixtures/mobile-devices.json'
 
 const faker = require('faker')
@@ -8,12 +9,14 @@ const filepathCorrect = 'images/logo.png'
 const randomNumber = faker.datatype.number() // generate random number
 const randomMessage = faker.lorem.sentence() // generate random sentence
 const recoverySeed =
-  'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower{enter}'
+  dataRecovery.accounts
+    .filter((item) => item.description === 'cypress')
+    .map((item) => item.recoverySeed) + '{enter}'
 
 describe('Run responsiveness tests on several devices', () => {
   Cypress.config('pageLoadTimeout', 180000) //adding more time for pageLoadTimeout only for this spec
   data.allDevices.forEach((item) => {
-    it.skip(`Create Account on ${item.description}`, () => {
+    it(`Create Account on ${item.description}`, () => {
       cy.viewport(item.width, item.height)
       cy.createAccountPINscreen(randomPIN)
 
@@ -39,7 +42,7 @@ describe('Run responsiveness tests on several devices', () => {
       cy.createAccountSubmit()
     })
 
-    it.skip(`Import Account on ${item.description}`, () => {
+    it(`Import Account on ${item.description}`, { retries: 2 }, () => {
       cy.viewport(item.width, item.height)
       cy.importAccount(randomPIN, recoverySeed)
       //Validate profile name displayed
@@ -49,7 +52,7 @@ describe('Run responsiveness tests on several devices', () => {
       cy.goToConversation('cypress friend')
     })
 
-    it.skip(`Chat Features on ${item.description}`, () => {
+    it(`Chat Features on ${item.description}`, () => {
       //Setting viewport
       cy.viewport(item.width, item.height)
 

--- a/cypress/integration/pin-unlock-validations.js
+++ b/cypress/integration/pin-unlock-validations.js
@@ -1,9 +1,13 @@
+import { dataRecovery } from '../fixtures/test-data-accounts.json'
+
 const faker = require('faker')
-const userPassphrase =
-  'useful wedding venture reopen forest lawsuit essence hamster kitchen bundle level tower'
+const userPassphrase = dataRecovery.accounts
+  .filter((item) => item.description === 'cypress')
+  .map((item) => item.recoverySeed)
+  .toString()
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 
-describe.skip('Unlock pin should be persisted when store pin is enabled', () => {
+describe('Unlock pin should be persisted when store pin is enabled', () => {
   it('Create Account with store pin disabled', () => {
     //Go to URL, add a PIN and make sure that toggle for save pin is disabled
     cy.createAccountPINscreen(randomPIN, false, false)

--- a/cypress/integration/privacy-page-toggles.js
+++ b/cypress/integration/privacy-page-toggles.js
@@ -3,11 +3,7 @@ const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate
 const randomName = faker.internet.userName(name) // generate random name
 const randomStatus = faker.lorem.word() // generate random status
 
-//Creating two arrays to compare values displayed in toggle switches on both screens
-let toggleStatusSaved = []
-let toggleStatusProfile = []
-
-describe.skip('Privacy Settings Page - Toggles Tests', () => {
+describe('Privacy Settings Page - Toggles Tests', () => {
   it('Privacy Page - Validate existing toggles', () => {
     //Setting a viewport visible for all toggles
     cy.viewport(1200, 1200)

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -495,9 +495,15 @@ Cypress.Commands.add('goToConversation', (user) => {
   })
 
   //Find the friend and click on the message button associated
-  cy.get('[data-cy=sidebar-user-name]', { timeout: 30000 })
+  cy.get('[data-cy=sidebar-user-name]', { timeout: 60000 })
     .contains(user)
-    .click()
+    .then(($el) => {
+      cy.getAttached($el).click()
+    })
+
+  /*cy.get('[data-cy=sidebar-user-name]', { timeout: 30000 })
+    .contains(user)
+    .click()*/
 
   // Hide sidebar
   cy.get('[data-cy=hamburger-button]').click()
@@ -833,3 +839,18 @@ Cypress.Commands.add(
     return subject
   },
 )
+
+// Get element attached to DOM
+
+Cypress.Commands.add('getAttached', (selector) => {
+  const getElement =
+    typeof selector === 'function' ? selector : ($d) => $d.find(selector)
+  let $el = null
+  return cy
+    .document()
+    .should(($d) => {
+      $el = getElement(Cypress.$($d))
+      expect(Cypress.dom.isDetached($el)).to.be.false
+    })
+    .then(() => cy.wrap($el))
+})


### PR DESCRIPTION
**What this PR does** 📖
- Update cypress tests accounts for all tests due to textile api key change
- Updated all cypress tests to retrieve the recovery seeds from a fixtures file, to remove this data from test specs
- Unskip tests that should be working right now after updates to the application
- Added a new cypress command to get elements and avoid the cypress issue for non-attached to DOM elements. Implemented the usage of this command into the goToConversation cypress command
- Updated expected css values on reaction to chat cypress test
- Removed lines of code no longer used in privacy-page-toggles.js cypress test

**Which issue(s) this PR fixes** 🔨
None

**Special notes for reviewers** 🗒️
- Sending this as draft. In case that any test case fails due to slowness, I can add a retry to that test case
- On a next PR, I will create a cypress command to retrieve the recovery seed based on the name of the user, so we don't need to use the same code lines again and again

**Additional comments** 🎤
Too many cypress videos to upload!