### PR TITLE
fix(spoilers): transparent background on open spoilers

### DIFF
--- a/assets/styles/base.less
+++ b/assets/styles/base.less
@@ -1013,20 +1013,21 @@ li.active {
         animation-duration: 500ms;
       }
     }
+  }
+}
 
-    .spoiler-container {
-      cursor: pointer;
-      background-color: @gray;
-      border-radius: @corner-rounding-smaller;
-      .spoiler {
-        opacity: 0;
-      }
-
-      .spoiler-open {
-        cursor: text;
-        background-color: @darker-transparent;
-        opacity: 1;
-      }
+.spoiler-container {
+  cursor: pointer;
+  background-color: @gray;
+  border-radius: @corner-rounding-smaller;
+  .spoiler {
+    opacity: 0;
+  }
+  &.spoiler-open {
+    cursor: text;
+    background-color: transparent;
+    .spoiler {
+      opacity: 1;
     }
   }
 }

--- a/components/views/chat/message/Markdown.vue
+++ b/components/views/chat/message/Markdown.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-html="text" ref="message-row" />
+  <div ref="message-row" v-html="text" />
 </template>
 
 <script lang="ts">
@@ -15,7 +15,7 @@ export default Vue.extend({
   mounted() {
     Array.from(
       (this.$refs['message-row'] as HTMLElement).getElementsByClassName(
-        'spoiler',
+        'spoiler-container',
       ),
     ).forEach((spoiler) => {
       spoiler.addEventListener('click', (e) => {

--- a/components/views/chat/message/Message.less
+++ b/components/views/chat/message/Message.less
@@ -94,21 +94,6 @@
       margin-top: 0;
     }
   }
-
-  .spoiler-container {
-    cursor: pointer;
-    background-color: @gray;
-    border-radius: @corner-rounding-smaller;
-    .spoiler {
-      opacity: 0;
-    }
-
-    .spoiler-open {
-      cursor: text;
-      background-color: @darker-transparent;
-      opacity: 1;
-    }
-  }
 }
 
 // non-Retina-specific stuff here

--- a/components/views/user/User.vue
+++ b/components/views/user/User.vue
@@ -140,7 +140,9 @@ export default Vue.extend({
   },
   mounted() {
     Array.from(
-      (this.$refs.subtitle as HTMLElement).getElementsByClassName('spoiler'),
+      (this.$refs.subtitle as HTMLElement).getElementsByClassName(
+        'spoiler-container',
+      ),
     ).forEach((spoiler) => {
       spoiler.addEventListener('click', (e) => {
         e.preventDefault()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- remove redundant spoiler scoped css. user sidebar and chat message will now use styles in base.less
- adjust spoiler-open class placement so background will now be transparent

**Which issue(s) this PR fixes** 🔨
AP-1648
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
