### PR TITLE
fix(footer): fix online indicator for special characters

### DIFF
--- a/components/ui/Chat/TypingIndicator/TypingIndicator.html
+++ b/components/ui/Chat/TypingIndicator/TypingIndicator.html
@@ -1,6 +1,6 @@
 <div id="typing-badge-container">
   <div id="typing-loader" />
   <div id="text-container">
-    <TypographyText :text="text" :size="6" />
+    <TypographyText :text="decodeURIComponent(text)" :size="6" />
   </div>
 </div>

--- a/components/ui/Chat/TypingIndicator/TypingIndicator.vue
+++ b/components/ui/Chat/TypingIndicator/TypingIndicator.vue
@@ -10,7 +10,7 @@ export default Vue.extend({
     text(): string {
       return this.$tc('messaging.typing', this.typingParticipants.length, {
         user: this.typingParticipants
-          .map((p: ConversationParticipant) => p.name)
+          .map((p: ConversationParticipant) => encodeURIComponent(p.name))
           .join(', '),
       })
     },

--- a/components/ui/Chat/TypingIndicator/TypingIndicator.vue
+++ b/components/ui/Chat/TypingIndicator/TypingIndicator.vue
@@ -8,6 +8,7 @@ export default Vue.extend({
   computed: {
     ...mapGetters('conversation', ['typingParticipants']),
     text(): string {
+      console.log(this.typingParticipants)
       return this.$tc('messaging.typing', this.typingParticipants.length, {
         user: this.typingParticipants
           .map((p: ConversationParticipant) => encodeURIComponent(p.name))

--- a/components/views/chat/chatbar/footer/connected/Connected.html
+++ b/components/views/chat/chatbar/footer/connected/Connected.html
@@ -1,4 +1,8 @@
 <div class="is-connected">
   <circle-icon class="status" :class="connectedStatus" size="1x" />
-  <TypographyText :text="participantsText" data-cy="user-connected" :size="6" />
+  <TypographyText
+    :text="decodeURIComponent(participantsText)"
+    data-cy="user-connected"
+    :size="6"
+  />
 </div>

--- a/components/views/chat/chatbar/footer/connected/Connected.html
+++ b/components/views/chat/chatbar/footer/connected/Connected.html
@@ -1,8 +1,4 @@
 <div class="is-connected">
   <circle-icon class="status" :class="connectedStatus" size="1x" />
-  <TypographyText
-    :text="decodeURIComponent(participantsText)"
-    data-cy="user-connected"
-    :size="6"
-  />
+  <TypographyText :text="participantsText" data-cy="user-connected" :size="6" />
 </div>

--- a/components/views/chat/chatbar/footer/connected/Connected.vue
+++ b/components/views/chat/chatbar/footer/connected/Connected.vue
@@ -27,14 +27,15 @@ export default Vue.extend({
           this.onlineParticipants.length ? 'ui.online' : 'ui.offline',
           1,
           {
-            name: this.otherParticipants[0].name,
+            name: encodeURIComponent(this.otherParticipants[0].name),
           },
         )
       }
       // if group
       return this.$tc('ui.online', this.onlineParticipants.length, {
         name: this.onlineParticipants
-          .map((p: ConversationParticipant) => p.name)
+          // @ts-ignore // to encode strings to allow for custom modifier special characters to be used while pluralizing locales
+          .map((p: ConversationParticipant) => encodeURIComponent(p.name))
           .join(', '),
       })
     },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Fixes issues with footer related to special characters that don't work with i18n pluralization in the locales files. https://vue-i18n.intlify.dev/guide/essentials/syntax.html#special-characters
This encodes and decodes the strings we build to show the indicator.

**Which issue(s) this PR fixes** 🔨
[AP-1861](https://satellite-im.atlassian.net/browse/AP-1861) and [AP-1858](https://satellite-im.atlassian.net/browse/AP-1861)
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
