### PR TITLE
fix(sidebar): add specific relative timestamps to sidebar

### DIFF
--- a/components/views/chat/search/result/item/Item.vue
+++ b/components/views/chat/search/result/item/Item.vue
@@ -22,13 +22,13 @@ export default Vue.extend({
       const msgTimestamp = this.$dayjs(this.data.at)
       // if today
       if (this.$dayjs().isSame(msgTimestamp, 'day')) {
-        return `${this.$t('search.result.today')} ${this.getTimestamp({
+        return `${this.$t('time.today')} ${this.getTimestamp({
           time: this.data.at,
         })}`
       }
       // if yesterday
       if (this.$dayjs().diff(msgTimestamp, 'day') <= 1) {
-        return `${this.$t('search.result.yesterday')} ${this.getTimestamp({
+        return `${this.$t('time.yesterday')} ${this.getTimestamp({
           time: this.data.at,
         })}`
       }

--- a/components/views/user/User.html
+++ b/components/views/user/User.html
@@ -15,7 +15,7 @@
     />
   </div>
   <div class="user-chat-details">
-    <TypographyText :size="6" :text="timestamp" v-if="hasMessaged" />
+    <TypographyText v-if="hasMessaged" :size="6" :text="timestamp" />
     <TypographyTag v-if="unreadMessageCount" :text="unreadMessageCount" />
   </div>
   <div class="user-loader">

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -37,6 +37,10 @@ export default {
     online: 'All users are offline | {name} is online | {name} are online',
     offline: '{name} is not connected',
   },
+  time: {
+    today: 'today',
+    yesterday: 'yesterday',
+  },
   wallet: {
     wallet: 'Wallet',
     send_money: 'Send Money',
@@ -636,8 +640,6 @@ export default {
       users: 'Users',
       conversations: 'Conversations',
       select_date: 'Select Date',
-      today: 'today',
-      yesterday: 'yesterday',
     },
   },
   media: {
@@ -709,12 +711,6 @@ export default {
     message: 'Message',
     options: 'Options',
     cancel: 'Cancel request',
-    details: {
-      now: 'now',
-      yesterday: 'yesterday',
-      days_short: 'd',
-      no_message: 'no message',
-    },
   },
   market_place: {
     title: 'Marketplace\nComing soon',

--- a/plugins/local/dayjs.ts
+++ b/plugins/local/dayjs.ts
@@ -27,4 +27,5 @@ declare module '@nuxt/types' {
 
 Vue.prototype.$dayjs = dayjs
 
+// need to export for tests
 export { dayjs as extendedDayjs }

--- a/store/settings/getters.ts
+++ b/store/settings/getters.ts
@@ -14,6 +14,13 @@ export interface SettingsGetters {
   getTimestamp(
     state: SettingsState,
   ): ({ time, full }: { time: number; full?: boolean }) => string
+  /**
+   * @description return date associated with timestamp
+   * @argument {number} time unix timestamp
+   * @returns {string} formatted time
+   * @example (23423424) => 6/6/22
+   */
+  getDate(state: SettingsState): (time: number) => string
 }
 
 const getters: GetterTree<SettingsState, RootState> & SettingsGetters = {
@@ -24,6 +31,11 @@ const getters: GetterTree<SettingsState, RootState> & SettingsGetters = {
         .local()
         .tz(state.timezone)
         .format(full ? 'L LT' : 'LT')
+    },
+  getDate:
+    (state: SettingsState) =>
+    (time): string => {
+      return extendedDayjs(time).local().tz(state.timezone).format('L')
     },
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- timestamps for same day, yesterday, 2 days ago, and onward

**Which issue(s) this PR fixes** 🔨
AP-1918
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- I couldn't justify adding an interval to every single conversation to add 'now' for 1 minute, until it's replaced by another timestamp 1 minute later. I think when we add unread message notifications, that will serve a similar purpose that 'now' would.
