### PR TITLE
fix(audio): error handling for missing audio output devices

### DIFF
--- a/components/views/settings/pages/audio/Audio.html
+++ b/components/views/settings/pages/audio/Audio.html
@@ -34,7 +34,7 @@
       :text="$t('pages.settings.audio.sources.input.subtitle')"
     >
       <InteractablesSelect
-        v-model="isAudioInput"
+        v-model="selectedAudioInput"
         :options="audioInputs"
         :label="$t('pages.settings.audio.sources.input.title')"
       />
@@ -46,7 +46,7 @@
     >
       <InteractablesSelect
         v-if="browserAllowsAudioOut"
-        v-model="isAudioOutput"
+        v-model="selectedAudioOutput"
         :options="audioOutputs"
         :label="$t('pages.settings.audio.sources.output.title')"
       />

--- a/components/views/settings/pages/audio/index.vue
+++ b/components/views/settings/pages/audio/index.vue
@@ -268,10 +268,10 @@ export default Vue.extend({
 
         // Setting defaults on mount if one isn't already present in local storage
         if (!this.settings.audioInput) {
-          this.isAudioInput = permissionsObject.devices.audioIn[0].value // chrome, ffx, and safari all support the audioIn object
+          this.isAudioInput = permissionsObject.devices.audioIn[0]?.value // chrome, ffx, and safari all support the audioIn object
         }
         if (!this.settings.audioOutput) {
-          this.isAudioOutput = permissionsObject.devices.audioOut[0].value
+          this.isAudioOutput = permissionsObject.devices.audioOut[0]?.value
         }
 
         if (!this.$data.stream) {
@@ -287,7 +287,7 @@ export default Vue.extend({
         this.$data.userHasGivenVideoAccess =
           permissionsObject.permissions.webcam
         if (!this.settings.videoInput) {
-          this.isVideoInput = permissionsObject.devices.videoIn[0].value
+          this.isVideoInput = permissionsObject.devices.videoIn[0]?.value
         }
       }
 

--- a/components/views/settings/pages/audio/index.vue
+++ b/components/views/settings/pages/audio/index.vue
@@ -100,7 +100,7 @@ export default Vue.extend({
         return this.settings.sampleSize
       },
     },
-    isAudioInput: {
+    selectedAudioInput: {
       set(state) {
         this.$store.commit('settings/audioInput', state)
       },
@@ -108,7 +108,7 @@ export default Vue.extend({
         return this.settings.audioInput
       },
     },
-    isAudioOutput: {
+    selectedAudioOutput: {
       set(state) {
         this.$store.commit('settings/audioOutput', state)
         this.setConstraint('volume', state)
@@ -247,6 +247,7 @@ export default Vue.extend({
      */
     async setupDefaults() {
       const permissionsObject: any = await this.getUserPermissions()
+      console.log('permissionsObject', permissionsObject)
 
       // Toggles the show/hide on the button to request permissions
       this.$data.userHasGivenAudioAccess =
@@ -268,10 +269,11 @@ export default Vue.extend({
 
         // Setting defaults on mount if one isn't already present in local storage
         if (!this.settings.audioInput) {
-          this.isAudioInput = permissionsObject.devices.audioIn[0]?.value // chrome, ffx, and safari all support the audioIn object
+          this.selectedAudioInput = permissionsObject.devices.audioIn[0]?.value // chrome, ffx, and safari all support the audioIn object
         }
         if (!this.settings.audioOutput) {
-          this.isAudioOutput = permissionsObject.devices.audioOut[0]?.value
+          this.selectedAudioOutput =
+            permissionsObject.devices.audioOut[0]?.value
         }
 
         if (!this.$data.stream) {
@@ -294,7 +296,8 @@ export default Vue.extend({
       if (permissionsObject.browser !== 'Chrome') {
         this.$data.browserAllowsAudioOut = false
       } else if (!this.settings.audioOutput) {
-        this.isAudioOutput = permissionsObject.devices.audioOut[0]?.value || ''
+        this.selectedAudioOutput =
+          permissionsObject.devices.audioOut[0]?.value || ''
       }
     },
     /**

--- a/components/views/settings/pages/audio/index.vue
+++ b/components/views/settings/pages/audio/index.vue
@@ -247,7 +247,6 @@ export default Vue.extend({
      */
     async setupDefaults() {
       const permissionsObject: any = await this.getUserPermissions()
-      console.log('permissionsObject', permissionsObject)
 
       // Toggles the show/hide on the button to request permissions
       this.$data.userHasGivenAudioAccess =


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Fixes the dropdown for Video Input not opening when user clicks on it in Safari.

**Which issue(s) this PR fixes** 🔨
AP-1914

<!--AP-X-->

**Special notes for reviewers** 🗒️
- The "Video Input" dropdown problem was caused by an error spawning from missing audio output devices, as Safari does not allow setting “audio out”, which resulted in the function that set up the "Video Input" dropdown being exited before options could be set.

**Additional comments** 🎤
