### PR TITLE
fix(satellitecircle): remove illegible light grey color

### DIFF
--- a/components/ui/SatelliteCircle/SatelliteCircle.vue
+++ b/components/ui/SatelliteCircle/SatelliteCircle.vue
@@ -37,7 +37,6 @@ export default Vue.extend({
         '#45aaf2',
         '#4b7bec',
         '#a55eea',
-        '#d1d8e0',
         '#778ca3',
         '#2d98da',
         '#3867d6',


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Removes the light grey color from the list of colors for the satellite circle component

**Which issue(s) this PR fixes** 🔨
AP-1597
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
