### PR TITLE
fix(settings): switch privacy settings loading list to array

### DIFF
--- a/components/views/settings/pages/privacy/Privacy.html
+++ b/components/views/settings/pages/privacy/Privacy.html
@@ -42,7 +42,7 @@
       >
         <InteractablesSwitch
           v-model="consentScan"
-          :isLocked="loading === 'consentScan'"
+          :isLocked="loading.includes('consentScan')"
         />
       </SettingsUnit>
       <SettingsUnit
@@ -51,11 +51,14 @@
       >
         <InteractablesSwitch
           v-model="blockNsfw"
-          :isLocked="loading === 'blockNsfw'"
+          :isLocked="loading.includes('blockNsfw')"
         />
       </SettingsUnit>
     </div>
-    <TypographyText v-if="loading" :text="$t('pages.privacy.updating')" />
+    <TypographyText
+      v-if="loading.length"
+      :text="$t('pages.privacy.updating')"
+    />
     <!-- <div class="columns is-desktop">
     <SettingsUnit
       :title="$t('pages.privacy.serverType.title')"

--- a/components/views/settings/pages/privacy/index.vue
+++ b/components/views/settings/pages/privacy/index.vue
@@ -14,7 +14,7 @@ export default Vue.extend({
     return {
       formatError: false as boolean,
       lengthError: false as boolean,
-      loading: '' as string,
+      loading: [] as string[],
     }
   },
   computed: {
@@ -87,11 +87,11 @@ export default Vue.extend({
     },
     consentScan: {
       async set(consentToScan: boolean) {
-        this.loading = 'consentScan'
+        this.loading.push('consentScan')
         await this.$store.dispatch('textile/updateUserThreadData', {
           consentToScan,
         })
-        this.loading = ''
+        this.loading.splice(this.loading.indexOf('consentScan'), 1)
       },
       get(): boolean {
         return this.userThread.consentToScan
@@ -99,11 +99,11 @@ export default Vue.extend({
     },
     blockNsfw: {
       async set(blockNsfw: boolean) {
-        this.loading = 'blockNsfw'
+        this.loading.push('blockNsfw')
         await this.$store.dispatch('textile/updateUserThreadData', {
           blockNsfw,
         })
-        this.loading = ''
+        this.loading.splice(this.loading.indexOf('blockNsfw'), 1)
       },
       get(): boolean {
         return this.userThread.blockNsfw


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- use array for loading state rather than string
- This code would incorrectly unlock a remote setting even if it wasn't done loading since the loading state was only a string

**Which issue(s) this PR fixes** 🔨
AP-1723
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
