### PR TITLE
test(cypress): improvements to avoid failure on last test

### DIFF
--- a/cypress/integration-pair-chat/chat-first-user.js
+++ b/cypress/integration-pair-chat/chat-first-user.js
@@ -98,7 +98,7 @@ describe('Chat features with two accounts at the same time - First User', () => 
 
   it(
     'When the user clicks the video button camera should be enabled',
-    { retries: 1 },
+    { retries: 2 },
     () => {
       // Click on call video button and validate that video-stream is visible
       cy.get('[data-cy=call-video]').click()

--- a/cypress/integration-pair-chat/chat-second-user.js
+++ b/cypress/integration-pair-chat/chat-second-user.js
@@ -119,9 +119,6 @@ describe('Chat features with two accounts at the same time - Second User', () =>
     //Deny incoming videocall
     cy.get('[data-cy=incoming-call]', { timeout: 90000 }).should('be.visible')
     cy.get('[data-cy=incoming-call-deny]').click()
-
-    //Wait 30 seconds before calling User A again
-    cy.wait(30000)
   })
 
   it('Call to User A for a second time', () => {


### PR DESCRIPTION
**What this PR does** 📖
- Increased retries on test "When the user clicks the video button camera should be enabled" for chat-first-user.js due to uncaught exception randomly presented when clicking on enable camera button
- Removed unnecessary wait on chat-second-user.js that might be causing the issue in last cypress test for chat-first-user.js

**Which issue(s) this PR fixes** 🔨
None

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
Chat First User Cypress Video:
https://user-images.githubusercontent.com/35935591/175108340-ee7272f7-f328-48de-8ffc-ec97567f2ea7.mp4

Chat Second User Cypress Video:
https://user-images.githubusercontent.com/35935591/175108362-e2c05950-d3f7-4f57-83b9-84fc3cb80e21.mp4

Both tests passing:
![image](https://user-images.githubusercontent.com/35935591/175108318-58218e55-c0dd-4f87-a729-14ed2ced064b.png)
