### PR TITLE
fix(chat): add timestamps on hover for subsequent messages

### DIFF
--- a/components/views/chat/group/Group.html
+++ b/components/views/chat/group/Group.html
@@ -7,7 +7,7 @@
       <span v-on:click="showQuickProfile">
         <UiUserName :username="username" :badge="badge" />
       </span>
-      <TypographyText :text="timestamp" :data-cy="`chat-timestamp`" />
+      <TypographyText :text="timestamp" data-cy="chat-timestamp" />
     </div>
     <div class="group-message">
       <Message :group="group" :message="group.message" :from="username" />
@@ -15,6 +15,7 @@
   </div>
 </div>
 <div v-else class="group-same">
+  <TypographyText class="timestamp" :text="formattedTimestamp" />
   <div class="group-messages">
     <Message :group="group" :message="group.message" :from="username" />
   </div>

--- a/components/views/chat/group/Group.less
+++ b/components/views/chat/group/Group.less
@@ -15,10 +15,9 @@
   .group-body {
     .group-heading {
       .is-text {
-        margin-left: @light-spacing;
-        // line-height: 1;
-        font-size: @micro-text-size;
         &:extend(.font-muted);
+        font-size: @micro-text-size;
+        margin-left: @light-spacing;
         display: flex;
         align-items: flex-end;
         height: 1.2rem;
@@ -28,7 +27,7 @@
       flex-direction: row;
       align-items: center;
     }
-    margin-left: 0.75rem;
+    margin-left: @normal-spacing;
     &:extend(.full-width);
   }
 
@@ -37,5 +36,26 @@
   margin-top: @light-spacing;
 }
 .group-same {
-  margin-left: calc(35px + 0.75rem);
+  display: flex;
+  align-items: center;
+  .timestamp {
+    &:extend(.font-muted);
+    display: none;
+    font-size: @micro-text-size;
+    width: 52px;
+  }
+  .group-messages {
+    flex-grow: 1;
+    margin-left: 3.25rem;
+  }
+
+  &:focus,
+  &:hover {
+    .timestamp {
+      display: block;
+    }
+    .group-messages {
+      margin-left: 0;
+    }
+  }
 }

--- a/components/views/chat/group/Group.vue
+++ b/components/views/chat/group/Group.vue
@@ -16,15 +16,11 @@ export default Vue.extend({
   props: {
     group: {
       type: Object as PropType<Group>,
-      default: () => ({
-        at: 0,
-        from: '',
-        to: '',
-      }),
+      required: true,
     },
     groupId: {
       type: String as PropType<string>,
-      default: () => '',
+      required: true,
     },
   },
   data() {
@@ -39,19 +35,20 @@ export default Vue.extend({
   computed: {
     ...mapState(['ui', 'friends', 'accounts', 'groups']),
     ...mapGetters('friends', ['findFriendByKey']),
-    address() {
+    ...mapGetters('settings', ['getTimezone']),
+    address(): string {
       return (
         this.groupMember?.name ||
         getAddressFromState(this.group.from, this.$store.state)
       )
     },
-    username() {
+    username(): string {
       return (
         this.groupMember?.name ||
         getUsernameFromState(this.group.from, this.$store.state)
       )
     },
-    badge() {
+    badge(): string {
       return ''
     },
     src(): string {
@@ -84,6 +81,12 @@ export default Vue.extend({
       return this.groups.all
         .find((it: Group) => it.id === this.groupId)
         ?.members?.find((it: GroupMember) => it.address === this.group.sender)
+    },
+    formattedTimestamp(): string {
+      return this.$dayjs(this.group.at)
+        .local()
+        .tz(this.getTimezone)
+        .format('LT')
     },
   },
   created() {

--- a/types/messaging.d.ts
+++ b/types/messaging.d.ts
@@ -40,6 +40,7 @@ export type Group = {
   from: string
   to: string
   messages: Array<UIMessage> | null
+  sender?: string
 }
 
 export type MessageGroup = Array<Group | Divider>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- add timestamp on hover for subsequent messages in a group
- slightly adjust chat margin to make room for the timestamp

**Which issue(s) this PR fixes** 🔨
AP-1662
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- I didn't realize we switched to static timestamps for messages, i love it!
- I feel like the special string timestamps (now, yesterday) don't add much value considering the effort it takes. I think those should be adjusted to static timestamps as well, then we could get rid of all the interval stuff

![image](https://user-images.githubusercontent.com/33670767/171371744-1c481cc6-3a2d-4c3b-8434-16c85c110b13.png)
