### PR TITLE
fix(files): hide sidebar options that 100% wont be ready

### DIFF
--- a/components/views/files/aside/Aside.html
+++ b/components/views/files/aside/Aside.html
@@ -19,8 +19,8 @@
     <TypographyText :size="6" :text="$t('pages.files.aside.quick_access')" />
     <FilesAsideList :items="quickAccessOptions" />
   </div>
-  <div>
+  <!-- <div>
     <TypographyText :size="6" :text="$t('pages.files.aside.shared_items')" />
     <FilesAsideList :items="sharedItemsOptions" />
-  </div>
+  </div> -->
 </div>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- hide bottom two 'shared' related options. gonna try to complete deleted and favorite soon, but these definitely wont be ready

**Which issue(s) this PR fixes** 🔨
AP-1571
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
