### PR TITLE
fix(settings): remove mobile redirect to profile modal settings

### DIFF
--- a/components/views/settings/modal/Modal.vue
+++ b/components/views/settings/modal/Modal.vue
@@ -36,17 +36,6 @@ export default Vue.extend({
     },
   },
   watch: {
-    'ui.showSettings': {
-      handler(newSValue) {
-        if (newSValue && this.$device.isMobile) {
-          setTimeout(() => {
-            this.changeRoute('profile')
-          }, 100)
-        }
-      },
-      deep: true,
-      immediate: true,
-    },
     'ui.settingsRoute'(val) {
       this.$store.commit('ui/toggleModal', {
         name: ModalWindows.CROP,
@@ -55,7 +44,7 @@ export default Vue.extend({
     },
   },
   mounted() {
-    this.showSidebar(false)
+    this.showSidebar(this.$device.isMobile)
   },
   methods: {
     /**


### PR DESCRIPTION
What this PR does 📖
Removed redirect to profile section in modal settings when asking for file consent on iOS (redirect to privacy section instead)

Which issue(s) this PR fixes 🔨
AP-1529

Special notes for reviewers 🗒️

Additional comments 🎤