### PR TITLE
chore(store): remove unused store

### DIFF
--- a/components/ui/Chat/Scroll/Scroll.vue
+++ b/components/ui/Chat/Scroll/Scroll.vue
@@ -48,9 +48,6 @@ export default Vue.extend({
         dark: this.theme === 'dark',
       }
     },
-    isMediaOpen() {
-      return this.$store.state.ui.showMedia
-    },
   },
   watch: {
     // Once a new message is sent

--- a/store/ui/__snapshots__/state.test.ts.snap
+++ b/store/ui/__snapshots__/state.test.ts.snap
@@ -90,7 +90,6 @@ Object {
   },
   "settingsRoute": "personalize",
   "settingsSideBar": true,
-  "showMedia": false,
   "showOlderMessagesInfo": false,
   "showPinned": false,
   "showSearchResult": false,

--- a/store/ui/actions.test.ts
+++ b/store/ui/actions.test.ts
@@ -148,7 +148,6 @@ const initialState = {
   showSidebar: true,
   showSearchResult: false,
   showSettings: false,
-  showMedia: false,
   settingsSideBar: true,
   settingsRoute: 'personalize',
   quickProfile: false,

--- a/store/ui/getters.test.ts
+++ b/store/ui/getters.test.ts
@@ -376,7 +376,6 @@ describe('init', () => {
       ],
       showSearchResult: false,
       showSettings: false,
-      showMedia: false,
       settingsSideBar: true,
       settingsRoute: 'personalize',
       quickProfile: false,

--- a/store/ui/mutations.test.ts
+++ b/store/ui/mutations.test.ts
@@ -2298,7 +2298,6 @@ describe('mutations', () => {
     showSidebar: true,
     showSearchResult: false,
     showSettings: false,
-    showMedia: false,
     settingsSideBar: true,
     settingsRoute: 'personalize',
     quickProfile: false,
@@ -2534,11 +2533,7 @@ describe('mutations', () => {
     mutations.default.showSidebar(localizedState, true)
     expect(localizedState.showSidebar).toBeTruthy()
   })
-  test('showMedia', () => {
-    const localizedState = { ...initialState }
-    mutations.default.showMedia(localizedState, true)
-    expect(localizedState.showMedia).toBeTruthy()
-  })
+
   test('setContextMenuValues', () => {
     const localizedState = { ...initialState }
     mutations.default.setContextMenuValues(localizedState, true)
@@ -3480,7 +3475,6 @@ describe('mutations', () => {
       ],
       showSearchResult: false,
       showSettings: false,
-      showMedia: false,
       settingsSideBar: true,
       settingsRoute: 'personalize',
       quickProfile: false,
@@ -3623,7 +3617,7 @@ describe('mutations', () => {
       notifications: [],
       showSearchResult: false,
       showSettings: false,
-      showMedia: false,
+
       settingsSideBar: true,
       settingsRoute: 'personalize',
       quickProfile: false,
@@ -3798,7 +3792,7 @@ describe('mutations', () => {
       ],
       showSearchResult: false,
       showSettings: false,
-      showMedia: false,
+
       settingsSideBar: true,
       settingsRoute: 'personalize',
       quickProfile: false,
@@ -3950,7 +3944,7 @@ describe('mutations', () => {
       ],
       showSearchResult: false,
       showSettings: false,
-      showMedia: false,
+
       settingsSideBar: true,
       settingsRoute: 'personalize',
       quickProfile: false,
@@ -4095,7 +4089,7 @@ describe('mutations', () => {
       ],
       showSearchResult: false,
       showSettings: false,
-      showMedia: false,
+
       settingsSideBar: true,
       settingsRoute: 'personalize',
       quickProfile: false,
@@ -4239,7 +4233,7 @@ describe('mutations', () => {
       ],
       showSearchResult: false,
       showSettings: false,
-      showMedia: false,
+
       settingsSideBar: true,
       settingsRoute: 'personalize',
       quickProfile: false,

--- a/store/ui/mutations.ts
+++ b/store/ui/mutations.ts
@@ -29,9 +29,6 @@ export default {
   showSidebar(state: UIState, enabled: boolean) {
     state.showSidebar = enabled
   },
-  showMedia(state: UIState, show: boolean) {
-    state.showMedia = show
-  },
   setContextMenuValues(state: UIState, values: any) {
     state.contextMenuValues = values
   },

--- a/store/ui/state.ts
+++ b/store/ui/state.ts
@@ -14,7 +14,6 @@ const InitialUIState = (): UIState => ({
   notifications: [],
   showSearchResult: false,
   showSettings: false,
-  showMedia: false,
   settingsSideBar: true,
   settingsRoute: SettingsRoutes.PERSONALIZE,
   quickProfile: false,

--- a/store/ui/types.ts
+++ b/store/ui/types.ts
@@ -166,7 +166,6 @@ export interface UIState {
   contextMenuPosition: object
   quickProfilePosition: object
   showSettings: boolean
-  showMedia: boolean
   settingsSideBar: boolean
   settingsRoute: SettingsRoutes
   showSidebarUsers: boolean

--- a/store/webrtc/actions.ts
+++ b/store/webrtc/actions.ts
@@ -463,7 +463,6 @@ const webRTCActions = {
           type,
         })
       }
-      commit('ui/showMedia', true, { root: true })
       dispatch('sounds/playSound', Sounds.CALL, { root: true })
     }
     call.on('INCOMING_CALL', onCallIncoming)
@@ -471,7 +470,6 @@ const webRTCActions = {
     function onCallOutgoing({ peerId }: { peerId: string }) {
       commit('setIncomingCall', undefined)
       commit('setActiveCall', { callId, peerId })
-      commit('ui/showMedia', true, { root: true })
       dispatch('sounds/playSound', Sounds.CALL, { root: true })
     }
     call.on('OUTGOING_CALL', onCallOutgoing)
@@ -491,7 +489,6 @@ const webRTCActions = {
 
     function onCallHangup() {
       commit('updateCreatedAt', 0)
-      commit('ui/showMedia', false, { root: true })
       commit('conversation/setCalling', false, { root: true })
       commit('setIncomingCall', undefined)
       commit('setActiveCall', undefined)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- we previously used this store value to shift the quickchat layout if something was occupying the center of the screen. However, it was removed in a recent PR. this removes the unused store value

**Which issue(s) this PR fixes** 🔨
AP-1880
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
