### PR TITLE
chore(edit): hide edit message

### DIFF
--- a/components/views/chat/message/Message.vue
+++ b/components/views/chat/message/Message.vue
@@ -86,7 +86,8 @@ export default Vue.extend({
           return [
             ...mainList,
             { text: this.$t('context.copy_msg'), func: this.copyMessage },
-            { text: this.$t('context.edit'), func: this.editMessage },
+            // { text: this.$t('context.edit'), func: this.editMessage },
+            // skipped due to edit message is now coming soon and this shouldn't appear on context menu
           ]
         }
         // another persons text message


### PR DESCRIPTION

**What this PR does** 📖

Hide edit message on the context menu

Atm edit message is coming soon so shouldn't appear on the context menu




before

<img width="539" alt="Captura de ecrã 2022-06-14, às 15 33 39" src="https://user-images.githubusercontent.com/29093946/173604002-f374fc13-6bff-4c5a-821b-8973f915d99a.png">

after

<img width="444" alt="Captura de ecrã 2022-06-14, às 15 33 06" src="https://user-images.githubusercontent.com/29093946/173603988-73cdc742-5b82-4852-bb30-dba46d053352.png">


