### PR TITLE
refactor(sidebar): switch props to store when possible

### DIFF
--- a/components/views/navigation/sidebar/Sidebar.html
+++ b/components/views/navigation/sidebar/Sidebar.html
@@ -97,7 +97,7 @@
           :count="4"
           inverted
         />
-        <div v-else-if="users && users.length">
+        <div v-else-if="friends.all && friends.all.length">
           <UiInlineNotification
             :text="$t('messaging.new_messages')"
             v-if="ui.unreadMessage.length"
@@ -119,7 +119,7 @@
           </div>
         </div>
         <div
-          v-else-if="dataState.friends !== DataStateType.Loading && !users.length"
+          v-else-if="dataState.friends !== DataStateType.Loading && !friends.all.length"
           class="mascot-container"
         >
           <TypographyTitle :text="$t('pages.chat.no_friends_yet')" :size="6" />

--- a/components/views/navigation/sidebar/Sidebar.vue
+++ b/components/views/navigation/sidebar/Sidebar.vue
@@ -15,17 +15,9 @@ import {
 } from 'satellite-lucide-icons'
 
 import { DataStateType } from '~/store/dataState/types'
-import { User } from '~/types/ui/user'
 import { Conversation } from '~/store/textile/types'
 import GroupInvite from '~/components/views/group/invite/Invite.vue'
-import { Group } from '~/store/groups/types'
 import { RootState } from '~/types/store/store'
-
-declare module 'vue/types/vue' {
-  interface Vue {
-    sortUserList: Function
-  }
-}
 
 export default Vue.extend({
   components: {
@@ -43,10 +35,6 @@ export default Vue.extend({
       type: Function,
       default: () => {},
     },
-    users: {
-      type: Array as PropType<Array<User>>,
-      default: () => [],
-    },
     showMenu: {
       type: Function,
       default: () => {},
@@ -58,13 +46,17 @@ export default Vue.extend({
   },
   computed: {
     DataStateType: () => DataStateType,
-    ...mapState(['ui', 'dataState', 'media', 'friends', 'groups']),
     ...mapState({
+      ui: (state) => (state as RootState).ui,
+      dataState: (state) => (state as RootState).dataState,
+      media: (state) => (state as RootState).media,
+      friends: (state) => (state as RootState).friends,
+      groups: (state) => (state as RootState).groups,
       conversations: (state) =>
         (state as RootState).textile.conversations || [],
     }),
     toggleView: {
-      get() {
+      get(): boolean {
         return this.ui.showSidebarUsers
       },
       set(value: Boolean) {
@@ -72,11 +64,8 @@ export default Vue.extend({
       },
     },
     usersAndGroups() {
-      const combined = [...this.$props.users, ...this.groups.all]
+      const combined = [...this.friends.all, ...this.groups.all]
       return combined.sort((a, b) => b.lastUpdate - a.lastUpdate)
-    },
-    sortedGroups() {
-      return sortBy(this.groups.all, 'name')
     },
   },
   watch: {

--- a/components/views/navigation/sidebar/Sidebar.vue
+++ b/components/views/navigation/sidebar/Sidebar.vue
@@ -1,9 +1,8 @@
 <template src="./Sidebar.html"></template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue'
+import Vue from 'vue'
 import { mapState } from 'vuex'
-import { sortBy } from 'lodash'
 import {
   UsersIcon,
   UserPlusIcon,

--- a/layouts/chat.vue
+++ b/layouts/chat.vue
@@ -35,8 +35,6 @@
           />
           <Sidebar
             v-if="!$device.isMobile"
-            :users="friends.all"
-            :groups="groups.all"
             :sidebar="showSidebar"
             :show-menu="toggleMenu"
           />

--- a/layouts/files.vue
+++ b/layouts/files.vue
@@ -30,8 +30,6 @@
           />
           <Sidebar
             v-if="!$device.isMobile"
-            :users="friends.all"
-            :groups="$mock.groups"
             :sidebar="showSidebar"
             :show-menu="toggleMenu"
           />

--- a/layouts/friends.vue
+++ b/layouts/friends.vue
@@ -34,8 +34,6 @@
           <Sidebar
             v-if="!$device.isMobile"
             :show-menu="toggleMenu"
-            :users="friends.all"
-            :groups="groups.all"
             :sidebar="showSidebar"
           />
         </swiper-slide>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- refactor Sidebar to use store values rather than layout parent components passing store values as props. This way the component is more self contained. you don't need to look around multiple files to understand what is happening
- remove unused computed and imports

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️
shouldnt notice any difference in functionality

**Additional comments** 🎤
