### PR TITLE
fix(files): width and height for files image view

### DIFF
--- a/components/views/files/view/View.less
+++ b/components/views/files/view/View.less
@@ -52,6 +52,10 @@
     max-height: 60vh;
     &:extend(.round-corners);
     overflow: hidden;
+    img {
+      height: 100%;
+      width: 100%;
+    }
   }
 
   .no-preview {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- svg with no inline width/height was being rendered with value of 0 for both
- 100% height and width for files image view

**Which issue(s) this PR fixes** 🔨
AP-1524
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
