### PR TITLE
fix(quickchat): improve quickchat/sidebar css

### DIFF
--- a/assets/styles/base.less
+++ b/assets/styles/base.less
@@ -457,22 +457,14 @@ a.link {
 //Sidebar
 #sidebar {
   .sidebar-nav {
-    .button,
-    div {
-      &.is-primary {
-        &:extend(.background-flair-gradient);
-        &:extend(.glow-flair);
-      }
-      .tag-inverted {
-        background: @midground !important;
-      }
+    .tag-inverted {
+      background: @midground;
     }
   }
 
   .label {
     &:extend(.background-flair);
   }
-  background: @background !important;
 }
 
 .side-bar-inner {

--- a/components/views/friends/quick/Quick.html
+++ b/components/views/friends/quick/Quick.html
@@ -1,4 +1,4 @@
-<div class="quick-chat" :class="{compact : showMedia}">
+<div class="quick-chat">
   <div>
     <TypographySubtitle :size="6" :text="$t('pages.chat.new_chat')" />
     <TypographyText :text="$t('pages.chat.new_chat_description')" />

--- a/components/views/friends/quick/Quick.less
+++ b/components/views/friends/quick/Quick.less
@@ -4,18 +4,14 @@
   &:extend(.first-layer);
   &:extend(.bordered);
   &:extend(.blur);
-  position: fixed;
+  position: absolute;
   width: 18rem;
-  top: 11rem;
+  top: 100%;
+  left: 13px;
   padding: @light-spacing @light-spacing @normal-spacing;
-  left: @sidebar-size + 2rem;
   display: flex;
   flex-direction: column;
   gap: @normal-spacing;
-
-  &.compact {
-    left: @servers-size + 2rem;
-  }
 
   .subtitle {
     margin-bottom: @light-spacing;

--- a/components/views/friends/quick/Quick.vue
+++ b/components/views/friends/quick/Quick.vue
@@ -2,9 +2,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import { mapState } from 'vuex'
 import { ModalWindows } from '~/store/ui/types'
-import { RootState } from '~/types/store/store'
 import { Friend } from '~/types/ui/friends'
 
 export default Vue.extend({
@@ -18,9 +16,6 @@ export default Vue.extend({
     }
   },
   computed: {
-    ...mapState({
-      showMedia: (state) => (state as RootState).ui.showMedia,
-    }),
     isInvalidName(): boolean {
       return (
         !this.name ||

--- a/components/views/navigation/sidebar/Sidebar.html
+++ b/components/views/navigation/sidebar/Sidebar.html
@@ -1,12 +1,10 @@
-<div id="sidebar" class="collapsed">
-  <div
-    :class="media.streaming ? 'sidebar-inner sidebar-inner-streaming' : 'sidebar-inner'"
-  >
+<div id="sidebar">
+  <div class="sidebar-inner">
     <div class="sidebar-search">
       <menu-icon
         class="toggle-sidebar"
         data-cy="hamburger-button"
-        v-on:click="showMenu"
+        @click="showMenu"
         size="1.2x"
         full-width
         :style="`${sidebar ? 'display: block' : 'display: none'}`"
@@ -27,26 +25,24 @@
         />
       </UiComingSoon>
     </div>
-    <div class="sidebar-nav" v-if="!$device.isMobile">
-      <div style="position: relative">
-        <InteractablesButton
-          :inactive="$route.path.includes('/friends/list') ? false : true"
-          class="sidebar-full-btn"
-          data-cy="sidebar-friends"
-          :type="$route.path.includes('/friends/list') ? 'primary' : 'dark'"
-          size="small"
-          :action="() => { friends.incomingRequests.length ? $router.push('/friends/list?tab=requests') : $router.push('/friends/list') }"
-          :text="$t('friends.friends')"
-        >
-          <users-icon size="1.2x" />
-        </InteractablesButton>
-        <span
-          v-if="friends.incomingRequests.length && dataState.friends === DataStateType.Ready"
-          :class="$route.path.includes('/friends/list') ? 'label tag-inverted' : 'label'"
-        >
-          {{friends.incomingRequests.length}}
-        </span>
-      </div>
+    <div class="sidebar-nav">
+      <InteractablesButton
+        :inactive="$route.path.includes('/friends/list') ? false : true"
+        class="sidebar-full-btn"
+        data-cy="sidebar-friends"
+        :type="$route.path.includes('/friends/list') ? 'primary' : 'dark'"
+        size="small"
+        :action="() => { friends.incomingRequests.length ? $router.push('/friends/list?tab=requests') : $router.push('/friends/list') }"
+        :text="$t('friends.friends')"
+      >
+        <users-icon size="1.2x" />
+      </InteractablesButton>
+      <span
+        v-if="friends.incomingRequests.length && dataState.friends === DataStateType.Ready"
+        :class="$route.path.includes('/friends/list') ? 'label tag-inverted' : 'label'"
+      >
+        {{friends.incomingRequests.length}}
+      </span>
       <InteractablesButton
         :inactive="$route.path.includes('/files') ? false : true"
         class="sidebar-full-btn"
@@ -59,48 +55,21 @@
         <folder-icon size="1.2x" />
       </InteractablesButton>
     </div>
-
-    <Slimbar
-      v-if="$device.isMobile"
-      :servers="$mock.servers"
-      :open-modal="toggleModal"
-      horizontal
-    />
-
-    <div class="tabs sidebar-selector padded no-top-pad flexy">
-      <div
-        class="quick-chat"
-        v-tooltip.top="$t('pages.chat.new_chat')"
-        @click="()=>toggleModal('quickchat')"
-        v-if="!$device.isMobile && toggleView"
-      >
-        <plus-circle-icon size="1x" />
-      </div>
-      <div
-        class="quick-chat"
-        v-tooltip.top="$t(pages.chat.new_group)"
-        @click="()=>toggleModal('creategroup')"
-        v-if="!$device.isMobile && !toggleView"
-      >
-        <plus-circle-icon size="1x" />
-      </div>
+    <div class="quick-toggle" v-tooltip.top="$t('pages.chat.new_chat')">
+      <plus-circle-icon size="1x" @click="()=>toggleModal('quickchat')" />
+      <FriendsQuick
+        v-if="ui.modals.quickchat"
+        v-click-outside="()=>toggleModal('quickchat')"
+      />
     </div>
-    <FriendsQuick
-      v-if="ui.modals.quickchat"
-      v-click-outside="()=>toggleModal('quickchat')"
-    />
-    <div
-      v-if="ui.showSidebarUsers"
-      class="scrolling hidden-scroll users"
-      v-scroll-lock="true"
-    >
+    <div class="scrolling hidden-scroll users" v-scroll-lock="true">
       <UiSimpleScroll scrollMode="vertical" scrollShow="scroll">
         <UiLoadersAddress
           v-if="dataState.friends === DataStateType.Loading"
           :count="4"
           inverted
         />
-        <div v-else-if="friends.all && friends.all.length">
+        <template v-else-if="friends.all && friends.all.length">
           <UiInlineNotification
             v-if="ui.unreadMessage.length"
             :text="$t('messaging.new_messages')"
@@ -120,7 +89,7 @@
               :isSelected="thing.id === $route.params.id"
             />
           </div>
-        </div>
+        </template>
         <div
           v-else-if="dataState.friends !== DataStateType.Loading && !friends.all.length"
           class="mascot-container"
@@ -141,8 +110,6 @@
       </UiSimpleScroll>
     </div>
   </div>
-
-  <div class="filler"></div>
   <div class="controls">
     <SidebarLive />
     <SidebarControls />

--- a/components/views/navigation/sidebar/Sidebar.less
+++ b/components/views/navigation/sidebar/Sidebar.less
@@ -8,7 +8,7 @@
   display: flex;
   flex-direction: column;
   padding-bottom: @normal-spacing;
-  background: transparent;
+  background: @background;
 
   .sidebar-inner {
     &:extend(.round-corners);

--- a/components/views/navigation/sidebar/Sidebar.less
+++ b/components/views/navigation/sidebar/Sidebar.less
@@ -1,8 +1,4 @@
 @sidebar-inner-offset: 175px;
-@mobile-sidebar-inner-offset: 245px;
-
-@sidebar-inner-streaming-pad: 2rem;
-@mobile-sidebar-inner-streaming-pad: 6rem;
 
 #sidebar {
   width: @sidebar-size;
@@ -16,34 +12,40 @@
 
   .sidebar-inner {
     &:extend(.round-corners);
-    margin-top: @normal-spacing;
     &:extend(.background-semitransparent-light);
     box-shadow: @ui-shadow;
     max-height: calc(@app-height - @sidebar-inner-offset);
     display: flex;
     flex-direction: column;
-    padding-bottom: @normal-spacing;
+    margin-top: @normal-spacing;
+    padding: @normal-spacing;
+    gap: @normal-spacing;
 
-    .mascot {
-      max-width: @half;
-      padding-top: @normal-spacing;
-      pointer-events: none;
+    .sidebar-search {
+      padding-right: @xlarge-spacing;
+
+      .toggle-sidebar {
+        cursor: pointer;
+        position: absolute;
+        top: @normal-spacing * 2.5;
+        right: @normal-spacing;
+        &:extend(.filter-glow);
+      }
     }
 
-    .mascot-container {
-      &:extend(.full-width);
-      display: inline-flex;
-      justify-content: center;
+    .sidebar-nav {
+      display: flex;
       flex-direction: column;
-      align-items: center;
+      gap: @light-spacing;
+    }
 
-      .button {
-        margin-top: @normal-spacing;
-        width: 75%;
-      }
-
-      .is-text {
-        text-align: center;
+    .quick-toggle {
+      display: flex;
+      align-self: flex-end;
+      padding-left: @light-spacing;
+      position: relative;
+      svg {
+        cursor: pointer;
       }
     }
 
@@ -55,25 +57,29 @@
         width: @sidebar-size - (@normal-spacing * 2);
       }
     }
-    .sidebar-search {
+
+    .mascot-container {
       &:extend(.full-width);
-      padding: @normal-spacing;
-      padding-right: @normal-spacing * 3;
-    }
+      display: flex;
+      justify-content: center;
+      flex-direction: column;
+      align-items: center;
 
-    .toggle-sidebar {
-      cursor: pointer;
-      position: absolute;
-      top: @normal-spacing * 2.5;
-      right: @normal-spacing;
-      &:extend(.filter-glow);
-    }
-  }
+      .mascot {
+        max-width: @half;
+        padding-top: @normal-spacing;
+        pointer-events: none;
+      }
 
-  .sidebar-inner-streaming {
-    max-height: calc(
-      @app-height - @sidebar-inner-offset - @sidebar-inner-streaming-pad
-    );
+      .button {
+        margin-top: @normal-spacing;
+        width: 75%;
+      }
+
+      .is-text {
+        text-align: center;
+      }
+    }
   }
 
   .controls {
@@ -81,24 +87,7 @@
     &:extend(.round-corners);
     padding: @light-spacing @normal-spacing @normal-spacing @normal-spacing;
     box-shadow: @ui-shadow;
-  }
-
-  .filler {
-    flex: 1;
-    position: relative;
-  }
-
-  .padded {
-    padding: @normal-spacing @normal-spacing 0 @normal-spacing;
-  }
-
-  .no-top-pad {
-    padding: 0 @normal-spacing;
-  }
-
-  .tabs {
-    margin-bottom: @normal-spacing;
-    overflow: unset;
+    margin-top: auto;
   }
 
   .label {
@@ -116,118 +105,9 @@
     font-family: @primary-font;
   }
 
-  .sidebar-selector {
-    .button:nth-child(1) {
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
-    }
-    .button:nth-child(2) {
-      border-top-left-radius: 0;
-      border-bottom-left-radius: 0;
-    }
-  }
-
-  .scrolling {
-    padding: 0 @normal-spacing;
-    .ps {
-      padding-right: @normal-spacing * 1.5;
-      right: -@normal-spacing;
-      left: 0;
-      width: calc(@full + @normal-spacing);
-    }
-  }
-
   .loading-container {
     display: inline-flex;
     justify-content: center;
     &:extend(.full-width);
-  }
-}
-
-.sidebar-selector {
-  align-self: flex-end;
-}
-
-.flexy {
-  display: inline-flex;
-  .quick-chat {
-    padding-left: @light-spacing;
-    display: inline-flex;
-    justify-items: flex-end;
-    align-self: flex-end;
-    float: right;
-    cursor: pointer;
-    width: auto;
-  }
-}
-
-.sidebar-full-btn {
-  &:extend(.full-width);
-  margin-bottom: @light-spacing;
-  justify-content: flex-start;
-}
-
-.sidebar-nav {
-  padding: 0 @normal-spacing;
-  margin-bottom: @light-spacing;
-}
-
-@media only screen and (max-width: @mobile-breakpoint) {
-  #sidebar {
-    &:extend(.first-layer);
-    width: @sidebar-size-mobile;
-    min-width: @sidebar-size-mobile;
-    padding-bottom: @mobile-nav-size;
-    .sidebar-inner {
-      max-height: calc(@app-height - @mobile-sidebar-inner-offset);
-      box-shadow: none;
-      background: none;
-    }
-    .sidebar-inner-streaming {
-      max-height: calc(
-        @app-height - @sidebar-inner-offset -
-          @mobile-sidebar-inner-streaming-pad
-      );
-    }
-  }
-
-  .flexy {
-    .quick-chat {
-      &:extend(.second-layer);
-      &::before {
-        &:extend(.second-layer);
-      }
-    }
-  }
-
-  .desktop #sidebar {
-    width: calc(@sidebar-size-mobile - @slimbar-size);
-    min-width: calc(@sidebar-size-mobile - @slimbar-size);
-  }
-
-  .quick-mobile-chat {
-    position: absolute;
-    width: 45px;
-    height: 45px;
-    bottom: 88px;
-    right: 16px;
-    box-shadow: 0px 1px 2px rgba(26, 26, 36, 0.65),
-      -2px 0px 20px rgba(39, 97, 253, 0.35),
-      -2px 5px 14px rgba(39, 97, 253, 0.4);
-  }
-}
-
-@media only screen and (max-width: @mobile-candybar-breakpoint) {
-  #sidebar {
-    max-width: @sidebar-size;
-    min-width: @sidebar-size-mobile;
-    sidebar-inner {
-      max-height: calc(@app-height - @mobile-sidebar-inner-offset);
-      .users {
-        .inline-notification {
-          width: 100vw - 32rem !important;
-        }
-      }
-    }
   }
 }

--- a/components/views/navigation/sidebar/Sidebar.less
+++ b/components/views/navigation/sidebar/Sidebar.less
@@ -37,6 +37,7 @@
       display: flex;
       flex-direction: column;
       gap: @light-spacing;
+      position: relative;
     }
 
     .quick-toggle {

--- a/components/views/navigation/sidebar/Sidebar.vue
+++ b/components/views/navigation/sidebar/Sidebar.vue
@@ -55,14 +55,6 @@ export default Vue.extend({
       conversations: (state) =>
         (state as RootState).textile.conversations || [],
     }),
-    toggleView: {
-      get(): boolean {
-        return this.ui.showSidebarUsers
-      },
-      set(value: Boolean) {
-        this.$store.commit('ui/showSidebarUsers', value)
-      },
-    },
     usersAndGroups() {
       const combined = [...this.friends.all, ...this.groups.all]
       return combined.sort((a, b) => b.lastUpdate - a.lastUpdate)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- rather than assigning a relatively arbitrary `left:` value to quickchat, now it will render beneath the parent button.
- I saw some simple improvements in sidebar as well while I was there
  - flex + gap
  - remove isMobile conditionals since this component will only be rendered on desktop

**Which issue(s) this PR fixes** 🔨
AP-1780

<!--AP-X-->

**Special notes for reviewers** 🗒️
quickchat would occasionally get shifted to the left during active calls, this will no longer do that. zindexes are working fine

**Additional comments** 🎤
