### PR TITLE
refactor(toolbar): refactor styles and increase text overflow length w/ flex

### DIFF
--- a/components/views/navigation/slimbar/Slimbar.less
+++ b/components/views/navigation/slimbar/Slimbar.less
@@ -7,6 +7,8 @@
   justify-content: flex-start;
   pointer-events: none;
   box-sizing: border-box;
+  transition: @transition-all;
+  &:extend(.third-layer);
 
   .circle-group {
     margin: @normal-spacing 0;

--- a/components/views/navigation/toolbar/Toolbar.less
+++ b/components/views/navigation/toolbar/Toolbar.less
@@ -1,9 +1,10 @@
 #toolbar {
-  flex: 1;
   display: flex;
+  align-items: center;
   height: @toolbar-height;
-  padding: 0 @normal-spacing;
+  padding: 0 @normal-spacing 0 3rem;
   min-width: 500px;
+  min-height: @toolbar-height;
 
   .vertical-divider {
     height: 30px;
@@ -24,22 +25,15 @@
   }
 
   .controls {
+    display: flex;
+    align-items: center;
+    margin-left: @large-spacing;
+    font-size: @icon-size;
+    box-shadow: @ui-shadow;
+    &:extend(.light-padding);
     &:extend(.background-semitransparent-light);
     &:extend(.round-corners);
-    display: inline-flex;
-    justify-content: center;
-    align-items: center;
-    justify-self: center;
-    align-self: center;
-    font-size: @icon-size;
-    &:extend(.light-padding);
-    box-shadow: @ui-shadow;
-    pointer-events: all;
-    margin-left: auto;
 
-    .input-wrap {
-      margin-left: @normal-spacing !important;
-    }
     .control-icon {
       margin: 0 @light-spacing;
       cursor: pointer;
@@ -52,52 +46,36 @@
     }
     .disabled {
       &:extend(.font-muted);
-      & {
-        cursor: not-allowed;
-      }
     }
-  }
-  .toolbar-spacer {
-    height: 45px;
-    flex: auto;
   }
   .circle {
     // cursor: pointer; // TODO: Re-enable when clickable
   }
 
   .circle-container {
-    height: @toolbar-height;
-    display: inline-flex;
-    position: relative;
-    align-items: center;
+    display: flex;
+    flex-shrink: 0;
   }
 
   .user-info {
     position: relative;
     align-self: center;
     margin-left: 0.75rem;
-    max-width: 250px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    &:extend(.no-select);
+    flex-grow: 1;
+    &:extend(.ellipsis);
     pointer-events: none;
 
     .title {
       margin: 0;
       font-size: @title-text;
-      text-overflow: ellipsis;
-      overflow: hidden;
-      white-space: nowrap;
+      &:extend(.ellipsis);
       line-height: 2 !important;
     }
     .subtitle {
       margin: 0;
       padding: 0;
       font-size: @mini-text-size;
-      text-overflow: ellipsis;
-      overflow: hidden;
-      display: block;
-      white-space: nowrap;
+      &:extend(.ellipsis);
     }
   }
 

--- a/components/views/navigation/toolbar/Toolbar.less
+++ b/components/views/navigation/toolbar/Toolbar.less
@@ -3,8 +3,9 @@
   align-items: center;
   height: @toolbar-height;
   padding: 0 @normal-spacing 0 3rem;
-  min-width: 500px;
   min-height: @toolbar-height;
+  transition: @transition-all;
+  &:extend(.third-layer);
 
   .vertical-divider {
     height: 30px;

--- a/layouts/Layout.less
+++ b/layouts/Layout.less
@@ -79,10 +79,6 @@
       transition: @transition-all;
     }
 
-    #toolbar {
-      max-height: @toolbar-height;
-    }
-
     .media-open {
       &:extend(.full-width);
       flex: 1;
@@ -129,10 +125,6 @@
     .breadcrumb {
       padding-top: @xlarge-spacing + @light-spacing;
     }
-  }
-
-  #toolbar {
-    padding-left: 3rem;
   }
 
   &.is-collapsed-aside {

--- a/layouts/Layout.less
+++ b/layouts/Layout.less
@@ -110,12 +110,6 @@
     }
   }
 
-  #servers-vertical-list,
-  #toolbar {
-    transition: @transition-all;
-    &:extend(.third-layer);
-  }
-
   &.is-collapsed {
     #sidebar .toggle-sidebar {
       right: -2rem;
@@ -130,12 +124,6 @@
   &.is-collapsed-aside {
     #aside {
       transform: translateX(calc(@sidebar-size));
-    }
-
-    &.group {
-      #toolbar {
-        padding-right: 3rem;
-      }
     }
 
     &.direct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- general refactor. remove unused styles. move styles from huge Layout file to scoped css file.
- increases text overflow length from 250px to using flex. I set a margin on the toolbar controls so it doesn't hug too closely

![image](https://user-images.githubusercontent.com/33670767/174256062-80c01aef-ec59-4fef-a323-72ecec0b6450.png)


**Which issue(s) this PR fixes** 🔨
AP-1851
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
