### PR TITLE
fix(call): fullscreen call search results z index issue

### DIFF
--- a/layouts/Layout.less
+++ b/layouts/Layout.less
@@ -110,7 +110,6 @@
       }
       #mediastream {
         height: calc(@full - @toolbar-height - @light-spacing);
-        &:extend(.fifth-layer);
       }
     }
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- assigned z index on fullscreen was hiding search results. I couldn't find any issues by removing it.
- if this breaks something else, we can add an even higher z index to search results

**Which issue(s) this PR fixes** 🔨
AP-1802
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
