### PR TITLE
test(cypress): update accounts and small fixes

### DIFF
--- a/cypress/fixtures/test-data-accounts.json
+++ b/cypress/fixtures/test-data-accounts.json
@@ -4,47 +4,57 @@
       {
         "id": 1,
         "description": "Chat User A",
-        "recoverySeed": "rookie fitness angry concert lemon unique trouble foot need step crack easy"
+        "recoverySeed": "inform mouse side leg truck enable science urban energy eager helmet absent"
       },
       {
         "id": 2,
         "description": "Chat User B",
-        "recoverySeed": "allow helmet winter guide someone magic north alcohol face alpha cancel inquiry"
+        "recoverySeed": "total accuse spell upper limit virtual birth number raw split thumb pencil"
       },
       {
         "id": 3,
         "description": "Chat User C",
-        "recoverySeed": "bless humor leisure brain throw pelican shine amused regular head connect economy"
+        "recoverySeed": "plunge gather abuse wreck engine aware employ chicken actual clarify actress warfare"
       },
       {
         "id": 4,
         "description": "cypress",
-        "recoverySeed": "cargo thank invest burden frog diamond invite law escape phrase iron fringe"
+        "recoverySeed": "roof phone sketch device govern general repeat bean play nature three skull"
       },
       {
         "id": 5,
         "description": "cypress friend",
-        "recoverySeed": "shock divorce gather label draft broccoli forum example outside wall flame pretty"
+        "recoverySeed": "slide project coral dish upgrade horn road potato chapter cinnamon mutual retire"
       },
       {
         "id": 6,
         "description": "Snap QA",
-        "recoverySeed": "image worry kitten lyrics obvious scare keen clown clump baby guitar rate"
+        "recoverySeed": "ready need present stairs reward popular oval symptom disagree ecology knock try"
       },
       {
         "id": 7,
         "description": "Snap Friend",
-        "recoverySeed": "differ trial pipe oil filter affair nest avocado club castle clerk future"
+        "recoverySeed": "tortoise pottery apple secret whisper army borrow thought gun neutral argue canvas"
       },
       {
         "id": 8,
         "description": "Chat Pair A",
-        "recoverySeed": "mobile increase debate rate boring goose demand stomach gossip panda stone rug"
+        "recoverySeed": "nasty degree bike hybrid artefact nominee damp sadness vendor chest shell logic"
       },
       {
         "id": 9,
         "description": "Chat Pair B",
-        "recoverySeed": "spring congress lock depend produce any trumpet ladder secret era device clip"
+        "recoverySeed": "employ pull monster sweet orange roast turn soccer dutch spend install truly"
+      },
+      {
+        "id": 10,
+        "description": "Only Text",
+        "recoverySeed": "impulse betray amateur food kid laundry hurry valid dish twin believe palm"
+      },
+      {
+        "id": 11,
+        "description": "Only Text Friend",
+        "recoverySeed": "route furnace segment region expose weapon web net siege strike unit convince"
       }
     ]
   }

--- a/cypress/integration/chat-features.js
+++ b/cypress/integration/chat-features.js
@@ -7,7 +7,7 @@ const randomMessage = faker.lorem.sentence() // generate random sentence
 const imageLocalPath = 'cypress/fixtures/images/logo.png'
 const recoverySeed =
   dataRecovery.accounts
-    .filter((item) => item.description === 'cypress')
+    .filter((item) => item.description === 'Only Text')
     .map((item) => item.recoverySeed) + '{enter}'
 let imageURL
 let randomTextEdited = randomMessage + randomNumber
@@ -21,7 +21,7 @@ describe('Chat Features Tests', () => {
     cy.validateChatPageIsLoaded()
 
     // Validate message is sent
-    cy.goToConversation('cypress friend')
+    cy.goToConversation('Only Text Friend')
     cy.chatFeaturesSendMessage(randomMessage)
   })
 
@@ -143,7 +143,7 @@ describe('Chat Features Tests', () => {
     })
 
     //Start validation
-    cy.chatFeaturesProfileName('cypress')
+    cy.chatFeaturesProfileName('Only Text')
     cy.get('[data-cy=hamburger-button]').click()
   })
 

--- a/cypress/integration/chat-pair-features.js
+++ b/cypress/integration/chat-pair-features.js
@@ -363,7 +363,7 @@ describe('Chat features with two accounts', () => {
     cy.get('@reactionToMessage').should(
       'have.css',
       'background-image',
-      'linear-gradient(40deg, rgb(39, 97, 253) 0%, rgb(39, 97, 253) 100%)',
+      'linear-gradient(40deg, rgb(39, 97, 253) 40%, rgb(40, 108, 254) 100%)',
     )
   })
 })

--- a/cypress/integration/chat-text-validations.js
+++ b/cypress/integration/chat-text-validations.js
@@ -4,7 +4,7 @@ const faker = require('faker')
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 const recoverySeed =
   dataRecovery.accounts
-    .filter((item) => item.description === 'cypress')
+    .filter((item) => item.description === 'Only Text')
     .map((item) => item.recoverySeed) + '{enter}'
 let longMessage = faker.random.alphaNumeric(2060) // generate random alphanumeric text with 2060 chars
 const randomMessage = faker.lorem.sentence() // generate random sentence
@@ -20,7 +20,7 @@ describe('Chat Text and Sending Links Validations', () => {
 
     //Ensure messages are displayed before starting
     cy.validateChatPageIsLoaded()
-    cy.goToConversation('cypress friend')
+    cy.goToConversation('Only Text Friend')
   })
 
   it('Message with more than 2048 chars - Counter get reds', () => {

--- a/cypress/integration/files-features.js
+++ b/cypress/integration/files-features.js
@@ -5,7 +5,7 @@ const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate
 const randomNumber = faker.datatype.number() // generate random number
 const recoverySeed =
   dataRecovery.accounts
-    .filter((item) => item.description === 'cypress')
+    .filter((item) => item.description === 'Only Text')
     .map((item) => item.recoverySeed) + '{enter}'
 
 describe('Files Features Tests', () => {
@@ -17,7 +17,7 @@ describe('Files Features Tests', () => {
     cy.validateChatPageIsLoaded()
 
     // Validate message is sent
-    cy.goToConversation('cypress friend')
+    cy.goToConversation('Only Text Friend')
 
     //Click on toggle button and then on files
     cy.get('[data-cy=toggle-sidebar]').click()

--- a/cypress/integration/import-account.js
+++ b/cypress/integration/import-account.js
@@ -1,7 +1,7 @@
 import { dataRecovery } from '../fixtures/test-data-accounts.json'
 const recoverySeed =
   dataRecovery.accounts
-    .filter((item) => item.description === 'cypress')
+    .filter((item) => item.description === 'Only Text')
     .map((item) => item.recoverySeed) + '{enter}'
 const faker = require('faker')
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN

--- a/cypress/integration/localstorage-validations.js
+++ b/cypress/integration/localstorage-validations.js
@@ -4,7 +4,7 @@ const faker = require('faker')
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 const recoverySeed =
   dataRecovery.accounts
-    .filter((item) => item.description === 'cypress')
+    .filter((item) => item.description === 'Only Text')
     .map((item) => item.recoverySeed) + '{enter}'
 
 describe('Verify passphrase does not get stored in localstorage', () => {

--- a/cypress/integration/pin-unlock-validations.js
+++ b/cypress/integration/pin-unlock-validations.js
@@ -2,7 +2,7 @@ import { dataRecovery } from '../fixtures/test-data-accounts.json'
 
 const faker = require('faker')
 const userPassphrase = dataRecovery.accounts
-  .filter((item) => item.description === 'cypress')
+  .filter((item) => item.description === 'Only Text')
   .map((item) => item.recoverySeed)
   .toString()
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -736,7 +736,10 @@ Cypress.Commands.add('sendMessageWithMarkdown', (text, markdown) => {
   cy.get('[data-cy=editable-input]')
     .should('be.visible')
     .trigger('input')
-    .type(textMarkdown)
+    .paste({
+      pasteType: 'text',
+      pastePayload: textMarkdown,
+    })
   // Assert the text message is displayed before sending
   cy.get('[data-cy=editable-input]')
     .should('have.text', textMarkdown)


### PR DESCRIPTION
**What this PR does** 📖
- Create new accounts for cypress tests and changed the test files to use accounts without images/glyphs when it is not needed to have these in the conversations
- Updated the background color expected for a reaction in chat-pair-features.js
- Updated sendMessageWithMarkdown cypress command to use paste instead of type command (to avoid the element non typable cypress issue)

**Which issue(s) this PR fixes** 🔨
None

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
