### PR TITLE
fix(sidebar): remove pointer events from lastMessage in sidebar

### DIFF
--- a/components/views/user/User.html
+++ b/components/views/user/User.html
@@ -10,7 +10,8 @@
     <TypographyTitle :size="6" data-cy="sidebar-user-name" :text="user.name" />
     <div
       v-html="wrapEmoji(markdownToHtml(lastMessage))"
-      :class="`subtitle ${containsOnlyEmoji(lastMessage) ? 'bigmoji' : ''}`"
+      class="subtitle"
+      :class="{bigmoji : containsOnlyEmoji(lastMessage)}"
       ref="subtitle"
     />
   </div>

--- a/components/views/user/User.vue
+++ b/components/views/user/User.vue
@@ -106,19 +106,6 @@ export default Vue.extend({
       return this.user.state === 'online'
     },
   },
-  mounted() {
-    Array.from(
-      (this.$refs.subtitle as HTMLElement).getElementsByClassName(
-        'spoiler-container',
-      ),
-    ).forEach((spoiler) => {
-      spoiler.addEventListener('click', (e) => {
-        e.preventDefault()
-        e.stopPropagation()
-        spoiler.classList.add('spoiler-open')
-      })
-    })
-  },
   beforeDestroy() {
     // ensure the user can't click context menu options after a friend has been removed
     this.$store.commit('ui/toggleContextMenu', false)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- remove pointer events from sidebar last message preview, preventing link clicks.
- also prevents exposing spoilers in sidebar, but i think thats ultimately a good thing. makes it so any spoiler click is very deliberate. at the moment, they could intend to click into the chat and reveal by accident

**Which issue(s) this PR fixes** 🔨
AP-1848

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
