### PR TITLE
Revert "fix(chatbar-mobile): fixed chatbar focus when pressed"

### DIFF
--- a/components/ui/Chat/Scroll/Scroll.html
+++ b/components/ui/Chat/Scroll/Scroll.html
@@ -1,7 +1,7 @@
 <div
   :class="classObject"
   ref="scrollRef"
-  @scroll="onScrolled()"
+  v-on:scroll="onScrolled(); hideKeyboard();"
   v-scroll-lock="true"
 >
   <div ref="scrollContent" class="chat-scroll-content">

--- a/components/ui/Chat/Scroll/Scroll.vue
+++ b/components/ui/Chat/Scroll/Scroll.vue
@@ -86,6 +86,15 @@ export default Vue.extend({
       }
     },
     /**
+     * @method hideKeyboard
+     * @description hide virtual keyboard on mobile
+     */
+    hideKeyboard() {
+      if (this.$device.isMobile) {
+        document.activeElement.blur()
+      }
+    },
+    /**
      * @method onScrolled DocsTODO
      * @description
      * @example

--- a/components/views/chat/chatbar/Chatbar.html
+++ b/components/views/chat/chatbar/Chatbar.html
@@ -1,4 +1,4 @@
-<div id="chatbar" ref="chatbar" v-click-outside="blurChatbar">
+<div id="chatbar" ref="chatbar">
   <Enhancers @click="handleChatTextFromOutside" />
   <!-- Hide commands for early access -->
   <!-- <ChatbarCommandsPreview :recipient="recipient" :message="ui.chatbarContent" /> -->

--- a/components/views/chat/chatbar/Chatbar.vue
+++ b/components/views/chat/chatbar/Chatbar.vue
@@ -145,13 +145,6 @@ export default Vue.extend({
   },
   methods: {
     /**
-     * @method blurChatbar
-     * @description blur chatbar
-     */
-    blurChatbar() {
-      document.activeElement?.blur()
-    },
-    /**
      * @method throttleTyping
      * @description Throttles the typing event so that we only send the typing once every two seconds
      */

--- a/components/views/chat/chatbar/Editable.vue
+++ b/components/views/chat/chatbar/Editable.vue
@@ -105,7 +105,7 @@ export default Vue.extend({
     focusInput() {
       this.$nextTick(() => {
         if (!this.$refs?.editable) return
-        const messageBox = this.$refs.editable as HTMLElement
+        const messageBox = this.$refs?.editable as HTMLElement
         Cursor.setCurrentCursorPosition(this.value.length, messageBox)
       })
     },

--- a/components/views/chat/message/Message.vue
+++ b/components/views/chat/message/Message.vue
@@ -231,7 +231,7 @@ export default Vue.extend({
         messageID: this.message.id,
         to: to === myTextilePublicKey ? from : to,
       })
-      this.$nextTick(() => this.$store.dispatch('ui/setChatbarFocus'))
+      this.$store.dispatch('ui/setChatbarFocus')
     },
     /**
      * @method emojiReaction DocsTODO


### PR DESCRIPTION
Reverts Satellite-im/Core-PWA#3777

this causes chat search to lose focus after click, plus it breaks the chatbar focus when you switch chats (unless chatbar focus was already busted)