### PR TITLE
fix(chat): link styling

### DIFF
--- a/components/views/chat/message/Message.less
+++ b/components/views/chat/message/Message.less
@@ -60,6 +60,15 @@
       font-size: @text-size;
       display: inline;
     }
+    // override bulma link style
+    a {
+      color: @satellite-color;
+      &:hover,
+      &:focus {
+        color: @satellite-color;
+        text-decoration: underline;
+      }
+    }
   }
 
   .message-container {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- links were using default bulma colors, hover looked especially bad.
- I considered using flair color, but I believe ux principles indicate links should be blue

**Which issue(s) this PR fixes** 🔨
AP-1751

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
