### PR TITLE
style(chat): fix scrollbar overlapping with long messages in chat

### DIFF
--- a/components/ui/Chat/Scroll/Scroll.less
+++ b/components/ui/Chat/Scroll/Scroll.less
@@ -19,6 +19,7 @@
   overflow-y: auto;
   overflow-x: hidden;
   height: 100%;
+  padding: 0 @normal-spacing;
 
   /* Custom Scroll for Firefox */
   scrollbar-width: thin;

--- a/components/views/chat/conversation/Conversation.less
+++ b/components/views/chat/conversation/Conversation.less
@@ -1,5 +1,4 @@
 .conversation {
-  padding: 0 @normal-spacing;
   height: 100%;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
What this PR does 📖
Fix scrollbar overlapping with long messages in chat

Before
![image-20220629-134512](https://user-images.githubusercontent.com/52865716/176697741-b9ad9dc3-7d32-4b3b-8f2e-4b3ba479d57d.png)

After
<img width="1322" alt="CleanShot 2022-06-30 at 16 03 45@2x" src="https://user-images.githubusercontent.com/52865716/176697633-525a4c62-8a51-4c1a-bf31-293bf059d0bb.png">

Which issue(s) this PR fixes 🔨
[AP-1919](https://satellite-im.atlassian.net/browse/AP-1919)

Special notes for reviewers 🗒️

Additional comments 🎤