### PR TITLE
test(cypress): updates to chat top toolbar tests

### DIFF
--- a/components/views/files/upload/preview/item/Item.html
+++ b/components/views/files/upload/preview/item/Item.html
@@ -1,4 +1,4 @@
-<div class="file-item">
+<div class="file-item" data-cy="file-item">
   <button
     class="close"
     :class="{disabled: messageLoading}"
@@ -17,7 +17,12 @@
     <file-icon size="3x" class="control-icon" />
   </div>
   <div>
-    <TypographyText :size="6" :text="item.file.name" class="ellipsis" />
+    <TypographyText
+      :size="6"
+      :text="item.file.name"
+      data-cy="file-item-filename"
+      class="ellipsis"
+    />
     <div v-if="item.progress > 0 && item.progress <= 100">
       <UiProgress :progress="item.progress" />
       <TypographySubtitle :text="`${item.progress}% Uploaded...`" />

--- a/components/views/navigation/toolbar/Toolbar.html
+++ b/components/views/navigation/toolbar/Toolbar.html
@@ -22,6 +22,7 @@
   <div class="controls">
     <div
       class="toggle-alerts"
+      data-cy="toolbar-alerts"
       @click="toggleAlerts"
       v-tooltip.bottom="$t('pages.chat.alerts')"
     >

--- a/cypress/integration/chat-pair-features.js
+++ b/cypress/integration/chat-pair-features.js
@@ -101,7 +101,7 @@ describe('Chat features with two accounts', () => {
   })
 
   it('Send file to user B', () => {
-    cy.chatFeaturesSendFile(fileLocalPath)
+    cy.chatFeaturesSendFile(fileLocalPath, 'test-file.txt')
     cy.get('[data-cy=chat-file]')
       .last()
       .scrollIntoView()

--- a/cypress/integration/chat-top-toolbar.js
+++ b/cypress/integration/chat-top-toolbar.js
@@ -7,11 +7,9 @@ const recoverySeed =
     .filter((item) => item.description === 'cypress')
     .map((item) => item.recoverySeed) + '{enter}'
 
-describe.skip('Chat Toolbar Tests', () => {
-  //skipped due to all these works manually but
-  //Cypress is failing, probably because we refactored the tooltips - AP-1668
+describe('Chat Toolbar Tests', () => {
   it(
-    'Chat - Toolbar - Validate audio icon is displayed',
+    'Chat - Toolbar - Load Account for Testing Scenarios',
     { retries: 2 },
     () => {
       //Import account
@@ -20,50 +18,37 @@ describe.skip('Chat Toolbar Tests', () => {
       //Ensure messages are displayed before starting
       cy.validateChatPageIsLoaded()
       cy.goToConversation('cypress friend')
-      cy.hoverOnActiveIcon(
-        '[data-cy=toolbar-enable-audio]',
-        'Offline calling unavailable',
-      )
     },
   )
 
-  it('Chat - Toolbar - Validate video icon is displayed', () => {
+  it('Chat - Toolbar - Audio icon is active', () => {
+    //Start validations
     cy.hoverOnActiveIcon(
       '[data-cy=toolbar-enable-audio]',
       'Offline calling unavailable',
     )
   })
 
-  it('Chat - Toolbar - Alerts icon shows Coming Soon', () => {
-    cy.get('[data-cy=toolbar-alerts]').should('be.visible')
-    cy.hoverOnComingSoonIcon(
-      '[data-cy=toolbar-alerts] > .tooltip-container',
-      'Alerts\nComing Soon',
-    )
+  it('Chat - Toolbar - Alerts icon is active', () => {
+    cy.hoverOnActiveIcon('[data-cy=toolbar-alerts]', 'Alerts')
   })
 
   it('Chat - Toolbar - Archived Messages icon shows Coming Soon', () => {
-    cy.get('[data-cy=toolbar-archived-messages]').should('be.visible')
     cy.hoverOnComingSoonIcon(
-      '[data-cy=toolbar-archived-messages] > .tooltip-container',
-      'Archived Messages\nComing Soon',
+      '[data-cy=toolbar-archived-messages]',
+      'Archived Messages Coming Soon',
     )
   })
 
-  it('Chat - Toolbar - Validate new group icon is displayed', () => {
-    cy.hoverOnActiveIcon('[data-cy=toolbar-new-group]', 'New Group')
-  })
-
-  it('Chat - Toolbar - Marketplace icon is displayed', () => {
-    cy.hoverOnActiveIcon('[data-cy=toolbar-marketplace]', 'Marketplace')
+  it('Chat - Toolbar - Marketplace icon shows Coming Soon', () => {
+    cy.hoverOnComingSoonIcon(
+      '[data-cy=toolbar-marketplace]',
+      'Marketplace Coming soon',
+    )
   })
 
   it('Chat - Toolbar - Wallet icon shows Coming Soon', () => {
-    cy.get('[data-cy=toolbar-wallet]').should('be.visible')
-    cy.hoverOnComingSoonIcon(
-      '[data-cy=toolbar-wallet] > .tooltip-container',
-      'Wallet\nComing Soon',
-    )
+    cy.hoverOnComingSoonIcon('[data-cy=toolbar-wallet]', 'Wallet Coming Soon')
   })
 
   it('Chat - Marketplace - Coming Soon modal content is correct', () => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -417,12 +417,10 @@ Cypress.Commands.add('chatFeaturesSendImage', (imagePath, filename) => {
   cy.get('#quick-upload').selectFile(imagePath, {
     force: true,
   })
-  cy.get('.file-item', { timeout: 30000 }).should('exist')
-  cy.get('.file-info > .title').should('contain', filename)
-  cy.contains('Scanning', { timeout: 120000 }).should('not.exist')
-  cy.get('.thumbnail').should('exist')
+  cy.get('[data-cy=file-item]', { timeout: 60000 }).should('exist')
+  cy.get('[data-cy=file-item-filename]').should('contain', filename)
   cy.get('[data-cy=send-message]').click() //sending image message
-  cy.get('.thumbnail', { timeout: 120000 }).should('not.exist')
+  cy.get('[data-cy=file-item]', { timeout: 120000 }).should('not.exist')
 })
 
 Cypress.Commands.add('goToLastImageOnChat', (waitTime = 30000) => {
@@ -434,15 +432,14 @@ Cypress.Commands.add('goToLastImageOnChat', (waitTime = 30000) => {
 
 // Chat - Send Files Commands
 
-Cypress.Commands.add('chatFeaturesSendFile', (filePath) => {
+Cypress.Commands.add('chatFeaturesSendFile', (filePath, filename) => {
   cy.get('#quick-upload').selectFile(filePath, {
     force: true,
   })
-  cy.get('.file-item').should('exist')
-  cy.get('.file-info > .title').should('contain', 'test-file.txt')
-  cy.get('.preview', { timeout: 180000 }).should('exist')
-  cy.get('[data-cy=send-message]').click() //sending file message
-  cy.get('.preview', { timeout: 120000 }).should('not.exist')
+  cy.get('[data-cy=file-item]', { timeout: 30000 }).should('exist')
+  cy.get('[data-cy=file-item-filename]').should('contain', filename)
+  cy.get('[data-cy=send-message]').click() //sending image message
+  cy.get('[data-cy=file-item]', { timeout: 120000 }).should('not.exist')
 })
 
 // Chat - Context Menu Commands
@@ -515,27 +512,24 @@ Cypress.Commands.add('goToConversation', (user, isMobile = false) => {
   }
 
   //Wait until conversation is fully loaded
-  cy.get('[data-cy=message-loading]', { timeout: 180000 }).should('not.exist')
+  cy.get('[data-cy=chat-message]', { timeout: 180000 }).last().should('exist')
 })
 
 // Chat - Hover on Icon Commands
 
 Cypress.Commands.add('hoverOnComingSoonIcon', (locator, expectedMessage) => {
-  cy.get(locator)
-    .should('be.visible')
-    .should('have.attr', 'data-tooltip', expectedMessage)
-    .should('have.class', 'grayscaled')
-    .realHover()
-  cy.get('.tooltip-container').should('be.visible')
+  cy.get(locator).should('be.visible').find('.coming-soon').should('exist')
+  cy.get(locator).realHover()
+  cy.wait(1000)
+  cy.contains(expectedMessage).should('be.visible')
+  cy.wait(1000)
 })
 
 Cypress.Commands.add('hoverOnActiveIcon', (locator, expectedMessage) => {
-  cy.get(locator)
-    .should('be.visible')
-    .should('have.attr', 'data-tooltip', expectedMessage)
-    .should('not.have.class', 'grayscaled')
-    .realHover()
-  cy.get('.tooltip-container').should('be.visible')
+  cy.get(locator).should('be.visible').realHover()
+  cy.wait(1000)
+  cy.contains(expectedMessage).should('be.visible')
+  cy.wait(1000)
 })
 
 // Chat - URL Commands


### PR DESCRIPTION
**What this PR does** 📖
- Added data-cy attributes for toolbar alerts and file previews used in cypress tests
- Updates for the following cypress commands: sending images/files, hover on active/coming soon icons and go to conversation commands
- Update to pass one additional parameter on command used for send file cypress test for chat-pair-features.js
- Updates on chat-top-toolbar tests due to changes on tooltip functionality

**Which issue(s) this PR fixes** 🔨
AP-1668

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
Chat Top Toolbar Cypress Video:
https://user-images.githubusercontent.com/35935591/174922630-03e018f2-5ca1-40cc-bf23-82ee9c20d476.mp4

Chat Pair Features Cypress Video:
https://user-images.githubusercontent.com/35935591/174922624-8ed17600-a6c4-422f-a286-16efa4f84a12.mp4

Tests Passed:
![image](https://user-images.githubusercontent.com/35935591/174922081-d7b91422-7170-450d-983d-1b750995154a.png)

