### PR TITLE
fix(onlineStatus): update peer events handlers

### DIFF
--- a/store/webrtc/actions.ts
+++ b/store/webrtc/actions.ts
@@ -44,6 +44,20 @@ const webRTCActions = {
     await $Peer2Peer.node?.relay?.start()
 
     $Peer2Peer.on('peer:connect', ({ peerId }) => {
+      const connectedParticipant = rootState.conversation.participants.find(
+        (participant: ConversationParticipant) =>
+          participant.peerId === peerId.toB58String(),
+      )
+      if (connectedParticipant) {
+        commit(
+          'conversation/updateParticipant',
+          {
+            peerId: connectedParticipant.peerId,
+            state: 'CONNECTED',
+          },
+          { root: true },
+        )
+      }
       const connectedFriend = rootState.friends.all.find(
         (friend) => friend.peerId === peerId.toB58String(),
       )
@@ -250,7 +264,7 @@ const webRTCActions = {
           })
       }
       rootState.friends.all
-        .filter((friend) => !!friend.peerId && friend.state !== 'online')
+        .filter((friend) => !!friend.peerId)
         .forEach((friend) => {
           $Peer2Peer.sendMessage(
             {


### PR DESCRIPTION
**What this PR does** 📖
Sometimes online status of friends and conversation participants is not updated. This PR intended to fix the issue.

**Which issue(s) this PR fixes** 🔨
AP-1697

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
