### PR TITLE
fix(chat): refresh crash error

### DIFF
--- a/components/views/chat/group/Group.vue
+++ b/components/views/chat/group/Group.vue
@@ -78,7 +78,7 @@ export default Vue.extend({
         return this.accounts.details?.address
       }
       const friend = this.findFriendByKey(this.group.from)
-      return friend.address
+      return friend?.address ?? ''
     },
   },
   methods: {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- this crash was introduced when my pr to fix avatar color and Hogan's PR to load messages earlier both went it.
- mapGetters loses type safety so I didn't think to account for an undefined return on `array.find`

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
