### PR TITLE
feat(account): button to delete account on login screen

### DIFF
--- a/components/views/settings/pages/storage/index.vue
+++ b/components/views/settings/pages/storage/index.vue
@@ -21,6 +21,8 @@ export default Vue.extend({
         this.$toast.success(
           this.$t('pages.settings.storage.clear.message') as string,
         )
+        this.$store.commit('settings/removeAppState')
+        location.reload()
       } catch (e: any) {
         this.$toast.error(this.$t(e.message) as string)
       } finally {

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -205,6 +205,7 @@ export default {
       create: 'Create Account Pin',
       placeholder: 'Enter Pin...',
       store_pin: 'Store Pin? (Less Secure)',
+      delete_account_label: 'Not you? Create or import an account',
     },
     loading: {
       loading: 'Linking Satellites...',

--- a/pages/auth/unlock/Unlock.html
+++ b/pages/auth/unlock/Unlock.html
@@ -30,7 +30,7 @@
     />
     <br />
     <a v-if="getPinHash" class="delete-link" @click="deleteAccount">
-      Not you? Create or import an account
+      {{$t('pages.unlock.delete_account_label')}}
     </a>
     <div class="realm-container">
       <InteractablesRealm />

--- a/pages/auth/unlock/Unlock.html
+++ b/pages/auth/unlock/Unlock.html
@@ -29,6 +29,9 @@
       :label="$t('pages.unlock.store_pin')"
     />
     <br />
+    <a v-if="getPinHash" class="delete-link" @click="deleteAccount">
+      Not you? Create or import an account
+    </a>
     <div class="realm-container">
       <InteractablesRealm />
     </div>

--- a/pages/auth/unlock/Unlock.less
+++ b/pages/auth/unlock/Unlock.less
@@ -26,9 +26,17 @@
   }
 
   .decryption-body {
-    min-width: 250px;
     align-self: center;
     margin-bottom: 25vh;
+    .delete-link {
+      display: flex;
+      font-family: @secondary-font;
+      font-size: 10pt;
+      color: white;
+      &:hover {
+        opacity: 0.75;
+      }
+    }
   }
 
   .version {

--- a/pages/auth/unlock/index.vue
+++ b/pages/auth/unlock/index.vue
@@ -3,6 +3,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import { mapGetters, mapState } from 'vuex'
+import { Dexie } from 'dexie'
 import { UnlockIcon, ChevronRightIcon, InfoIcon } from 'satellite-lucide-icons'
 import { ConsoleWarning } from '~/utilities/ConsoleWarning'
 
@@ -87,13 +88,11 @@ export default Vue.extend({
         await this.$store.dispatch('accounts/unlock', this.$data.pin)
 
         if (this.getPhrase === '') {
-          // if user deleted local storage manually via dev console, clear indexeddb as well
-          if (
-            (await indexedDB.databases())
-              .map((db) => db.name)
-              .includes(this.$Config.indexedDbName)
-          ) {
-            indexedDB.deleteDatabase(this.$Config.indexedDbName)
+          // manually clear local storage and indexeddb if it exists
+          try {
+            await this.$store.dispatch('settings/clearLocalStorage')
+          } catch (e: any) {
+            this.$toast.error(this.$t(e.message) as string)
           }
           this.$router.replace('/setup/disclaimer')
         } else {
@@ -119,6 +118,10 @@ export default Vue.extend({
       } catch (error: any) {
         this.error = error.message
       }
+    },
+    async deleteAccount() {
+      await this.$store.dispatch('settings/clearLocalStorage')
+      location.reload()
     },
   },
 })

--- a/store/settings/actions.test.ts
+++ b/store/settings/actions.test.ts
@@ -1,4 +1,5 @@
 import Vue from 'vue'
+import { Dexie } from 'dexie'
 import * as actions from './actions'
 import { SettingsError } from './types'
 import { db } from '~/libraries/SatelliteDB/SatelliteDB'
@@ -24,10 +25,8 @@ describe('actions.default', () => {
   test('actions.default.clearLocalStorage successful', async () => {
     Vue.prototype.$TextileManager = new TextileManager()
     db.delete = jest.fn().mockReturnValue(true)
-    const commit = jest.fn()
-    await actions.default.clearLocalStorage({ commit })
-    expect(window.location.reload).toHaveBeenCalled()
-    expect(commit).toHaveBeenCalledWith('removeAppState', true)
+    Dexie.exists = jest.fn().mockReturnValue(true)
+    await actions.default.clearLocalStorage()
   })
 
   test('actions.default.clearLocalStorage error', async () => {
@@ -36,8 +35,7 @@ describe('actions.default', () => {
       db.delete = jest.fn().mockImplementation(() => {
         throw new Error('mock error')
       })
-      const commit = jest.fn()
-      await actions.default.clearLocalStorage({ commit })
+      await actions.default.clearLocalStorage()
     } catch (error) {
       expect(error).toBeInstanceOf(Error)
       expect(error).toHaveProperty(

--- a/store/settings/actions.ts
+++ b/store/settings/actions.ts
@@ -1,18 +1,21 @@
 import Vue from 'vue'
+import { Dexie } from 'dexie'
 import { TextileError } from '../textile/types'
 import { db } from '~/libraries/SatelliteDB/SatelliteDB'
 import { UserInfoManager } from '~/libraries/Textile/UserManager'
 import { SettingsError, SettingsState } from '~/store/settings/types'
 import { ActionsArguments } from '~/types/store/store'
+import { Config } from '~/config'
 
 export default {
-  async clearLocalStorage({ commit }: ActionsArguments<SettingsState>) {
+  async clearLocalStorage() {
     try {
-      await db.delete()
+      if (await Dexie.exists(Config.indexedDbName)) {
+        await db.delete()
+      }
       localStorage.clear()
-      commit('removeAppState', true)
-      location.reload()
     } catch (e) {
+      console.log(e)
       throw new Error(SettingsError.DATABASE_NOT_CLEARED)
     }
   },

--- a/store/settings/actions.ts
+++ b/store/settings/actions.ts
@@ -15,7 +15,6 @@ export default {
       }
       localStorage.clear()
     } catch (e) {
-      console.log(e)
       throw new Error(SettingsError.DATABASE_NOT_CLEARED)
     }
   },

--- a/store/settings/mutations.test.ts
+++ b/store/settings/mutations.test.ts
@@ -2387,10 +2387,9 @@ describe('mutations misc', () => {
       serverType: 'et',
       ownInfo: 'maxime',
     }
-    const passedInValue = false
 
-    mutations.default.removeAppState(localState, passedInValue)
-    expect(localState.removeState).toBe(passedInValue)
+    mutations.default.removeAppState(localState)
+    expect(localState.removeState).toBe(true)
   })
 
   test('mutations.default.setServerType', () => {

--- a/store/settings/mutations.ts
+++ b/store/settings/mutations.ts
@@ -51,8 +51,8 @@ const mutations = {
   setTimezone(state: SettingsState, value: string) {
     state.timezone = value
   },
-  removeAppState(state: SettingsState, value: boolean) {
-    state.removeState = value
+  removeAppState(state: SettingsState) {
+    state.removeState = true
   },
   setServerType(state: SettingsState, value: string) {
     state.serverType = value


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- added button to account unlock screen that will delete indexeddb + localstorage
- updated action to be more reusable, rather than forcing a reload inside the action
- switch to dexie for db check for firefox

**Which issue(s) this PR fixes** 🔨
AP-954, AP-1621
<!--AP-X-->

**Special notes for reviewers** 🗒️
- maybe we want some kind of warning second click (similar to settings page)? let me know what you think

**Additional comments** 🎤
