### PR TITLE
fix(search): scroll to top on paginate

### DIFF
--- a/components/ui/Scroll/Scroll.vue
+++ b/components/ui/Scroll/Scroll.vue
@@ -1,4 +1,4 @@
-<template src="./Scroll.html" />
+<template src="./Scroll.html"></template>
 
 <script>
 import Vue from 'vue'

--- a/components/views/chat/search/result/Result.html
+++ b/components/views/chat/search/result/Result.html
@@ -76,6 +76,7 @@
       @toggleOrder="toggleOrderBy"
     />
     <UiScroll
+      ref="scrollRef"
       verticalScroll
       scrollbarVisibility="scroll"
       class="search-result-content"

--- a/components/views/chat/search/result/Result.vue
+++ b/components/views/chat/search/result/Result.vue
@@ -136,9 +136,14 @@ export default Vue.extend({
       })
       this.isLoading = DataStateType.Ready
     },
-    handleClickPaginate(pageNum: number) {
+    async handleClickPaginate(pageNum: number) {
       this.page = pageNum
-      this.fetchResult()
+      await this.fetchResult()
+      if (!this.$refs.scrollRef) {
+        return
+      }
+      const scrollEl = this.$refs.scrollRef as Vue
+      scrollEl.$el.scrollTop = 0
     },
     onChange(value: any) {
       this.queryOptions = {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Fixes the issue where paginating through search results would not reset the scroll view offset to the top of the next page's results

**Which issue(s) this PR fixes** 🔨
AP-1725
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
