### PR TITLE
fix(group): remove duplicated dispatch to storeInMessage action

### DIFF
--- a/store/textile/actions.ts
+++ b/store/textile/actions.ts
@@ -909,8 +909,6 @@ export default {
         sender: MessageRouteEnum.OUTBOUND,
         message: result,
       })
-
-      dispatch('storeInMessage', { address: groupId, message })
     } catch (e) {
       Vue.prototype.$Logger.log('textile/sendGroupMessage: error', e)
     } finally {


### PR DESCRIPTION
**What this PR does** 📖
- Remove redundant dispatch call to `storeInMessage` action. We already dispatch `storeInMessage` in `subscribeToGroup` method.

**Which issue(s) this PR fixes** 🔨
AP-1690

Fixed Bug:
<img width="674" alt="Screen Shot 2022-06-21 at 4 58 56 PM" src="https://user-images.githubusercontent.com/23323312/175101353-7d3ad633-21fc-4ff2-a4d1-f259f4df61cb.png">

<img width="1619" alt="Screen Shot 2022-06-01 at 2 49 37 PM" src="https://user-images.githubusercontent.com/23323312/175101450-77c9a2a7-def6-481d-98d1-6e6f7b71b20f.png">

