### PR TITLE
test(cypress): updates on mobiles and pair tests

### DIFF
--- a/components/views/settings/modal/Modal.html
+++ b/components/views/settings/modal/Modal.html
@@ -27,7 +27,10 @@
             class="menu-toggle"
           />
           <SettingsBreadcrumbs />
-          <InteractablesClose :action="closeModal" />
+          <InteractablesClose
+            data-cy="settings-close-button"
+            :action="closeModal"
+          />
           <SettingsPagesPersonalize
             v-if="this.ui.settingsRoute === SettingsRoutes.PERSONALIZE"
           />

--- a/cypress/integration/chat-features.js
+++ b/cypress/integration/chat-features.js
@@ -113,8 +113,8 @@ describe('Chat Features Tests', () => {
   it('Chat - Verify when clicking on Send Money, coming soon appears', () => {
     // Hover over on Send Money and Coming Soon tooltip will appear when clicking on its button
     cy.hoverOnComingSoonIcon(
-      '#chatbar-controls > span > .tooltip-container',
-      'Send Money\nComing Soon',
+      '#chatbar-controls > span',
+      'Send Money Coming Soon',
     )
   })
 

--- a/cypress/integration/chat-pair-features.js
+++ b/cypress/integration/chat-pair-features.js
@@ -18,7 +18,7 @@ const randomMessage = faker.lorem.sentence() // generate random sentence
 const imageLocalPath = 'cypress/fixtures/images/logo.png'
 const fileLocalPath = 'cypress/fixtures/test-file.txt'
 const textReply = 'This is a reply to the message'
-let glyphURL, imageURL, fileURL
+let glyphURL, imageURL, fileURL, messageTimestamp
 
 describe('Chat features with two accounts', () => {
   it(
@@ -35,8 +35,16 @@ describe('Chat features with two accounts', () => {
     },
   )
 
-  it.skip('Send message to user B', () => {
+  it('Send message to user B', () => {
+    //Send message
     cy.chatFeaturesSendMessage(randomMessage)
+
+    // Obtain timestamp from chat message
+    cy.getTimestamp().then((value) => {
+      messageTimestamp = value
+    })
+
+    //Go to last chat message
     cy.get('[data-cy=chat-message]')
       .contains(randomMessage)
       .last()
@@ -52,7 +60,7 @@ describe('Chat features with two accounts', () => {
       .should('have.text', '😄')
   })
 
-  it.skip('Context Menu Options - Text Message', () => {
+  it('Context Menu Options - Text Message', () => {
     let optionsMessage = ['Add Reaction', 'Reply', 'Copy Message']
     cy.get('[data-cy=chat-message]')
       .contains(randomMessage)
@@ -132,7 +140,7 @@ describe('Chat features with two accounts', () => {
     },
   )
 
-  it.skip('Assert message received from user A', () => {
+  it('Assert message received from user A', () => {
     //Adding assertion to validate that messages are displayed
     cy.get('[data-cy=chat-message]')
       .contains(randomMessage)
@@ -141,7 +149,7 @@ describe('Chat features with two accounts', () => {
       .should('exist')
   })
 
-  it.skip('Message not sent by same user cannot be edited', () => {
+  it('Message not sent by same user cannot be edited', () => {
     cy.get('[data-cy=chat-message]')
       .contains(randomMessage)
       .last()
@@ -149,7 +157,7 @@ describe('Chat features with two accounts', () => {
     cy.validateOptionNotInContextMenu('@lastmessage', 'Edit')
   })
 
-  it.skip('User should be able to reply a message', () => {
+  it('User should be able to reply a message', () => {
     cy.get('[data-cy=chat-message]')
       .contains(randomMessage)
       .last()
@@ -157,7 +165,7 @@ describe('Chat features with two accounts', () => {
     cy.chatFeaturesReplyMessage('Chat User A', '@lastmessage', textReply)
   })
 
-  it.skip('Reply to message shows as collapsed first', () => {
+  it('Reply to message shows as collapsed first', () => {
     //reply path
     cy.getReply(randomMessage)
     cy.get('@reply-preview')
@@ -165,7 +173,7 @@ describe('Chat features with two accounts', () => {
       .should('contain', 'Reply from Chat User B')
   })
 
-  it.skip('Reply to message is displayed by clicking on it', () => {
+  it('Reply to message is displayed by clicking on it', () => {
     cy.getReply(randomMessage)
     cy.get('@reply-preview').click()
     cy.get('[data-cy=reply-message]').should('have.text', textReply)
@@ -174,21 +182,21 @@ describe('Chat features with two accounts', () => {
       .should('contain', 'Collapse')
   })
 
-  it.skip('Reply to message is not displayed when clicking on Collapse', () => {
+  it('Reply to message is not displayed when clicking on Collapse', () => {
     cy.get('[data-cy=reply-close]').scrollIntoView().click()
     cy.get('[data-cy=reply-message]').should('not.exist')
     cy.getReply(randomMessage)
     cy.get('@reply-preview').should('exist').scrollIntoView()
   })
 
-  it.skip('Assert emoji received from user A', () => {
+  it('Assert emoji received from user A', () => {
     cy.get('[data-cy=chat-message] > span')
       .last()
       .scrollIntoView()
       .should('have.text', '😄')
   })
 
-  it.skip('Assert glyph received from user A', () => {
+  it('Assert glyph received from user A', () => {
     cy.goToLastGlyphOnChat()
       .invoke('attr', 'src')
       .then((glyphSecondAccountSrc) => {
@@ -196,7 +204,7 @@ describe('Chat features with two accounts', () => {
       })
   })
 
-  it.skip('Assert image received from user A', () => {
+  it('Assert image received from user A', () => {
     cy.goToLastImageOnChat()
       .invoke('attr', 'src')
       .then((imageSecondAccountSrc) => {
@@ -204,7 +212,7 @@ describe('Chat features with two accounts', () => {
       })
   })
 
-  it.skip('Assert file received from user A', () => {
+  it('Assert file received from user A', () => {
     cy.get('[data-cy=chat-file]')
       .last()
       .scrollIntoView()
@@ -220,11 +228,11 @@ describe('Chat features with two accounts', () => {
       .last()
       .invoke('text')
       .then(($text) => {
-        expect($text).to.contain('now')
+        expect($text).to.contain(messageTimestamp)
       })
   })
 
-  it.skip('Add reactions to text message in chat', () => {
+  it('Add reactions to text message in chat', () => {
     cy.get('[data-cy=chat-message]')
       .contains(randomMessage)
       .last()
@@ -233,26 +241,34 @@ describe('Chat features with two accounts', () => {
     cy.validateChatReaction('@messageToReact', '😄')
   })
 
-  it.skip('Add reactions to image in chat', () => {
+  it('Add reactions to image in chat', () => {
     cy.get('[data-cy=chat-image]').last().as('imageToReact')
     cy.reactToChatElement('@imageToReact', '[title="smile"]')
     cy.validateChatReaction('@imageToReact', '😄')
   })
 
-  it.skip('Add reactions to file in chat', () => {
+  it('Add reactions to file in chat', () => {
     cy.get('[data-cy=chat-file]').last().as('fileToReact')
     cy.reactToChatElement('@fileToReact', '[title="smile"]')
     cy.validateChatReaction('@fileToReact', '😄')
   })
 
-  it.skip('Add reactions to glyph in chat', () => {
+  it('Add reactions to glyph in chat', () => {
     cy.get('[data-cy=chat-glyph]').last().as('glyphToReact')
     cy.reactToChatElement('@glyphToReact', '[title="smile"]')
     cy.validateChatReaction('@glyphToReact', '😄')
   })
 
   it('Assert timestamp immediately after sending message', () => {
+    //Send chat message
     cy.chatFeaturesSendMessage(randomMessage)
+
+    // Obtain timestamp from last chat message
+    cy.getTimestamp().then((value) => {
+      messageTimestamp = value
+    })
+
+    //Go to last chat message
     cy.get('[data-cy=chat-message]')
       .contains(randomMessage)
       .last()
@@ -266,31 +282,12 @@ describe('Chat features with two accounts', () => {
         cy.getAttached($timestamp)
           .invoke('text')
           .then(($text) => {
-            expect($text).to.contain('now')
+            expect($text).to.contain(messageTimestamp)
           })
       })
   })
 
-  it.skip('Assert timestamp one minute after sending message', () => {
-    //Wait for 60 seconds
-    cy.wait(60000)
-
-    //Assert timestamp text after a minute has passed
-    //Assert timestamp text immediately
-    cy.get('[data-cy=chat-timestamp]')
-      .last()
-      .then(($timestamp) => {
-        cy.getAttached($timestamp)
-          .invoke('text')
-          .then(($text) => {
-            let regexTimestamp = '((1[0-2]|0?[1-9]):([0-5][0-9]) ([AaPp][Mm]))'
-            expect($text).to.match(regexTimestamp)
-          }) //skipped due to  ''CypressError: `match` requires its argument be a `RegExp`.
-        // You passed: `((1[0-2]|0?[1-9]):([0-5][0-9]) ([AaPp][Mm]))`'' - AP-1666
-      })
-  })
-
-  it.skip(
+  it(
     'User should be able to reply without first clicking into the chat bar - Chat User C',
     { retries: 2 },
     () => {
@@ -329,7 +326,7 @@ describe('Chat features with two accounts', () => {
     },
   )
 
-  it.skip('React to other users reaction - Execute validation', () => {
+  it('React to other users reaction - Execute validation', () => {
     //Find the last reaction message
     cy.get('[data-cy=chat-message]')
       .contains(randomMessage)

--- a/cypress/integration/create-account.js
+++ b/cypress/integration/create-account.js
@@ -47,7 +47,7 @@ describe('Create Account Validations', () => {
     cy.createAccountSubmit()
   })
 
-  it.skip('Create account with non-NSFW after attempting to load a NSFW image', () => {
+  it('Create account with non-NSFW after attempting to load a NSFW image', () => {
     //Creating pin
     cy.createAccountPINscreen(randomPIN)
 
@@ -62,7 +62,7 @@ describe('Create Account Validations', () => {
     //Attempting to add NSFW image and validating error message is displayed
     cy.createAccountAddImage(filepathNsfw)
     cy.get('[data-cy=error-message]', { timeout: 60000 }).should(
-      'have.text',
+      'contain',
       'Unable to upload file/s due to NSFW status',
     )
 
@@ -79,7 +79,7 @@ describe('Create Account Validations', () => {
     cy.createAccountSubmit()
   })
 
-  it.skip(
+  it(
     'Create account successfully without image after attempting to add a NSFW picture',
     { retries: 2 },
     () => {
@@ -98,7 +98,7 @@ describe('Create Account Validations', () => {
       //Attempting to add NSFW image and validating error message is displayed
       cy.createAccountAddImage(filepathNsfw)
       cy.get('[data-cy=error-message]', { timeout: 30000 }).should(
-        'have.text',
+        'contain',
         'Unable to upload file/s due to NSFW status',
       )
 
@@ -116,7 +116,7 @@ describe('Create Account Validations', () => {
     },
   )
 
-  it.skip(
+  it(
     'Create account without image after attempting to add an invalid image file',
     { retries: 2 },
     () => {
@@ -134,7 +134,7 @@ describe('Create Account Validations', () => {
       //Attempting to add an invalid image and validating error message is displayed
       cy.createAccountAddImage(invalidImagePath)
       cy.get('[data-cy=error-message]', { timeout: 60000 }).should(
-        'have.text',
+        'contain',
         'Please upload a valid image type such as JPG, PNG or SVG',
       )
 
@@ -170,7 +170,7 @@ describe('Create Account Validations', () => {
       //Attempting to add an invalid image and validating error message is displayed
       cy.createAccountAddImage(invalidImagePath)
       cy.get('[data-cy=error-message]', { timeout: 60000 }).should(
-        'have.text',
+        'contain',
         'Please upload a valid image type such as JPG, PNG or SVG',
       )
 

--- a/cypress/integration/mobiles-responsiveness.js
+++ b/cypress/integration/mobiles-responsiveness.js
@@ -22,7 +22,7 @@ data.allDevices.forEach((item) => {
     },
     () => {
       Cypress.config('pageLoadTimeout', 180000) //adding more time for pageLoadTimeout only for this spec
-      it(`Create Account on ${item.description}`, () => {
+      it(`Create Account on ${item.description}`, { retries: 2 }, () => {
         cy.createAccountPINscreen(randomPIN, false, false, true)
 
         //Create or Import account selection screen
@@ -56,14 +56,7 @@ data.allDevices.forEach((item) => {
         cy.goToConversation('cypress friend', true)
       })
 
-      it.skip(`Chat Features - Send Messages on ${item.description}`, () => {
-        // Click to hamburger button to display chat if app wrap is open (chat not displayed)
-        cy.get('#app-wrap').then(($appWrap) => {
-          if ($appWrap.hasClass('is-open')) {
-            cy.get('[data-cy=hamburger-button]').click()
-          }
-        })
-
+      it(`Chat Features - Send Messages on ${item.description}`, () => {
         //Validate message and emojis are sent
         cy.chatFeaturesSendMessage(randomMessage)
       })
@@ -74,6 +67,34 @@ data.allDevices.forEach((item) => {
 
       it.skip(`Chat Features - Edit Messages on ${item.description}`, () => {
         cy.chatFeaturesEditMessage(randomMessage, randomNumber)
+      })
+
+      it(`Glyphs Modal on ${item.description}`, () => {
+        //Go to last glyph and click on glyphs modal
+        cy.goToLastGlyphOnChat().click()
+        cy.validateGlyphsModal()
+      })
+
+      it(`Glyphs Modal - Coming Soon on ${item.description}`, () => {
+        //Coming soon modal
+        cy.contains('View Glyph Pack').click()
+        cy.get('[data-cy=modal-cta]').should('be.visible')
+        cy.closeModal('[data-cy=modal-cta]')
+      })
+
+      it(`Glyphs Pack Screen can be dismissed on ${item.description}`, () => {
+        //Glyph Pack Screen can be dismissed
+        cy.goToLastGlyphOnChat().click()
+        cy.get('[data-cy=glyphs-modal]').should('be.visible')
+        cy.closeModal('[data-cy=glyphs-modal]')
+      })
+
+      it(`Glyphs Selection - Coming Soon Modal on ${item.description}`, () => {
+        //Glyph Selection - Coming Soon Modal
+        cy.get('#glyph-toggle').click()
+        cy.get('[data-cy=glyphs-marketplace]').click()
+        cy.get('[data-cy=modal-cta]').should('be.visible')
+        cy.closeModal('[data-cy=modal-cta]')
       })
 
       it(`Marketplace - Coming Soon Modal on ${item.description}`, () => {
@@ -90,56 +111,34 @@ data.allDevices.forEach((item) => {
         cy.closeModal('[data-cy=modal-cta]')
       })
 
-      it.skip(`Glyphs Modal on ${item.description}`, () => {
-        //Go to last glyph and click on glyphs modal
-        //skipped due to bug
-        cy.goToLastGlyphOnChat().click()
-        cy.validateGlyphsModal()
-      })
-
-      it.skip(`Glyphs Modal - Coming Soon on ${item.description}`, () => {
-        //Coming soon modal
-        //skipped due to bug
-        cy.contains('View Glyph Pack').click()
-        cy.get('[data-cy=modal-cta]').should('be.visible')
-        cy.closeModal('[data-cy=modal-cta]')
-      })
-
-      it.skip(`Glyphs Pack Screen can be dismissed on ${item.description}`, () => {
-        //Glyph Pack Screen can be dismissed
-        //skipped due to bug
-        cy.goToLastGlyphOnChat().click()
-        cy.get('[data-cy=glyphs-modal]').should('be.visible')
-        cy.closeModal('[data-cy=glyphs-modal]')
-      })
-
-      it(`Glyphs Selection - Coming Soon Modal on ${item.description}`, () => {
-        //Glyph Selection - Coming Soon Modal
-        cy.goToConversation('cypress friend', true)
-        cy.get('#glyph-toggle').click()
-        cy.get('[data-cy=glyphs-marketplace]').click()
-        cy.get('[data-cy=modal-cta]').should('be.visible')
-        cy.closeModal('[data-cy=modal-cta]')
-      })
-
-      it.skip(`Swipe on Settings Screen on ${item.description}`, () => {
-        //Swipe on Settings Screen
-        cy.get('[data-cy=toggle-sidebar]').click() //Show main screen again
+      it(`Swipe on Settings Screen on ${item.description}`, () => {
+        // From the chat screen, swipe to the right to return to main screen
+        cy.get('body').realSwipe('toRight')
         cy.get('#mobile-nav').should('be.visible')
-        cy.get('[data-cy=mobile-nav-settings]').click() //Click on settings
-        cy.contains('Settings').should('be.visible')
-        cy.get('#settings').realSwipe('toRight') // Swipe to the right, to go back to the left part of the screen
+
+        //Go to settings screen
+        cy.get('[data-cy=mobile-nav-settings]').click()
+
+        //Validate that left part of Settings screen is displayed on mobile initially
         cy.contains('Personalize').should('be.visible')
-        cy.get('#settings').realSwipe('toLeft') // Swipe to the left, to go to the right part of the screen
+
+        // Swipe to the left, to go to the right part of the screen
+        cy.get('#settings').realSwipe('toLeft')
+
+        //Validate that right part of Settings screen is displayed after doing the swipe
         cy.contains('Settings').should('be.visible')
-        cy.get('.close-button').click()
+
+        //Close settings screen
+        cy.get('[data-cy=settings-close-button]').click()
       })
 
-      it.skip(`Swipe on Chat Screen on ${item.description}`, () => {
-        //Swipe on Chat screen to Main screen
-        cy.goToConversation('cypress friend', true)
+      it(`Swipe on Chat Screen on ${item.description}`, () => {
+        // Return to chat screen, doing a swipe from main screen
+        cy.get('body').realSwipe('toLeft')
         cy.get('[data-cy=editable-input]').should('be.visible')
-        cy.get('body').realSwipe('toRight') // Swipe to the right, to return to main page
+
+        // From the chat screen, swipe to the right to return to main screen
+        cy.get('body').realSwipe('toRight')
         cy.get('#mobile-nav').should('be.visible')
       })
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -766,6 +766,20 @@ Cypress.Commands.add('sendMessageWithMarkdown', (text, markdown) => {
   }
 })
 
+//Chat - Get Time
+
+Cypress.Commands.add('getTimestamp', () => {
+  let date = new Date()
+  let hours = date.getHours()
+  let minutes = date.getMinutes()
+  let ampm = hours >= 12 ? ' PM' : ' AM'
+  hours = hours % 12
+  hours = hours ? hours : 12
+  minutes = minutes.toString().padStart(2, '0')
+  let strTime = hours + ':' + minutes + ampm
+  return strTime
+})
+
 //Version Release Notes Commands
 
 Cypress.Commands.add('releaseNotesScreenValidation', () => {


### PR DESCRIPTION
**What this PR does** 📖
- Fixed Send Money - Coming Soon cypress test on chat-features.js
- Unskipped cypress tests on chat-pair-features.js, fixed timestamp tests and remove the timestamp validation after 60 seconds, since timestamp is displayed with HH:MM AM/PM format. The removed test scenario is no longer adding any value to the test suite now
- Fixed create-account.js cypress tests validating error messages, by implementing the use of should contain, instead of should have.text
- Unskipped cypress tests for mobiles-responsiveness.js and applied fixes to swipe and glyphs modal validations
- Added a new cypress command to retrieve the timestamp from system used to return the expected value for the chat messages timestamp
- Added data-cy attribute for close modal button on settings, used in cypress tests

**Which issue(s) this PR fixes** 🔨
AP-1883, AP-1884 and AP-1666

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
Chat Features Cypress Video:
https://user-images.githubusercontent.com/35935591/175433126-44b9ddb4-c9f8-4789-a3fe-ddbc8614b5aa.mp4

Chat Pair Features Cypress Video:
https://user-images.githubusercontent.com/35935591/175433136-baeb28fa-8340-4d44-ab07-baff8fc4e6e9.mp4

Create Account Cypress Video:
https://user-images.githubusercontent.com/35935591/175433145-8f181602-ef1d-4164-aa64-d69bd88b7b4c.mp4

Mobiles Responsiveness Cypress Video:
https://user-images.githubusercontent.com/35935591/175433152-ea98f5c4-4a2f-4e59-9bd2-25b798ab9597.mp4

All tests passed:
![image](https://user-images.githubusercontent.com/35935591/175433102-62b2262c-d6b0-40d7-bb81-ad2f3ba5910d.png)
