### PR TITLE
fix(cta): svg overflow clipping

### DIFF
--- a/components/views/callToAction/CallToAction.less
+++ b/components/views/callToAction/CallToAction.less
@@ -12,6 +12,7 @@
   .sat-icon {
     fill: @white;
     margin: 0 auto @normal-spacing;
+    overflow: visible;
   }
   .main-title {
     text-align: center;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Sets overflow to visible on SVG element so edges are rendered properly on Safari

**Which issue(s) this PR fixes** 🔨
AP-1718
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
