### PR TITLE
fix(settings): correct audio input/output volume control position

### DIFF
--- a/components/views/settings/pages/audio/Audio.html
+++ b/components/views/settings/pages/audio/Audio.html
@@ -59,18 +59,6 @@
 
   <!--Audio Bitrate & Sample-->
   <div class="columns is-desktop">
-    <SettingsUnit :title="$t('pages.settings.audio.volume.title')">
-      <br />
-      <div class="meter-container">
-        <UiMeter :value="0" :height="5" solid />
-      </div>
-      <MediaActionsVolume
-        :volume="audio.volume"
-        direction="ltr"
-        plain
-        @volumeControlValueChange="volumeControlValueChange"
-      />
-    </SettingsUnit>
     <SettingsUnit :title="$t('pages.settings.audio.inputVolume.title')">
       <br />
       <div class="meter-container">
@@ -81,6 +69,18 @@
         direction="ltr"
         plain
         @volumeControlValueChange="inputVolumeControlValueChange"
+      />
+    </SettingsUnit>
+    <SettingsUnit :title="$t('pages.settings.audio.volume.title')">
+      <br />
+      <div class="meter-container">
+        <UiMeter :value="0" :height="5" solid />
+      </div>
+      <MediaActionsVolume
+        :volume="audio.volume"
+        direction="ltr"
+        plain
+        @volumeControlValueChange="volumeControlValueChange"
       />
     </SettingsUnit>
   </div>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Swaps the position of the audio input/output volume sliders so that they are aligned with the input/output device controls

**Which issue(s) this PR fixes** 🔨
AP-1592
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
