### PR TITLE
refactor(timestamps): switch localized timestamps to store getter

### DIFF
--- a/components/views/chat/group/Group.vue
+++ b/components/views/chat/group/Group.vue
@@ -68,7 +68,7 @@ export default Vue.extend({
         ?.members?.find((it: GroupMember) => it.address === this.group.sender)
     },
     timestamp(): string {
-      return this.getTimestamp(this.group.at)
+      return this.getTimestamp({ time: this.group.at })
     },
     address(): string {
       if (this.group.sender) {

--- a/components/views/chat/group/Group.vue
+++ b/components/views/chat/group/Group.vue
@@ -26,7 +26,7 @@ export default Vue.extend({
       groups: (state) => (state as RootState).groups,
     }),
     ...mapGetters('friends', ['findFriendByKey']),
-    ...mapGetters('settings', ['getTimezone']),
+    ...mapGetters('settings', ['getTimestamp']),
     username(): string {
       return (
         this.groupMember?.name ||
@@ -68,10 +68,7 @@ export default Vue.extend({
         ?.members?.find((it: GroupMember) => it.address === this.group.sender)
     },
     timestamp(): string {
-      return this.$dayjs(this.group.at)
-        .local()
-        .tz(this.getTimezone)
-        .format('LT')
+      return this.getTimestamp(this.group.at)
     },
     address(): string {
       if (this.group.sender) {

--- a/components/views/chat/message/reply/Item/Item.vue
+++ b/components/views/chat/message/reply/Item/Item.vue
@@ -6,7 +6,6 @@ import { UIMessage, Group } from '~/types/messaging'
 import { RootState } from '~/types/store/store'
 import {
   getUsernameFromState,
-  convertTimestampToDate,
   getAddressFromState,
 } from '~/utilities/Messaging'
 
@@ -41,7 +40,7 @@ export default Vue.extend({
       accounts: (state) => (state as RootState).accounts,
     }),
     ...mapGetters('friends', ['findFriendByKey']),
-    ...mapGetters('settings', ['getTimezone']),
+    ...mapGetters('settings', ['getTimestamp']),
     address() {
       if (!this.reply.from) {
         return ''
@@ -55,10 +54,7 @@ export default Vue.extend({
       return getUsernameFromState(this.reply.from, this.$store.state)
     },
     timestamp() {
-      return this.$dayjs(this.reply.at)
-        .local()
-        .tz(this.getTimezone)
-        .format('LT')
+      return this.getTimestamp(this.reply.at)
     },
     src(): string {
       // To check if the sender is you we just compare the from field

--- a/components/views/chat/message/reply/Item/Item.vue
+++ b/components/views/chat/message/reply/Item/Item.vue
@@ -54,7 +54,7 @@ export default Vue.extend({
       return getUsernameFromState(this.reply.from, this.$store.state)
     },
     timestamp() {
-      return this.getTimestamp(this.reply.at)
+      return this.getTimestamp({ time: this.reply.at })
     },
     src(): string {
       // To check if the sender is you we just compare the from field

--- a/components/views/chat/search/result/item/Item.vue
+++ b/components/views/chat/search/result/item/Item.vue
@@ -13,7 +13,7 @@ export default Vue.extend({
     },
   },
   computed: {
-    ...mapGetters('settings', ['getTimezone']),
+    ...mapGetters('settings', ['getTimestamp', 'getFullTimestamp']),
     src(): string {
       const hash = this.data.user?.profilePicture
       return hash ? `${this.$Config.textile.browser}/ipfs/${hash}` : ''
@@ -22,19 +22,19 @@ export default Vue.extend({
       const msgTimestamp = this.$dayjs(this.data.at)
       // if today
       if (this.$dayjs().isSame(msgTimestamp, 'day')) {
-        return `${this.$t('search.result.today')} ${msgTimestamp
-          .local()
-          .tz(this.getTimezone)
-          .format('LT')}`
+        return (
+          this.$t('search.result.today') + ' ' + this.getTimestamp(this.data.at)
+        )
       }
       // if yesterday
       if (this.$dayjs().diff(msgTimestamp, 'day') <= 1) {
-        return `${this.$t('search.result.yesterday')} ${msgTimestamp
-          .local()
-          .tz(this.getTimezone)
-          .format('LT')}`
+        return (
+          this.$t('search.result.yesterday') +
+          ' ' +
+          this.getTimestamp(this.data.at)
+        )
       }
-      return msgTimestamp.local().tz(this.getTimezone).format('L LT')
+      return this.getFullTimestamp(this.data.at)
     },
   },
 })

--- a/components/views/chat/search/result/item/Item.vue
+++ b/components/views/chat/search/result/item/Item.vue
@@ -22,17 +22,15 @@ export default Vue.extend({
       const msgTimestamp = this.$dayjs(this.data.at)
       // if today
       if (this.$dayjs().isSame(msgTimestamp, 'day')) {
-        return (
-          this.$t('search.result.today') + ' ' + this.getTimestamp(this.data.at)
-        )
+        return `${this.$t('search.result.today')} ${this.getTimestamp(
+          this.data.at,
+        )}`
       }
       // if yesterday
       if (this.$dayjs().diff(msgTimestamp, 'day') <= 1) {
-        return (
-          this.$t('search.result.yesterday') +
-          ' ' +
-          this.getTimestamp(this.data.at)
-        )
+        return `${this.$t('search.result.yesterday')} ${this.getTimestamp(
+          this.data.at,
+        )}`
       }
       return this.getFullTimestamp(this.data.at)
     },

--- a/components/views/chat/search/result/item/Item.vue
+++ b/components/views/chat/search/result/item/Item.vue
@@ -13,7 +13,7 @@ export default Vue.extend({
     },
   },
   computed: {
-    ...mapGetters('settings', ['getTimestamp', 'getFullTimestamp']),
+    ...mapGetters('settings', ['getTimestamp']),
     src(): string {
       const hash = this.data.user?.profilePicture
       return hash ? `${this.$Config.textile.browser}/ipfs/${hash}` : ''
@@ -22,17 +22,17 @@ export default Vue.extend({
       const msgTimestamp = this.$dayjs(this.data.at)
       // if today
       if (this.$dayjs().isSame(msgTimestamp, 'day')) {
-        return `${this.$t('search.result.today')} ${this.getTimestamp(
-          this.data.at,
-        )}`
+        return `${this.$t('search.result.today')} ${this.getTimestamp({
+          time: this.data.at,
+        })}`
       }
       // if yesterday
       if (this.$dayjs().diff(msgTimestamp, 'day') <= 1) {
-        return `${this.$t('search.result.yesterday')} ${this.getTimestamp(
-          this.data.at,
-        )}`
+        return `${this.$t('search.result.yesterday')} ${this.getTimestamp({
+          time: this.data.at,
+        })}`
       }
-      return this.getFullTimestamp(this.data.at)
+      return this.getTimestamp({ time: this.data.at, full: true })
     },
   },
 })

--- a/components/views/user/User.html
+++ b/components/views/user/User.html
@@ -15,7 +15,7 @@
     />
   </div>
   <div class="user-chat-details">
-    <TypographyText :size="6" :text="timestamp" v-if="existConversation" />
+    <TypographyText :size="6" :text="timestamp" v-if="hasMessaged" />
     <TypographyTag v-if="unreadMessageCount" :text="unreadMessageCount" />
   </div>
   <div class="user-loader">

--- a/components/views/user/User.vue
+++ b/components/views/user/User.vue
@@ -11,11 +11,6 @@ import ContextMenu from '~/components/mixins/UI/ContextMenu'
 import { User } from '~/types/ui/user'
 import { Message, TextMessage } from '~/types/textile/mailbox'
 import { MessagingTypesEnum } from '~/libraries/Enums/enums'
-import { Config } from '~/config'
-import {
-  refreshTimestampInterval,
-  convertTimestampToDate,
-} from '~/utilities/Messaging'
 import { RootState } from '~/types/store/store'
 import { toHTML } from '~/libraries/ui/Markdown'
 import { ContextMenuItem } from '~/store/ui/types'
@@ -47,26 +42,18 @@ export default Vue.extend({
     return {
       existConversation: false,
       isLoading: false,
-      timestamp: convertTimestampToDate(
-        this.$t('friends.details'),
-        this.$store.state.textile.conversations[this.user.address]?.lastUpdate,
-      ),
       timestampRefreshInterval: null,
     }
   },
   computed: {
     ...mapState({
       ui: (state) => (state as RootState).ui,
-      userConversationLastUpdate(state) {
-        return (
-          (state as RootState).textile.conversations[this.user.address]
-            ?.lastUpdate ?? 0
-        )
-      },
       textilePubkey: (state) =>
         (state as RootState).accounts?.details?.textilePubkey ?? '',
+      conversations: (state) => (state as RootState).textile?.conversations,
     }),
     ...mapGetters('textile', ['getConversation']),
+    ...mapGetters('settings', ['getTimestamp']),
     contextMenuValues(): ContextMenuItem[] {
       return this.user.state === 'online'
         ? [
@@ -82,7 +69,10 @@ export default Vue.extend({
             { text: this.$t('context.remove'), func: this.removeUser },
           ]
     },
-
+    hasMessaged(): boolean {
+      const lastMessage = this.getConversation(this.user.address)?.lastMessage
+      return !!lastMessage
+    },
     lastMessage(): string {
       const conversation = this.getConversation(this.user.address)
       const lastMessage = conversation?.lastMessage
@@ -104,38 +94,10 @@ export default Vue.extend({
       }
       return '99+'
     },
-  },
-  watch: {
-    userConversationLastUpdate: {
-      handler(lastUpdate) {
-        if (this.timestampRefreshInterval) {
-          clearInterval(this.timestampRefreshInterval)
-        }
-
-        this.existConversation = lastUpdate > 0
-        this.timestamp = convertTimestampToDate(
-          this.$t('friends.details'),
-          lastUpdate,
-        )
-
-        const setTimestamp = (timePassed: number) => {
-          if (
-            timePassed === this.getConversation(this.user.address)?.lastUpdate
-          ) {
-            this.timestamp = convertTimestampToDate(
-              this.$t('friends.details'),
-              timePassed,
-            )
-          }
-        }
-
-        this.$data.timestampRefreshInterval = refreshTimestampInterval(
-          lastUpdate,
-          setTimestamp,
-          Config.chat.timestampUpdateInterval,
-        )
-      },
-      immediate: true,
+    timestamp(): string {
+      return this.getTimestamp({
+        time: this.conversations[this.user.address]?.lastUpdate,
+      })
     },
   },
   mounted() {

--- a/plugins/local/dayjs.ts
+++ b/plugins/local/dayjs.ts
@@ -26,3 +26,5 @@ declare module '@nuxt/types' {
 }
 
 Vue.prototype.$dayjs = dayjs
+
+export { dayjs as extendedDayjs }

--- a/store/settings/__snapshots__/getters.test.ts.snap
+++ b/store/settings/__snapshots__/getters.test.ts.snap
@@ -1,13 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getters.default.getTimezone 0 1`] = `"Europe/Paris"`;
+exports[`settings.getters getFullTimestamp 1`] = `"06/06/2022 5:37 AM"`;
 
-exports[`getters.default.getTimezone 1 1`] = `"Asia/Yakutsk"`;
-
-exports[`getters.default.getTimezone 2 1`] = `"Europe/Paris"`;
-
-exports[`getters.default.getTimezone 3 1`] = `"Asia/Tehran"`;
-
-exports[`getters.default.getTimezone 4 1`] = `"Europe/Berlin"`;
-
-exports[`getters.default.getTimezone 5 1`] = `""`;
+exports[`settings.getters getTimestamp 1`] = `"5:37 AM"`;

--- a/store/settings/getters.test.ts
+++ b/store/settings/getters.test.ts
@@ -8,11 +8,14 @@ const state = {
 
 describe('settings.getters', () => {
   test('getTimestamp', () => {
-    const actual = getters.getTimestamp(state)(1654486643615)
+    const actual = getters.getTimestamp(state)({ time: 1654486643615 })
     expect(actual).toMatchSnapshot()
   })
   test('getFullTimestamp', () => {
-    const actual = getters.getFullTimestamp(state)(1654486643615)
+    const actual = getters.getTimestamp(state)({
+      time: 1654486643615,
+      full: true,
+    })
     expect(actual).toMatchSnapshot()
   })
 })

--- a/store/settings/getters.test.ts
+++ b/store/settings/getters.test.ts
@@ -1,24 +1,9 @@
-import { CaptureMouseTypes, KeybindTypes } from '~/store/settings/types'
+import InitialSettingsState from '~/store/settings/state'
 import getters from '~/store/settings/getters'
 
 const state = {
-  audioInput: '',
-  audioOutput: '',
-  videoInput: '',
-  captureMouse: CaptureMouseTypes.always,
-  noiseSuppression: true,
-  echoCancellation: true,
-  bitrate: 96000,
-  sampleSize: 24,
+  ...InitialSettingsState(),
   timezone: 'Europe/Paris',
-  userHasGivenAudioAccess: false,
-  userDeniedAudioAccess: false,
-  keybinds: KeybindTypes,
-  embeddedLinks: true,
-  displayCurrentActivity: true,
-  removeState: false,
-  serverType: 'satellite',
-  ownInfo: '',
 }
 
 describe('settings.getters', () => {

--- a/store/settings/getters.test.ts
+++ b/store/settings/getters.test.ts
@@ -1,142 +1,33 @@
-import * as getters from '~/store/settings/getters'
+import { CaptureMouseTypes, KeybindTypes } from '~/store/settings/types'
+import getters from '~/store/settings/getters'
 
-describe('getters.default.getTimezone', () => {
-  test('0', () => {
-    const result: any = getters.default.getTimezone({
-      audioInput: 'v1.2.4',
-      audioOutput: '/PDFData/rothfuss/data/UCF101/prepared_videos',
-      videoInput: '1.0.0',
-      captureMouse: '2021-07-29T23:03:48.812Z',
-      noiseSuppression: false,
-      echoCancellation: false,
-      bitrate: 0,
-      sampleSize: 256,
-      userHasGivenAudioAccess: true,
-      userDeniedAudioAccess: false,
-      keybinds: {},
-      embeddedLinks: true,
-      displayCurrentActivity: false,
-      timezone: 'Europe/Paris',
-      removeState: true,
-      serverType: 'UPDATE Projects SET pname = %s WHERE pid = %s',
-      ownInfo: '4.0.0-beta1\t',
-    })
-    expect(result).toMatchSnapshot()
+const state = {
+  audioInput: '',
+  audioOutput: '',
+  videoInput: '',
+  captureMouse: CaptureMouseTypes.always,
+  noiseSuppression: true,
+  echoCancellation: true,
+  bitrate: 96000,
+  sampleSize: 24,
+  timezone: 'Europe/Paris',
+  userHasGivenAudioAccess: false,
+  userDeniedAudioAccess: false,
+  keybinds: KeybindTypes,
+  embeddedLinks: true,
+  displayCurrentActivity: true,
+  removeState: false,
+  serverType: 'satellite',
+  ownInfo: '',
+}
+
+describe('settings.getters', () => {
+  test('getTimestamp', () => {
+    const actual = getters.getTimestamp(state)(1654486643615)
+    expect(actual).toMatchSnapshot()
   })
-
-  test('1', () => {
-    const result: any = getters.default.getTimezone({
-      audioInput: '4.0.0-beta1\t',
-      audioOutput: '/PDFData/rothfuss/data/UCF101/prepared_videos',
-      videoInput: '4.0.0-beta1\t',
-      captureMouse: '2021-07-29T15:31:46.922Z',
-      noiseSuppression: true,
-      echoCancellation: true,
-      bitrate: 300,
-      sampleSize: 64,
-      userHasGivenAudioAccess: true,
-      userDeniedAudioAccess: false,
-      keybinds: {},
-      embeddedLinks: true,
-      displayCurrentActivity: true,
-      timezone: 'Asia/Yakutsk',
-      removeState: true,
-      serverType: 'DELETE FROM Projects WHERE pid = %s',
-      ownInfo: '1.0.0',
-    })
-    expect(result).toMatchSnapshot()
-  })
-
-  test('2', () => {
-    const result: any = getters.default.getTimezone({
-      audioInput: 'v4.0.0-rc.4',
-      audioOutput: '/PDFData/rothfuss/data/UCF101/prepared_videos',
-      videoInput: '4.0.0-beta1\t',
-      captureMouse: '2021-07-29T17:54:41.653Z',
-      noiseSuppression: true,
-      echoCancellation: true,
-      bitrate: 6.0,
-      sampleSize: 32,
-      userHasGivenAudioAccess: false,
-      userDeniedAudioAccess: true,
-      keybinds: {},
-      embeddedLinks: false,
-      displayCurrentActivity: false,
-      timezone: 'Europe/Paris',
-      removeState: true,
-      serverType: 'DROP TABLE tmp;',
-      ownInfo: '^5.0.0',
-    })
-    expect(result).toMatchSnapshot()
-  })
-
-  test('3', () => {
-    const result: any = getters.default.getTimezone({
-      audioInput: 'v4.0.0-rc.4',
-      audioOutput: '/PDFData/rothfuss/data/UCF101/prepared_videos',
-      videoInput: '1.0.0',
-      captureMouse: '2021-07-29T17:54:41.653Z',
-      noiseSuppression: false,
-      echoCancellation: false,
-      bitrate: 0.0,
-      sampleSize: 64,
-      userHasGivenAudioAccess: false,
-      userDeniedAudioAccess: true,
-      keybinds: {},
-      embeddedLinks: true,
-      displayCurrentActivity: false,
-      timezone: 'Asia/Tehran',
-      removeState: false,
-      serverType:
-        "SELECT * FROM Movies WHERE Title=’Jurassic Park’ AND Director='Steven Spielberg';",
-      ownInfo: '^5.0.0',
-    })
-    expect(result).toMatchSnapshot()
-  })
-
-  test('4', () => {
-    const result: any = getters.default.getTimezone({
-      audioInput: 'v4.0.0-rc.4',
-      audioOutput: '/PDFData/rothfuss/data/UCF101/prepared_videos',
-      videoInput: '4.0.0-beta1\t',
-      captureMouse: '2021-07-29T23:03:48.812Z',
-      noiseSuppression: true,
-      echoCancellation: false,
-      bitrate: 0.0,
-      sampleSize: 256,
-      userHasGivenAudioAccess: true,
-      userDeniedAudioAccess: false,
-      keybinds: {},
-      embeddedLinks: false,
-      displayCurrentActivity: true,
-      timezone: 'Europe/Berlin',
-      removeState: true,
-      serverType: 'UPDATE Projects SET pname = %s WHERE pid = %s',
-      ownInfo: '1.0.0',
-    })
-    expect(result).toMatchSnapshot()
-  })
-
-  test('5', () => {
-    const result: any = getters.default.getTimezone({
-      audioInput: '',
-      audioOutput: '',
-      videoInput: '',
-      captureMouse: '',
-      noiseSuppression: false,
-      echoCancellation: false,
-      bitrate: -Infinity,
-      sampleSize: -Infinity,
-      userHasGivenAudioAccess: false,
-      userDeniedAudioAccess: false,
-      keybinds: {},
-      embeddedLinks: true,
-      displayCurrentActivity: false,
-      timezone: '',
-      removeState: false,
-      serverType: '',
-      ownInfo: '',
-    })
-    expect(result).toMatchSnapshot()
+  test('getFullTimestamp', () => {
+    const actual = getters.getFullTimestamp(state)(1654486643615)
+    expect(actual).toMatchSnapshot()
   })
 })

--- a/store/settings/getters.ts
+++ b/store/settings/getters.ts
@@ -6,30 +6,24 @@ import { SettingsState } from '~/store/settings/types'
 export interface SettingsGetters {
   /**
    * @description return localized timestamp
-   * @argument {number} timestamp unix timestamp
+   * @argument {number} time unix timestamp
    * @returns {string} formatted time
    * @example (23423424) => 2:49 PM
+   * @example (23423424, full) => 6/6/22 2:49 PM
    */
-  getTimestamp(state: SettingsState): (timestamp: number) => string
-  /**
-   * @description return localized timestamp, including date
-   * @argument {number} timestamp unix timestamp
-   * @returns {string} formatted time and date
-   * @example (23423424) => 6/6/22 2:49 PM
-   */
-  getFullTimestamp(state: SettingsState): (timestamp: number) => string
+  getTimestamp(
+    state: SettingsState,
+  ): ({ time, full }: { time: number; full?: boolean }) => string
 }
 
 const getters: GetterTree<SettingsState, RootState> & SettingsGetters = {
   getTimestamp:
     (state: SettingsState) =>
-    (timestamp: number): string => {
-      return extendedDayjs(timestamp).local().tz(state.timezone).format('LT')
-    },
-  getFullTimestamp:
-    (state: SettingsState) =>
-    (timestamp: number): string => {
-      return extendedDayjs(timestamp).local().tz(state.timezone).format('L LT')
+    ({ time, full }): string => {
+      return extendedDayjs(time)
+        .local()
+        .tz(state.timezone)
+        .format(full ? 'L LT' : 'LT')
     },
 }
 

--- a/store/settings/getters.ts
+++ b/store/settings/getters.ts
@@ -1,9 +1,24 @@
-import { SettingsState } from './types'
+import { GetterTree } from 'vuex'
+import { extendedDayjs } from '~/plugins/local/dayjs'
+import { RootState } from '~/types/store/store'
+import { SettingsState } from '~/store/settings/types'
 
-const getters = {
-  getTimezone: (state: SettingsState): string => {
-    return state.timezone
-  },
+export interface SettingsGetters {
+  getTimestamp(state: SettingsState): (timestamp: number) => string
+  getFullTimestamp(state: SettingsState): (timestamp: number) => string
+}
+
+const getters: GetterTree<SettingsState, RootState> & SettingsGetters = {
+  getTimestamp:
+    (state: SettingsState) =>
+    (timestamp: number): string => {
+      return extendedDayjs(timestamp).local().tz(state.timezone).format('LT')
+    },
+  getFullTimestamp:
+    (state: SettingsState) =>
+    (timestamp: number): string => {
+      return extendedDayjs(timestamp).local().tz(state.timezone).format('L LT')
+    },
 }
 
 export default getters

--- a/store/settings/getters.ts
+++ b/store/settings/getters.ts
@@ -4,7 +4,19 @@ import { RootState } from '~/types/store/store'
 import { SettingsState } from '~/store/settings/types'
 
 export interface SettingsGetters {
+  /**
+   * @description return localized timestamp
+   * @argument {number} timestamp unix timestamp
+   * @returns {string} formatted time
+   * @example (23423424) => 2:49 PM
+   */
   getTimestamp(state: SettingsState): (timestamp: number) => string
+  /**
+   * @description return localized timestamp, including date
+   * @argument {number} timestamp unix timestamp
+   * @returns {string} formatted time and date
+   * @example (23423424) => 6/6/22 2:49 PM
+   */
   getFullTimestamp(state: SettingsState): (timestamp: number) => string
 }
 

--- a/store/sounds/state.ts
+++ b/store/sounds/state.ts
@@ -1,6 +1,6 @@
 import { SoundsState } from './types'
 
-const InitialSettingsState = (): SoundsState => ({
+const InitialSoundsState = (): SoundsState => ({
   newMessage: true,
   hangup: true,
   call: true,
@@ -12,4 +12,4 @@ const InitialSettingsState = (): SoundsState => ({
   connected: true,
 })
 
-export default InitialSettingsState
+export default InitialSoundsState


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- I created some getters that provide a localized timestamp
- I wanted something reusable since we repeated this dayjs logic many times
- placed in settings store because it should rely on user selected timezone (settings store)
- added tests

**Which issue(s) this PR fixes** 🔨
AP-1729
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
