### PR TITLE
fix(textile): set peer id correctly when switching conversations

### DIFF
--- a/components/views/user/User.vue
+++ b/components/views/user/User.vue
@@ -173,7 +173,7 @@ export default Vue.extend({
       }
 
       this.$store.dispatch('conversation/setConversation', {
-        id: this.user.address,
+        id: this.user.peerId,
         type: 'friend',
         participants: [this.user],
         calling: false,

--- a/store/textile/actions.ts
+++ b/store/textile/actions.ts
@@ -156,6 +156,15 @@ export default {
       ]
     }
 
+    // Since this is async, we have to check that we are still in the chat, if
+    // the user has navigated to a different chat, we can just return early so
+    // we don't update the state with old information (prevents the toolbar
+    // from showing the wrong participant info when navigating between
+    // different conversations rapidly)
+    if (rootState.conversation.id !== friend.peerId) {
+      return
+    }
+
     // store latest data in indexeddb
     const messages = conversation.map((c) => ({ ...c, conversation: address }))
     const dbData: DexieConversation = {
@@ -776,6 +785,15 @@ export default {
       group,
       query,
     })
+
+    // Since this is async, we have to check that we are still in the chat, if
+    // the user has navigated to a different chat, we can just return early so
+    // we don't update the state with old information (prevents the toolbar
+    // from showing the wrong participant info when navigating between
+    // different conversations rapidly)
+    if (rootState.conversation.id !== groupId) {
+      return
+    }
 
     if (setActive) {
       dispatch(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Sets the conversation peer ID when switching conversations
- Prevents the conversation from being updated if the user has already navigated away from the chat (async textile issue)

**Which issue(s) this PR fixes** 🔨
AP-1864
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
