### PR TITLE
fix(message): disable save on empty message

### DIFF
--- a/components/views/chat/message/edit/Edit.html
+++ b/components/views/chat/message/edit/Edit.html
@@ -12,10 +12,14 @@
   </div>
   <div class="edit-message-bottom">
     <div>
-      {{$t('messaging.edit.escape_to')}}
-      <a @click="cancelMessage">{{$t('messaging.edit.cancel')}}</a>
-      {{$t('messaging.edit.enter_to')}}
-      <a @click="saveMessage">{{$t('messaging.edit.save')}}</a>
+      <div>
+        {{$t('messaging.edit.escape_to')}}
+        <a @click="cancelMessage">{{$t('messaging.edit.cancel')}}</a>
+      </div>
+      <div>
+        {{$t('messaging.edit.enter_to')}}
+        <a @click="saveMessage">{{$t('messaging.edit.save')}}</a>
+      </div>
     </div>
     <div>{{lengthCount}}/{{maxChars}}</div>
   </div>

--- a/components/views/chat/message/edit/Edit.less
+++ b/components/views/chat/message/edit/Edit.less
@@ -41,9 +41,13 @@
     margin: 0 -@light-spacing 0 0;
     justify-content: space-between;
     & > div {
-      padding: 0 @light-spacing;
-      a {
-        margin-right: @light-spacing;
+      display: flex;
+      margin: 0 @light-spacing;
+      > div {
+        &:not(:last-child)::after {
+          content: '•';
+          margin: 0 @light-spacing;
+        }
       }
     }
   }

--- a/components/views/chat/message/edit/Edit.vue
+++ b/components/views/chat/message/edit/Edit.vue
@@ -43,7 +43,8 @@ export default Vue.extend({
   },
   methods: {
     saveMessage() {
-      if (this.content.length === 0) {
+      if (this.content.trim().length === 0) {
+        this.$toast.error(this.$t('errors.chat.empty_message_error') as string)
         return
       }
       this.$emit('commitMessage', this.content.slice(0, this.maxChars))

--- a/components/views/chat/message/edit/Edit.vue
+++ b/components/views/chat/message/edit/Edit.vue
@@ -10,15 +10,6 @@ import { Config } from '~/config'
 import { KeybindingEnum } from '~/libraries/Enums/enums'
 import Editable from '~/components/views/chat/chatbar/Editable.vue'
 
-declare module 'vue/types/vue' {
-  interface Vue {
-    saveMessage: Function
-    cancelMessage: Function
-    lengthCount: number
-    charlimit: boolean
-  }
-}
-
 export default Vue.extend({
   components: {
     SmileIcon,
@@ -40,22 +31,22 @@ export default Vue.extend({
     }
   },
   computed: {
-    lengthCount() {
-      return this.$data.content.length
+    lengthCount(): number {
+      return this.content.length
     },
-    charlimit() {
+    charlimit(): boolean {
       return this.lengthCount > this.maxChars
     },
   },
   mounted() {
-    this.$data.content = this.$props.message
+    this.content = this.message
   },
   methods: {
     saveMessage() {
-      if (this.$data.content.length === 0) {
+      if (this.content.length === 0) {
         return
       }
-      this.$emit('commitMessage', this.$data.content.slice(0, this.maxChars))
+      this.$emit('commitMessage', this.content.slice(0, this.maxChars))
     },
     cancelMessage() {
       this.$emit('cancelMessage')

--- a/components/views/chat/message/edit/Edit.vue
+++ b/components/views/chat/message/edit/Edit.vue
@@ -52,6 +52,9 @@ export default Vue.extend({
   },
   methods: {
     saveMessage() {
+      if (this.$data.content.length === 0) {
+        return
+      }
       this.$emit('commitMessage', this.$data.content.slice(0, this.maxChars))
     },
     cancelMessage() {
@@ -64,6 +67,7 @@ export default Vue.extend({
       switch (event.key) {
         case KeybindingEnum.ENTER:
           if (!event.shiftKey) {
+            event.preventDefault()
             this.saveMessage()
           }
           break

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -92,9 +92,9 @@ export default {
       files: 'Files',
     },
     edit: {
-      escape_to: 'escape to ',
+      escape_to: 'escape to',
       cancel: 'cancel',
-      enter_to: ' • enter to ',
+      enter_to: 'enter to',
       save: 'save',
     },
   },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Prevents saving an edited message as an empty message
- Fixes styling and locale strings in the edit message UI

**Which issue(s) this PR fixes** 🔨
AP-1631
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
