### PR TITLE
fix(notification): clear alert number on open

### DIFF
--- a/components/views/media/actions/Actions.vue
+++ b/components/views/media/actions/Actions.vue
@@ -54,11 +54,15 @@ export default Vue.extend({
      */
     toggleMute(kind = 'audio') {
       this.isLoading = true
-      this.$store.dispatch(
-        'webrtc/toggleMute',
-        { kind, peerId: p2p.id },
-        { root: true },
-      )
+      try {
+        this.$store.dispatch(
+          'webrtc/toggleMute',
+          { kind, peerId: p2p.id },
+          { root: true },
+        )
+      } catch (e) {
+        console.log(E)
+      }
       this.isLoading = false
     },
     /**

--- a/components/views/media/actions/Actions.vue
+++ b/components/views/media/actions/Actions.vue
@@ -54,15 +54,11 @@ export default Vue.extend({
      */
     toggleMute(kind = 'audio') {
       this.isLoading = true
-      try {
-        this.$store.dispatch(
-          'webrtc/toggleMute',
-          { kind, peerId: p2p.id },
-          { root: true },
-        )
-      } catch (e) {
-        console.log(E)
-      }
+      this.$store.dispatch(
+        'webrtc/toggleMute',
+        { kind, peerId: p2p.id },
+        { root: true },
+      )
       this.isLoading = false
     },
     /**

--- a/components/views/navigation/toolbar/Toolbar.html
+++ b/components/views/navigation/toolbar/Toolbar.html
@@ -56,7 +56,7 @@
       :customStyles="$device.isMobile"
       :toggleMethod="() => $data.showAlerts = false"
     >
-      <ToolbarAlerts :notifications="allUnseenNotifications" />
+      <ToolbarAlerts />
     </UiFloatingContainer>
     <template v-if="conversation.type === 'friend'">
       <div

--- a/components/views/navigation/toolbar/Toolbar.vue
+++ b/components/views/navigation/toolbar/Toolbar.vue
@@ -144,6 +144,7 @@ export default Vue.extend({
       })
     },
     toggleAlerts() {
+      this.$store.commit('ui/clearAllNotifications')
       this.showAlerts = !this.showAlerts
     },
     isGroup(thing: any) {

--- a/components/views/navigation/toolbar/alerts/Alerts.html
+++ b/components/views/navigation/toolbar/alerts/Alerts.html
@@ -1,7 +1,6 @@
 <div id="alerts">
   <template v-if="notifications.length">
     <InteractablesButton
-      v-if="notifications.length"
       size="small"
       :action="clearNotifications"
       class="alerts-clear-button"

--- a/components/views/navigation/toolbar/alerts/Alerts.html
+++ b/components/views/navigation/toolbar/alerts/Alerts.html
@@ -1,21 +1,18 @@
 <div id="alerts">
-  <InteractablesButton
-    v-if="allUnseenNotifications.length"
-    size="small"
-    :action="clearNotifications"
-    class="alerts-clear-button"
-    type="primary"
-    :text="$t('ui.clear_all')"
-  />
-  <ToolbarAlertsAlert
-    v-for="notification in notifications"
-    v-if="notifications.length && notification.state !== AlertState.READ"
-    :alert="notification"
-    :key="notification.id"
-  />
-  <TypographySubtitle
-    v-if="!notifications.length "
-    :size="6"
-    :text="$t('alerts.caught_up')"
-  />
+  <template v-if="notifications.length">
+    <InteractablesButton
+      v-if="notifications.length"
+      size="small"
+      :action="clearNotifications"
+      class="alerts-clear-button"
+      type="primary"
+      :text="$t('ui.clear_all')"
+    />
+    <ToolbarAlertsAlert
+      v-for="notification in notifications"
+      :alert="notification"
+      :key="notification.id"
+    />
+  </template>
+  <TypographySubtitle v-else :size="6" :text="$t('alerts.caught_up')" />
 </div>

--- a/components/views/navigation/toolbar/alerts/Alerts.vue
+++ b/components/views/navigation/toolbar/alerts/Alerts.vue
@@ -1,4 +1,4 @@
-<template src="./Alerts.html" />
+<template src="./Alerts.html"></template>
 
 <script lang="ts">
 import Vue, { PropType } from 'vue'

--- a/components/views/navigation/toolbar/alerts/Alerts.vue
+++ b/components/views/navigation/toolbar/alerts/Alerts.vue
@@ -7,21 +7,16 @@ import { Alert, AlertState } from '~/libraries/ui/Alerts'
 import { RootState } from '~/types/store/store'
 
 export default Vue.extend({
-  props: {
-    notifications: {
-      type: Array as PropType<Array<Alert>>,
-      default: () => [],
-      required: false,
-    },
-  },
   computed: {
-    ...mapState({ ui: (state) => (state as RootState).ui }),
+    ...mapState({
+      notifications: (state) => (state as RootState).ui.notifications,
+    }),
     ...mapGetters('ui', ['allUnseenNotifications']),
     AlertState: () => AlertState,
   },
   methods: {
     clearNotifications() {
-      this.$store.commit('ui/clearAllNotifications')
+      this.$store.commit('ui/setNotifications', [])
     },
   },
 })

--- a/components/views/navigation/toolbar/alerts/alert/Alert.html
+++ b/components/views/navigation/toolbar/alerts/alert/Alert.html
@@ -1,24 +1,17 @@
-<div :class="`alert  ${hidden ? 'hidden' : 'shown'}`">
+<div class="alert">
   <div>
     <!--Optional alert image -->
     <img v-if="alert.content.image" :src="alert.content.image" />
-    <UiCircle
-      v-if="!alert.content.image"
-      type="random"
-      data-cy="circle-without-picture"
-    />
+    <UiCircle v-else type="random" data-cy="circle-without-picture" />
   </div>
   <div class="info-holder">
     <div class="a-heading">
-      <!--Alert title-->
       <TypographySubtitle :size="6" :text="alert.content.title" />
-      <!--Alert timestamp-->
       <TypographyText :text="$dayjs(alert.at).fromNow()" class="timestamp" />
     </div>
-    <!--Alert description-->
     <div class="description">
       <TypographyText :text="setTranslateText" />
     </div>
   </div>
-  <InteractablesClose :action="dismiss" />
+  <InteractablesClose :action="removeNotification" />
 </div>

--- a/components/views/navigation/toolbar/alerts/alert/Alert.less
+++ b/components/views/navigation/toolbar/alerts/alert/Alert.less
@@ -1,17 +1,3 @@
-.alert.UNREAD {
-  .a-heading {
-    .subtitle {
-      &:extend(.font-white);
-    }
-  }
-  .description > p {
-    &:extend(.font-white);
-  }
-}
-
-.alert.hidden {
-  opacity: 0;
-}
 .alert {
   transition: all @animation-speed ease;
   opacity: 1;

--- a/components/views/navigation/toolbar/alerts/alert/Alert.vue
+++ b/components/views/navigation/toolbar/alerts/alert/Alert.vue
@@ -1,10 +1,10 @@
-<template src="./Alert.html" />
+<template src="./Alert.html"></template>
 
 <script lang="ts">
 import Vue, { PropType } from 'vue'
 
 import { mapState } from 'vuex'
-import VueI18n from 'vue-i18n'
+import { TranslateResult } from 'vue-i18n'
 import { Alert, AlertType } from '~/libraries/ui/Alerts'
 import { RootState } from '~/types/store/store'
 
@@ -12,18 +12,12 @@ export default Vue.extend({
   props: {
     alert: {
       type: Object as PropType<Alert>,
-      required: false,
-      default: () => {},
+      required: true,
     },
-  },
-  data() {
-    return {
-      hidden: false,
-    }
   },
   computed: {
     ...mapState({ ui: (state) => (state as RootState).ui }),
-    setTranslateText(): VueI18n.TranslateResult | undefined {
+    setTranslateText(): TranslateResult | undefined {
       switch (this.alert?.type) {
         case AlertType.DIRECT_MESSAGE: {
           return this.$t('messaging.user_sent.user', {
@@ -36,9 +30,8 @@ export default Vue.extend({
     },
   },
   methods: {
-    dismiss() {
-      this.$store.dispatch('ui/removeSeenNotification', this.alert.id)
-      this.$data.hidden = true
+    removeNotification() {
+      this.$store.commit('ui/removeNotification', this.alert.id)
     },
   },
 })

--- a/libraries/ui/Alerts.ts
+++ b/libraries/ui/Alerts.ts
@@ -1,5 +1,3 @@
-import { v4 as uuidv4 } from 'uuid'
-
 export enum AlertType {
   FRIEND_REQUEST = 'FRIEND_REQUEST',
   MISSED_CALL = 'MISSED_CALL',
@@ -26,15 +24,6 @@ export type Alert = {
   state?: AlertState
   type: AlertType
   from: string
-  content: {
-    title: string
-    description: string
-    image?: string
-  }
-}
-
-export type AlertTemplate = {
-  type: AlertType
   content: {
     title: string
     description: string

--- a/store/ui/actions.test.ts
+++ b/store/ui/actions.test.ts
@@ -509,17 +509,6 @@ describe('init', () => {
     )
     expect(result).toBeUndefined()
   })
-  test('removeSeenNotification', async () => {
-    const commit = jest.fn()
-    const rootState = { ...initialRootState }
-    const localInitState = { ...initialState }
-    const payload = '01g2y9d6499169rzs5etrff48w'
-    await actions.default.removeSeenNotification(
-      { commit, localInitState, rootState },
-      payload,
-    )
-    expect(commit).toHaveBeenCalledWith('notificationSeen', payload)
-  })
   test('sendNotification with initialized mailbox manager', async () => {
     const TMConstructor = Vue.prototype.$TextileManager
     TMConstructor.notificationManager = jest.fn()

--- a/store/ui/actions.ts
+++ b/store/ui/actions.ts
@@ -111,12 +111,6 @@ export default {
       })
     commit('sendNotification', notificationResponse)
   },
-  removeSeenNotification(
-    { commit, rootState }: ActionsArguments<UIState>,
-    notificationId: string,
-  ) {
-    commit('notificationSeen', notificationId)
-  },
   /**
    * @method clearKeybinds
    * @description Unbinds all current keybindings with Mousetrap

--- a/store/ui/mutations.test.ts
+++ b/store/ui/mutations.test.ts
@@ -4039,31 +4039,5 @@ describe('mutations', () => {
       },
       swiperSlideIndex: 0,
     }
-    mutations.default.notificationSeen(
-      localizedState,
-      '69c1ad1d-37e9-4ff5-b929-de5509512a11', // Flag this notification as READ
-    )
-    expect(localizedState.notifications).toEqual([
-      {
-        _id: '01g2y9d6499169rzs5etrff48w',
-        _mod: 1652431427721842400,
-        at: 1652431426842,
-        content: { description: 'New DM', title: 'Notification' },
-        from: 'Andre2',
-        id: '69c1ad1d-37e9-4ff5-b929-de5509512a11',
-        state: 'READ', // State is transformed from UNREAD to READ
-        type: 'Direct Message',
-      },
-      {
-        _id: '01g2ya7w44h4c5mm4bgyedkrvy',
-        _mod: 1652432302212590600,
-        at: 1652432301322,
-        content: { description: 'New DM', title: 'Notification' },
-        from: 'Andre2',
-        id: '62fceb8d-60a5-4434-92e8-c07f52f9e8e6',
-        state: 'UNREAD',
-        type: 'Direct Message',
-      },
-    ])
   })
 })

--- a/store/ui/mutations.ts
+++ b/store/ui/mutations.ts
@@ -186,7 +186,7 @@ export default {
   ) {
     state.replyChatbarContent = message
   },
-  settingReaction(state: UIState, status: boolean) {
+  settingReaction(state: UIState, status: object) {
     state.settingReaction = status // TODO: check this mutation, probably a bug
   },
   /**
@@ -357,9 +357,8 @@ export default {
       notification.state = AlertState.READ
     })
   },
-  notificationSeen(state: UIState, notificationId: string) {
-    state.notifications.find((item) => item.id === notificationId).state =
-      AlertState.READ
+  removeNotification(state: UIState, id: string) {
+    state.notifications = state.notifications.filter((item) => item.id !== id)
   },
   updateTheme(state: UIState, theme: Theme) {
     state.theme.base = theme


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- adjust notifications read indicator
- change notification unread logic

**Which issue(s) this PR fixes** 🔨
AP-1500
<!--AP-X-->

**Special notes for reviewers** 🗒️
this is an updated version of Jeff's PR for the same feature. I wanted to give him feedback and needed to confirm my approach would work. Since it was already done, thought it was easy to open a new PR.

We could probably add some visual indicator for brand new notifications on open in a separate ticket (or this one if you really want)

**Additional comments** 🎤
