### PR TITLE
fix(files): update local files to match remote updates

### DIFF
--- a/components/views/files/controls/Controls.html
+++ b/components/views/files/controls/Controls.html
@@ -58,13 +58,7 @@
     :text="filesUploadStatus"
     :size="6"
   />
-  <div class="error-container" v-if="errors.length">
-    <alert-triangle-icon size="1.3x" />
-    <div>
-      <TypographyError v-for="error in errors" :key="error" :text="error" />
-    </div>
-    <x-icon size="1.3x" class="close" @click="errors=[]" />
-  </div>
+  <slot></slot>
   <div class="switcher-container">
     <TypographyText :size="6" :text="$t('pages.files.browse.files')" />
     <FilesViewSwitcher :changeView="changeView" />

--- a/components/views/files/controls/Controls.less
+++ b/components/views/files/controls/Controls.less
@@ -39,6 +39,7 @@
     margin-bottom: @normal-spacing;
     div {
       display: flex;
+      flex-grow: 1;
       gap: @xlight-spacing;
       flex-direction: column;
     }
@@ -46,7 +47,6 @@
       color: @red;
       flex-shrink: 0;
       &.close {
-        margin-left: auto;
         cursor: pointer;
       }
     }

--- a/components/views/files/controls/Controls.vue
+++ b/components/views/files/controls/Controls.vue
@@ -6,6 +6,7 @@ import { FolderPlusIcon, FilePlusIcon } from 'satellite-lucide-icons'
 import { isHeic } from '~/utilities/FileType'
 import { SettingsRoutes } from '~/store/ui/types'
 import { RootState } from '~/types/store/store'
+import { FileSystemErrors } from '~/libraries/Files/errors/Errors'
 const convert = require('heic-convert')
 
 export default Vue.extend({
@@ -163,9 +164,12 @@ export default Vue.extend({
             this.setProgress,
           )
         } catch (e: any) {
-          this.$emit('addError', e.message)
-          this.$store.commit('ui/setFilesUploadStatus', '')
-          return
+          // if out of date, sync
+          if (e.message === FileSystemErrors.NON_FF) {
+            await this.$store.dispatch('textile/syncFileSystem')
+            this.$emit('addError', this.$t('pages.files.errors.out_of_date'))
+            return
+          }
         }
       }
 

--- a/components/views/files/rename/Rename.vue
+++ b/components/views/files/rename/Rename.vue
@@ -69,12 +69,7 @@ export default Vue.extend({
         return
       }
       this.closeModal()
-      this.$store.commit(
-        'ui/setFilesUploadStatus',
-        this.$t('pages.files.status.index'),
-      )
       await this.$store.dispatch('textile/exportFileSystem')
-      this.$store.commit('ui/setFilesUploadStatus', '')
     },
   },
 })

--- a/components/views/files/rename/Rename.vue
+++ b/components/views/files/rename/Rename.vue
@@ -6,6 +6,7 @@ import { mapState, mapGetters } from 'vuex'
 import { SaveIcon } from 'satellite-lucide-icons'
 import { RootState } from '~/types/store/store'
 import { Directory } from '~/libraries/Files/Directory'
+import { FileSystemErrors } from '~/libraries/Files/errors/Errors'
 
 export default Vue.extend({
   components: {
@@ -69,7 +70,16 @@ export default Vue.extend({
         return
       }
       this.closeModal()
-      await this.$store.dispatch('textile/exportFileSystem')
+
+      try {
+        await this.$store.dispatch('textile/exportFileSystem')
+      } catch (e: any) {
+        // if out of date, sync
+        if (e.message === FileSystemErrors.NON_FF) {
+          await this.$store.dispatch('textile/syncFileSystem')
+          this.$toast.error(this.$t('pages.files.errors.out_of_date') as string)
+        }
+      }
     },
   },
 })

--- a/libraries/Files/Directory.ts
+++ b/libraries/Files/Directory.ts
@@ -149,4 +149,12 @@ export class Directory extends Item {
 
     return !this.hasChild(childName)
   }
+
+  /**
+   * @method removeAllChildren
+   * @description remove all in case if import remote file system
+   */
+  removeAllChildren() {
+    this._children.clear()
+  }
 }

--- a/libraries/Files/Directory.ts
+++ b/libraries/Files/Directory.ts
@@ -152,7 +152,7 @@ export class Directory extends Item {
 
   /**
    * @method removeAllChildren
-   * @description remove all in case if import remote file system
+   * @description remove all current items before importing from a remote source
    */
   removeAllChildren() {
     this._children.clear()

--- a/libraries/Files/errors/Errors.ts
+++ b/libraries/Files/errors/Errors.ts
@@ -16,4 +16,7 @@ export enum FileSystemErrors {
   // user facing - Fil
   FILE_SIZE = 'pages.files.errors.file_size',
   LIMIT = 'pages.files.errors.storage_limit',
+
+  // textile bucket errors. pushpath does not return an error code, need to use string
+  NON_FF = 'update is non-fast-forward',
 }

--- a/libraries/Files/remote/abstracts/Bucket.abstract.ts
+++ b/libraries/Files/remote/abstracts/Bucket.abstract.ts
@@ -147,4 +147,14 @@ export abstract class Bucket implements RFM {
       this._root = res.root
     }
   }
+
+  /**
+   * @description  set root so future pushes aren't rejected.
+   */
+  async updateRoot() {
+    if (!this._buckets || !this._key) {
+      throw new Error(TextileError.BUCKET_NOT_INITIALIZED)
+    }
+    this._root = await this._buckets.root(this._key)
+  }
 }

--- a/libraries/Files/remote/textile/PersonalBucket.ts
+++ b/libraries/Files/remote/textile/PersonalBucket.ts
@@ -84,14 +84,4 @@ export class PersonalBucket extends Bucket {
     const $FileSystem: FilSystem = Vue.prototype.$FileSystem
     await $FileSystem.import(this._index)
   }
-
-  /**
-   * @description  set root so future pushes aren't rejected.
-   */
-  async updateRoot() {
-    if (!this._buckets || !this._key) {
-      throw new Error(TextileError.BUCKET_NOT_INITIALIZED)
-    }
-    this._root = await this._buckets.root(this._key)
-  }
 }

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -156,6 +156,7 @@ export default {
         upload: 'Uploading {0}',
         delete: 'Deleting {0}',
         index: 'Updating remote index',
+        remote: 'Updating based on remote changes',
       },
       controls: {
         new_file: 'New File',
@@ -201,6 +202,7 @@ export default {
         enable_consent:
           'Please consent to file scanning in your privacy settings',
         lost: 'Cannot find file, please try again later',
+        out_of_date: 'Your files index was out of date, try again',
       },
     },
     unlock: {

--- a/pages/files/browse/Browse.html
+++ b/pages/files/browse/Browse.html
@@ -13,8 +13,22 @@
       <FilesControls
         ref="controls"
         :changeView="changeView"
-        @forceRender="forceRender"
-      />
+        @addError="(e) => errors.push(e)"
+        @clearErrors="errors=[]"
+        @export="exportFileSystem"
+      >
+        <div class="error-container" v-if="errors.length">
+          <alert-triangle-icon size="1.3x" />
+          <div>
+            <TypographyError
+              v-for="error in errors"
+              :key="error"
+              :text="error"
+            />
+          </div>
+          <x-icon size="1.3x" class="close" @click="errors=[]" />
+        </div>
+      </FilesControls>
       <UiLoadersGenericContent :count="3" v-if="!getInitialized" />
       <TypographyText
         v-else-if="!directory.length"

--- a/pages/files/browse/index.vue
+++ b/pages/files/browse/index.vue
@@ -165,6 +165,7 @@ export default Vue.extend({
      * @param {Function} callback if export was successful
      */
     async exportFileSystem(callback?: Function) {
+      this.errors = []
       try {
         await this.$store.dispatch('textile/exportFileSystem')
       } catch (e: any) {
@@ -176,7 +177,6 @@ export default Vue.extend({
         return
       }
       if (callback) callback()
-      this.errors = []
     },
     /**
      * @method forceRender

--- a/store/textile/__snapshots__/state.test.ts.snap
+++ b/store/textile/__snapshots__/state.test.ts.snap
@@ -14,6 +14,7 @@ Object {
   "userThread": Object {
     "blockNsfw": true,
     "consentToScan": false,
+    "filesVersion": 1,
     "flipVideo": true,
   },
 }

--- a/store/textile/actions.ts
+++ b/store/textile/actions.ts
@@ -1204,7 +1204,7 @@ export default {
       { root: true },
     )
     await $TextileManager.personalBucket.updateIndex($FileSystem.export)
-    await dispatch('updateUserThreadData', {
+    dispatch('updateUserThreadData', {
       filesVersion: $FileSystem.version,
     })
     commit('setFileSystem', {
@@ -1261,7 +1261,7 @@ export default {
     const $UserInfoManager: UserInfoManager =
       Vue.prototype.$TextileManager?.userInfoManager
     const $FileSystem: TextileFileSystem = Vue.prototype.$FileSystem
-    const callback = async (update?: Update<UserThreadData>) => {
+    const callback = (update?: Update<UserThreadData>) => {
       if (!update || !update.instance) return
       commit('setUserThreadData', update.instance)
       // if local file system is out of date (remote instance made an update)

--- a/store/textile/actions.ts
+++ b/store/textile/actions.ts
@@ -1266,7 +1266,7 @@ export default {
       commit('setUserThreadData', update.instance)
       // if local file system is out of date (remote instance made an update)
       if (state.userThread.filesVersion !== $FileSystem.version) {
-        // dispatch('syncFileSystem')
+        dispatch('syncFileSystem')
       }
     }
     await dispatch('textile/subscribeToMailbox', {}, { root: true })

--- a/store/textile/state.ts
+++ b/store/textile/state.ts
@@ -10,6 +10,7 @@ const InitialTextileState = (): TextileState => ({
     consentToScan: false,
     blockNsfw: true,
     flipVideo: true,
+    filesVersion: 1,
   },
   fileSystem: {
     totalSize: 0,

--- a/types/textile/user.ts
+++ b/types/textile/user.ts
@@ -5,5 +5,5 @@ export interface UserThreadData {
   consentUpdated?: number
   blockNsfw: boolean
   flipVideo: boolean
-  filesVersion?: number
+  filesVersion: number
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- textile listener to clear out your local filesystem and import fresh on any remote updates
  - maybe one day we can just check the delta and make that change. this is still relatively fast and seems like a decent first step
  - i tried running the import without clearing first, skipping/adding files as needed, but it seemed relatively error prone
- add try catch to all files operations to catch any remote differences in case you're trying multiple operations at the same time on different devices. The out of date instance will cancel your operation and sync local with updated remote version
- move file system errors up a component so Browse component can adjust as needed
- update created user thread to match initial store value

**Which issue(s) this PR fixes** 🔨
AP-1477
<!--AP-X-->

**Special notes for reviewers** 🗒️
- the files upload status being in the `ui` store module is weird. I don't know what I was thinking when I set that up. I would like to move it to Textile namespace after this

**Additional comments** 🎤
- I found a way to translate strings directly inside vuex, this was really helpful in reducing repetitive logic
