### PR TITLE
fix(groups): members order sorted alpha

### DIFF
--- a/components/views/navigation/toolbar/Toolbar.vue
+++ b/components/views/navigation/toolbar/Toolbar.vue
@@ -89,7 +89,7 @@ export default Vue.extend({
     },
     ModalWindows: () => ModalWindows,
     src(): string {
-      const hash = this.recipient?.profilePicture
+      const hash = (this.recipient as Friend).profilePicture
       return hash ? `${this.$Config.textile.browser}/ipfs/${hash}` : ''
     },
     isGroup(): boolean {

--- a/layouts/chat.vue
+++ b/layouts/chat.vue
@@ -225,10 +225,6 @@ export default Vue.extend({
     },
   },
   watch: {
-    recipient: {
-      handler() {},
-      immediate: true,
-    },
     showSidebar(newValue, oldValue) {
       if (newValue !== oldValue) {
         newValue

--- a/store/groups/mutations.ts
+++ b/store/groups/mutations.ts
@@ -25,9 +25,10 @@ const mutations = {
     state: GroupsState,
     { groupId, members }: { groupId: string; members: GroupMember[] },
   ) {
-    state.all = state.all.map((group) =>
-      group.id === groupId ? { ...group, members } : group,
-    )
+    const group = state.all.find((g) => g.id === groupId)
+    if (group) {
+      group.members = members.sort((a, b) => a.name.localeCompare(b.name))
+    }
   },
   setGroupsLastUpdate(state: GroupsState, payload: { [key: string]: number }) {
     state.all = state.all.map((group) => ({


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- set group members with an alpha sort. it seems like the backend returns them in a random order every time
- improve performance w/ find rather than iterating 100% of the time. a couple other mutations here could use this same treatment

**Which issue(s) this PR fixes** 🔨
AP-1698
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
