### PR TITLE
test(cypress): add save image test and updates to mobiles

### DIFF
--- a/cypress/integration/chat-images-validations.js
+++ b/cypress/integration/chat-images-validations.js
@@ -10,8 +10,10 @@ const pngImagePath = 'cypress/fixtures/images/logo.png'
 const jpgImagePath = 'cypress/fixtures/images/jpeg-test.jpg'
 const gifImagePath = 'cypress/fixtures/images/gif-test.gif'
 const invalidImagePath = 'cypress/fixtures/images/incorrect-image.png'
+const path = require('path')
 
-describe.skip('Chat - Sending Images Tests', () => {
+describe('Chat - Sending Images Tests', () => {
+  const downloadsFolder = Cypress.config('downloadsFolder')
   it('PNG image is sent successfully on chat', { retries: 2 }, () => {
     //Import account
     cy.importAccount(randomPIN, recoverySeed)
@@ -24,13 +26,22 @@ describe.skip('Chat - Sending Images Tests', () => {
 
     //Send PNG Image
     cy.chatFeaturesSendImage(pngImagePath, 'logo.png')
-    cy.goToLastImageOnChat()
+    cy.goToLastImageOnChat(60000) // first image sent takes more time
   })
 
   it('JPG image is sent successfully on chat', () => {
     //Send JPG Image
     cy.chatFeaturesSendImage(jpgImagePath, 'jpeg-test.jpg')
-    cy.goToLastImageOnChat()
+    cy.goToLastImageOnChat(30000)
+  })
+
+  it('Save Image from Chat', () => {
+    // Go to last image (jpeg), right click and select on context menu Save Image
+    cy.goToLastImageOnChat(30000).as('lastImage')
+    cy.selectContextMenuOption('@lastImage', 'Save Image')
+    // Assert image was downloaded in downloads folder with the same name
+    const downloadedFile = path.join(downloadsFolder, 'download.jpeg')
+    cy.readFile(downloadedFile, { timeout: 15000 }).should('exist')
   })
 
   it('GIF image is sent successfully on chat', () => {

--- a/cypress/integration/mobiles-responsiveness.js
+++ b/cypress/integration/mobiles-responsiveness.js
@@ -13,108 +13,137 @@ const recoverySeed =
     .filter((item) => item.description === 'cypress')
     .map((item) => item.recoverySeed) + '{enter}'
 
-describe('Run responsiveness tests on several devices', () => {
-  Cypress.config('pageLoadTimeout', 180000) //adding more time for pageLoadTimeout only for this spec
-  data.allDevices.forEach((item) => {
-    beforeEach(() => {
-      cy.viewport(item.width, item.height)
-    })
+data.allDevices.forEach((item) => {
+  describe(
+    `Run responsiveness tests on ${item.description}`,
+    {
+      viewportHeight: item.height,
+      viewportWidth: item.width,
+    },
+    () => {
+      Cypress.config('pageLoadTimeout', 180000) //adding more time for pageLoadTimeout only for this spec
+      it(`Create Account on ${item.description}`, () => {
+        cy.createAccountPINscreen(randomPIN, false, false, true)
 
-    it(`Create Account on ${item.description}`, () => {
-      cy.createAccountPINscreen(randomPIN, false, false, true)
+        //Create or Import account selection screen
+        cy.createAccountSecondScreen()
 
-      //Create or Import account selection screen
-      cy.createAccountSecondScreen()
+        //Recovery Seed Screen
+        cy.createAccountRecoverySeed()
 
-      //Recovery Seed Screen
-      cy.createAccountRecoverySeed()
+        //Username and Status Input
+        cy.validateUserInputIsDisplayed()
+        cy.createAccountUserInput(randomName, randomStatus)
 
-      //Username and Status Input
-      cy.validateUserInputIsDisplayed()
-      cy.createAccountUserInput(randomName, randomStatus)
+        //User Image Input
+        cy.createAccountAddImage(filepathCorrect)
+        cy.get('[data-cy=cropper-container]', { timeout: 60000 })
+          .should('exist')
+          .then(() => {
+            cy.contains('Crop', { timeout: 30000 }).should('exist').click()
+          })
 
-      //User Image Input
-      cy.createAccountAddImage(filepathCorrect)
-      cy.get('[data-cy=cropper-container]', { timeout: 60000 })
-        .should('exist')
-        .then(() => {
-          cy.contains('Crop', { timeout: 30000 }).should('exist').click()
+        //Finishing Account Creation
+        cy.createAccountSubmit()
+      })
+
+      it(`Import Account on ${item.description}`, { retries: 2 }, () => {
+        cy.importAccount(randomPIN, recoverySeed, true)
+        //Validate profile name displayed
+        cy.validateChatPageIsLoaded(true)
+
+        //Go to conversation
+        cy.goToConversation('cypress friend', true)
+      })
+
+      it(`Chat Features - Send Messages on ${item.description}`, () => {
+        // Click to hamburger button to display chat if app wrap is open (chat not displayed)
+        cy.get('#app-wrap').then(($appWrap) => {
+          if ($appWrap.hasClass('is-open')) {
+            cy.get('[data-cy=hamburger-button]').click()
+          }
         })
 
-      //Finishing Account Creation
-      cy.createAccountSubmit()
-    })
+        //Validate message and emojis are sent
+        cy.chatFeaturesSendMessage(randomMessage)
+      })
 
-    it(`Import Account on ${item.description}`, { retries: 2 }, () => {
-      cy.importAccount(randomPIN, recoverySeed, true)
-      //Validate profile name displayed
-      cy.validateChatPageIsLoaded(true)
+      it(`Chat Features - Send Emoji on ${item.description}`, () => {
+        cy.chatFeaturesSendEmoji('[title="smile"]', '😄')
+      })
 
-      //Go to conversation
-      cy.goToConversation('cypress friend', true)
-    })
+      it.skip(`Chat Features - Edit Messages on ${item.description}`, () => {
+        cy.chatFeaturesEditMessage(randomMessage, randomNumber)
+      })
 
-    it(`Chat Features - Messages on ${item.description}`, () => {
-      //Validate message and emojis are sent
-      cy.chatFeaturesSendMessage(randomMessage)
-      cy.chatFeaturesSendEmoji('[title="smile"]', '😄')
+      it(`Marketplace - Coming Soon Modal on ${item.description}`, () => {
+        cy.get('[data-cy=toggle-sidebar]').click() // return to main screen
+        cy.get('[data-cy=mobile-nav-marketplace]').click() // go to Marketplace icon
+        cy.validateComingSoonModal()
+      })
 
-      //Validate message can be edited - Commenting this since editMessages is not working
-      //cy.chatFeaturesEditMessage(randomMessage, randomNumber)
+      it(`Marketplace - Coming Soon Modal URL on ${item.description}`, () => {
+        cy.validateURLComingSoonModal()
+      })
 
-      //Marketplace - Coming Soon Modal
-      cy.get('[data-cy=toggle-sidebar]').click() // return to main screen
-      cy.get('[data-cy=mobile-nav-marketplace]').click() // go to Marketplace icon
-      cy.validateComingSoonModal()
+      it(`Marketplace - Coming Soon Modal can be dismissed on ${item.description}`, () => {
+        cy.closeModal('[data-cy=modal-cta]')
+      })
 
-      //Validate URL on coming soon modal
-      cy.validateURLComingSoonModal()
+      it.skip(`Glyphs Modal on ${item.description}`, () => {
+        //Go to last glyph and click on glyphs modal
+        cy.goToLastGlyphOnChat().click()
+        cy.validateGlyphsModal()
+      })
 
-      //Coming soon modal can be dismissed
-      cy.closeModal('[data-cy=modal-cta]')
+      it.skip(`Glyphs Modal - Coming Soon on ${item.description}`, () => {
+        //Coming soon modal
+        cy.contains('View Glyph Pack').click()
+        cy.get('[data-cy=modal-cta]').should('be.visible')
+        cy.closeModal('[data-cy=modal-cta]')
+      })
 
-      //Go to last glyph and click on glyphs modal
-      //cy.goToLastGlyphOnChat().click()
-      //cy.validateGlyphsModal()
+      it.skip(`Glyphs Pack Screen can be dismissed on ${item.description}`, () => {
+        //Glyph Pack Screen can be dismissed
+        cy.goToLastGlyphOnChat().click()
+        cy.get('[data-cy=glyphs-modal]').should('be.visible')
+        cy.closeModal('[data-cy=glyphs-modal]')
+      })
 
-      //Coming soon modal
-      //cy.contains('View Glyph Pack').click()
-      //cy.get('[data-cy=modal-cta]').should('be.visible')
-      //cy.closeModal('[data-cy=modal-cta]')
+      it(`Glyphs Selection - Coming Soon Modal on ${item.description}`, () => {
+        //Glyph Selection - Coming Soon Modal
+        cy.goToConversation('cypress friend', true)
+        cy.get('#glyph-toggle').click()
+        cy.get('[data-cy=glyphs-marketplace]').click()
+        cy.get('[data-cy=modal-cta]').should('be.visible')
+        cy.closeModal('[data-cy=modal-cta]')
+      })
 
-      //Glyph Pack Screen can be dismissed
-      //cy.goToLastGlyphOnChat().click()
-      //cy.get('[data-cy=glyphs-modal]').should('be.visible')
-      //cy.closeModal('[data-cy=glyphs-modal]')
+      it(`Swipe on Settings Screen on ${item.description}`, () => {
+        //Swipe on Settings Screen
+        cy.get('[data-cy=toggle-sidebar]').click() //Show main screen again
+        cy.get('#mobile-nav').should('be.visible')
+        cy.get('[data-cy=mobile-nav-settings]').click() //Click on settings
+        cy.contains('Settings').should('be.visible')
+        cy.get('#settings').realSwipe('toRight') // Swipe to the right, to go back to the left part of the screen
+        cy.contains('Personalize').should('be.visible')
+        cy.get('#settings').realSwipe('toLeft') // Swipe to the left, to go to the right part of the screen
+        cy.contains('Settings').should('be.visible')
+        cy.get('.close-button').click()
+      })
 
-      //Glyph Selection - Coming Soon Modal
-      cy.goToConversation('cypress friend', true)
-      cy.get('#glyph-toggle').click()
-      cy.get('[data-cy=glyphs-marketplace]').click()
-      cy.get('[data-cy=modal-cta]').should('be.visible')
-      cy.closeModal('[data-cy=modal-cta]')
+      it(`Swipe on Chat Screen on ${item.description}`, () => {
+        //Swipe on Chat screen to Main screen
+        cy.goToConversation('cypress friend', true)
+        cy.get('[data-cy=editable-input]').should('be.visible')
+        cy.get('body').realSwipe('toRight') // Swipe to the right, to return to main page
+        cy.get('#mobile-nav').should('be.visible')
+      })
 
-      //Swipe on Settings Screen
-      cy.get('[data-cy=toggle-sidebar]').click() //Show main screen again
-      cy.get('#mobile-nav').should('be.visible')
-      cy.get('[data-cy=mobile-nav-settings]').click() //Click on settings
-      cy.contains('Settings').should('be.visible')
-      cy.get('#settings').realSwipe('toRight') // Swipe to the right, to go back to the left part of the screen
-      cy.contains('Personalize').should('be.visible')
-      cy.get('#settings').realSwipe('toLeft') // Swipe to the left, to go to the right part of the screen
-      cy.contains('Settings').should('be.visible')
-      cy.get('.close-button').click()
-
-      //Swipe on Chat screen to Main screen
-      cy.goToConversation('cypress friend', true)
-      cy.get('[data-cy=editable-input]').should('be.visible')
-      cy.get('body').realSwipe('toRight') // Swipe to the right, to return to main page
-      cy.get('#mobile-nav').should('be.visible')
-    })
-
-    it(`Release Notes Screen on ${item.description}`, () => {
-      cy.visitRootPage()
-      cy.releaseNotesScreenValidation()
-    })
-  })
+      it(`Release Notes Screen on ${item.description}`, () => {
+        cy.visitRootPage()
+        cy.releaseNotesScreenValidation()
+      })
+    },
+  )
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -426,8 +426,11 @@ Cypress.Commands.add('chatFeaturesSendImage', (imagePath, filename) => {
   cy.get('.thumbnail', { timeout: 120000 }).should('not.exist')
 })
 
-Cypress.Commands.add('goToLastImageOnChat', () => {
-  cy.get('[data-cy=chat-image]').last().scrollIntoView().should('exist')
+Cypress.Commands.add('goToLastImageOnChat', (waitTime = 30000) => {
+  cy.get('[data-cy=chat-image]', { timeout: waitTime })
+    .last()
+    .scrollIntoView()
+    .should('be.visible')
 })
 
 // Chat - Send Files Commands


### PR DESCRIPTION
**What this PR does** 📖
- Add save image cypress test in chat-images-validations.js and unskip the describe block from this file
- Updates on mobiles-responsiveness.js file in order to have separate it blocks for tests and use skips for tests not working now instead of having commented code
- Small improvement to goToLastImageOnChat cypress command

**Which issue(s) this PR fixes** 🔨
AP-1322

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
Chat Images Validations Cypress Video:
https://user-images.githubusercontent.com/35935591/168914601-44333c9b-7586-467e-8ec5-8f4d340e95ed.mp4

Mobiles Responsiveness Cypress Video:
https://user-images.githubusercontent.com/35935591/168914644-7a10ea9d-f636-4e23-894f-2c02e46aad14.mp4
