### PR TITLE
feat(settings): add page and section components

### DIFF
--- a/components/interactables/Select/Select.less
+++ b/components/interactables/Select/Select.less
@@ -8,10 +8,6 @@
     padding-bottom: @xlight-spacing;
     display: inline-block;
   }
-
-  .list-container {
-    width: fit-content;
-  }
 }
 
 button,
@@ -22,14 +18,14 @@ select {
   position: relative;
   border-radius: 4rem;
   padding: @light-spacing 2.5rem @light-spacing @normal-spacing;
-
   color: @white;
   background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>')
     no-repeat right 13px center @flair-color;
   box-shadow: 0 5px 14px -5px @flair-color;
   border: none;
-
+  max-width: 100%;
   &:extend(.ellipsis);
+
   &:disabled {
     box-shadow: 0 5px 14px -5px @gray;
     background-color: @gray;

--- a/components/interactables/Volume/Volume.less
+++ b/components/interactables/Volume/Volume.less
@@ -55,6 +55,5 @@
   display: flex;
   padding: 0.65rem 0;
   position: relative;
-  margin-bottom: 0.25rem;
   max-width: @full !important;
 }

--- a/components/views/settings/page/Page.html
+++ b/components/views/settings/page/Page.html
@@ -1,0 +1,3 @@
+<div class="settings-page">
+  <slot />
+</div>

--- a/components/views/settings/page/Page.less
+++ b/components/views/settings/page/Page.less
@@ -1,0 +1,9 @@
+.settings-page {
+  display: flex;
+  flex-direction: column;
+  gap: @large-spacing;
+
+  .separator {
+    margin: 0;
+  }
+}

--- a/components/views/settings/page/Page.vue
+++ b/components/views/settings/page/Page.vue
@@ -1,0 +1,10 @@
+PagePage
+<template src="./Page.html"></template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({})
+</script>
+
+<style scoped lang="less" src="./Page.less"></style>

--- a/components/views/settings/page/Page.vue
+++ b/components/views/settings/page/Page.vue
@@ -1,4 +1,3 @@
-PagePage
 <template src="./Page.html"></template>
 
 <script lang="ts">

--- a/components/views/settings/pages/accounts/Accounts.html
+++ b/components/views/settings/pages/accounts/Accounts.html
@@ -1,16 +1,16 @@
-<div id="accounts-settings">
-  <div class="columns is-desktop">
-    <div class="column">
+<SettingsPage>
+  <SettingsSection>
+    <SettingsUnit>
       <TypographyTitle :size="6" :text="$t('pages.settings.accounts.title')" />
       <TypographySubtitle
         :size="6"
         :text="$t('pages.settings.accounts.subtitle')"
       />
-    </div>
-  </div>
+    </SettingsUnit>
+  </SettingsSection>
 
-  <div class="columns is-desktop">
-    <div class="column">
+  <SettingsSection>
+    <SettingsUnit>
       <TypographyLabel :text="$t('pages.settings.accounts.active')" />
       <InteractablesInputGroup
         readonly
@@ -20,20 +20,18 @@
       >
         <clipboard-icon size="1x" />
       </InteractablesInputGroup>
-    </div>
-  </div>
+    </SettingsUnit>
+  </SettingsSection>
 
-  <!-- <div class="columns is-desktop">
-    <div class="column">
+  <!-- <SettingsSection>
+    <SettingsUnit>
       <TypographyLabel :text="$t('pages.settings.accounts.gas_price')" />
       <InteractablesInput readonly type="primary" :text="accounts.gasPrice" />
-    </div>
-  </div> -->
+    </SettingsUnit>
+  </SettingsSection> -->
 
-  <UiSpacer :height="20" />
-
-  <div class="columns is-desktop">
-    <div class="column">
+  <SettingsSection>
+    <SettingsUnit>
       <TypographyTitle
         :size="6"
         :text="$t('pages.settings.accounts.devices')"
@@ -42,13 +40,11 @@
         :size="6"
         :text="$t('pages.settings.accounts.no_devices')"
       />
-    </div>
-  </div>
+    </SettingsUnit>
+  </SettingsSection>
 
-  <UiSpacer :height="20" />
-
-  <div class="columns is-desktop">
-    <div class="column">
+  <SettingsSection>
+    <SettingsUnit>
       <TypographyTitle
         :size="6"
         :text="$t('pages.settings.profile.phrase.title')"
@@ -79,6 +75,6 @@
           :number="i + 1"
         />
       </div>
-    </div>
-  </div>
-</div>
+    </SettingsUnit>
+  </SettingsSection>
+</SettingsPage>

--- a/components/views/settings/pages/audio/Audio.html
+++ b/components/views/settings/pages/audio/Audio.html
@@ -1,15 +1,17 @@
-<div id="audio-settings">
+<SettingsPage>
   <TypographyHorizontalRuleText
     plaintext
     :value="$t('pages.settings.audio.title')"
   />
   <!--Audio Sources-->
   <!-- Requires user permissions to see in most browsers -->
-  <div class="columns is-desktop">
+  <SettingsSection
+    v-if="!userHasGivenAudioAccess"
+  >
     <SettingsUnit
-      v-if="!userHasGivenAudioAccess && !userDeniedAudioAccess"
       :title="$t('pages.settings.audio.sources.title')"
       :text="$t('pages.settings.audio.sources.subtitle')"
+      v-if="!userDeniedAudioAccess"
     >
       <!-- Ask for permissions block -->
       <InteractablesButton
@@ -22,12 +24,12 @@
 
     <!-- Permission Denied Block -->
     <TypographyError
-      v-if="userDeniedAudioAccess"
+      v-else
       :text="$t('pages.settings.audio.sources.permissionDeniedMessage')"
     />
-  </div>
+  </SettingsSection>
   <!-- Permission Granted Block -->
-  <div v-if="userHasGivenAudioAccess" class="columns is-desktop">
+  <SettingsSection v-if="userHasGivenAudioAccess">
     <!-- Audio In -->
     <SettingsUnit
       :title="$t('pages.settings.audio.sources.input.title')"
@@ -55,10 +57,10 @@
         :text="$t('pages.settings.audio.sources.browserDoesNotSupportAudioOutChange')"
       />
     </SettingsUnit>
-  </div>
+  </SettingsSection>
 
   <!--Audio Bitrate & Sample-->
-  <div class="columns is-desktop">
+  <SettingsSection>
     <SettingsUnit :title="$t('pages.settings.audio.inputVolume.title')">
       <br />
       <div class="meter-container">
@@ -83,11 +85,11 @@
         @volumeControlValueChange="volumeControlValueChange"
       />
     </SettingsUnit>
-  </div>
+  </SettingsSection>
 
   <!--Audio Bitrate & Sample-->
   <UiComingSoon :areaCover="true" :hide="true">
-    <div class="columns is-desktop">
+    <SettingsSection>
       <SettingsUnit
         :title="$t('pages.settings.audio.bitrate.title')"
         :text="$t('pages.settings.audio.bitrate.subtitle')"
@@ -108,10 +110,10 @@
           :label="$t('pages.settings.audio.sampleSize.title')"
         />
       </SettingsUnit>
-    </div>
+    </SettingsSection>
 
     <!--Echo Cancellation & Noise Suppression-->
-    <div class="columns is-desktop">
+    <SettingsSection>
       <SettingsUnit
         :title="$t('pages.settings.audio.echo.title')"
         :text="$t('pages.settings.audio.echo.subtitle')"
@@ -130,7 +132,7 @@
           :isEnabled="settings.noiseSuppression"
         />
       </SettingsUnit>
-    </div>
+    </SettingsSection>
   </UiComingSoon>
   <!-- Video -->
   <TypographyHorizontalRuleText
@@ -139,7 +141,7 @@
   />
 
   <!--Video Input Source -->
-  <div class="columns is-desktop">
+  <SettingsSection>
     <SettingsUnit
       :title="$t('pages.settings.video.sources.input.title')"
       :text="$t('pages.settings.video.sources.input.subtitle')"
@@ -178,7 +180,7 @@
       />
     </SettingsUnit>
     <UiLoadersGenericContent class="column unit" :count="1" v-else />
-  </div>
+  </SettingsSection>
 
   <!-- Screen Share -->
   <TypographyHorizontalRuleText
@@ -188,7 +190,7 @@
   />
 
   <!-- Capture Mouse -->
-  <div class="columns is-desktop" v-if="featureReadyToShow">
+  <SettingsSection v-if="featureReadyToShow">
     <SettingsUnit
       :title="$t('pages.settings.screen.captureMouse.title')"
       :text="$t('pages.settings.screen.captureMouse.subtitle')"
@@ -199,7 +201,7 @@
         label="$t('pages.settings.screen.captureMouse.title')"
       />
     </SettingsUnit>
-  </div>
+  </SettingsSection>
 
   <!-- Notification Sounds -->
   <TypographyHorizontalRuleText
@@ -208,4 +210,4 @@
   />
   <SettingsPagesAudioSounds />
   <TypographyText v-if="loading.length" :text="$t('pages.privacy.updating')" />
-</div>
+</SettingsPage>

--- a/components/views/settings/pages/developer/Info.html
+++ b/components/views/settings/pages/developer/Info.html
@@ -1,16 +1,16 @@
-<div id="developer-settings">
-  <div class="columns is-desktop">
-    <div class="column">
+<SettingsPage>
+  <SettingsSection>
+    <SettingsUnit>
       <TypographyTitle :size="6" :text="$t('pages.settings.developer.title')" />
       <TypographySubtitle
         :size="6"
         :text="$t('pages.settings.developer.subtitle')"
       />
-    </div>
-  </div>
+    </SettingsUnit>
+  </SettingsSection>
 
-  <div class="columns is-desktop">
-    <div class="column">
+  <SettingsSection>
+    <SettingsUnit>
       <TypographyLabel :text="$t('pages.settings.developer.identifier')" />
       <br />
       <InteractablesInput
@@ -20,6 +20,6 @@
         readonly
         v-model="accounts.active"
       />
-    </div>
-  </div>
-</div>
+    </SettingsUnit>
+  </SettingsSection>
+</SettingsPage>

--- a/components/views/settings/pages/info/Developer.html
+++ b/components/views/settings/pages/info/Developer.html
@@ -1,16 +1,16 @@
-<div id="developer-settings">
-  <div class="columns is-desktop">
-    <div class="column">
+<SettingsPage>
+  <SettingsSection>
+    <SettingsUnit>
       <TypographyTitle :size="6" :text="$t('pages.settings.info.title')" />
       <TypographySubtitle
         :size="6"
         :text="$t('pages.settings.info.subtitle')"
       />
-    </div>
-  </div>
+    </SettingsUnit>
+  </SettingsSection>
 
-  <div class="columns is-desktop">
-    <div class="column">
+  <SettingsSection>
+    <SettingsUnit>
       <TypographyLabel :text="$t('pages.settings.app_info')" />
       <br />
       <pre>
@@ -21,15 +21,15 @@
         <span v-if="renderer">Processor:   {{renderer}}</span>
         Online:      {{ this.$envinfo.navigator.onLine }}
       </pre>
-    </div>
-  </div>
-  <div class="columns is-desktop">
-    <div class="column">
+    </SettingsUnit>
+  </SettingsSection>
+  <SettingsSection>
+    <SettingsUnit>
       <TypographyLabel :text="$t('pages.settings.changelog')" />
       <br />
       <pre>
         <vue-markdown :source="releaseData && releaseData.body" :breaks="false"/>
       </pre>
-    </div>
-  </div>
-</div>
+    </SettingsUnit>
+  </SettingsSection>
+</SettingsPage>

--- a/components/views/settings/pages/keybinds/Keybinds.html
+++ b/components/views/settings/pages/keybinds/Keybinds.html
@@ -1,16 +1,16 @@
-<div id="keybinds-settings">
-  <div class="columns is-desktop">
-    <div class="column">
+<SettingsPage>
+  <SettingsSection>
+    <SettingsUnit>
       <TypographyTitle :size="6" :text="$t('pages.settings.keybinds.title')" />
       <TypographySubtitle
         :size="6"
         :text="$t('pages.settings.keybinds.subtitle')"
       />
-    </div>
-  </div>
+    </SettingsUnit>
+  </SettingsSection>
 
-  <div class="columns is-desktop" v-if="editingKeybind.status">
-    <div class="column">
+  <SettingsSection v-if="editingKeybind.status">
+    <SettingsUnit>
       <InteractablesInput
         readonly
         type="primary"
@@ -23,8 +23,8 @@
         :text="editingKeybind.errorMessage"
         v-if="editingKeybind.error"
       />
-    </div>
-    <div class="column">
+    </SettingsUnit>
+    <SettingsUnit>
       <InteractablesButton
         :text="$t('pages.settings.keybinds.clear')"
         size="small"
@@ -43,46 +43,46 @@
         type="primary"
         :action="cancelKeybind"
       />
-    </div>
-  </div>
+    </SettingsUnit>
+  </SettingsSection>
 
-  <div class="columns is-desktop">
-    <div class="column" @click="editKeybind('toggleMute')">
+  <SettingsSection>
+    <SettingsUnit @click="editKeybind('toggleMute')">
       <TypographyLabel :text="$t('pages.settings.keybinds.mute')" />
       <InteractablesInput
         readonly
         type="primary"
         :placeholder="settings.keybinds.toggleMute"
       />
-    </div>
-    <div class="column" @click="editKeybind('openSettings')">
+    </SettingsUnit>
+    <SettingsUnit @click="editKeybind('openSettings')">
       <TypographyLabel :text="$t('pages.settings.keybinds.settings')" />
       <InteractablesInput
         readonly
         type="primary"
         :placeholder="settings.keybinds.openSettings"
       />
-    </div>
-  </div>
+    </SettingsUnit>
+  </SettingsSection>
 
-  <div class="columns is-desktop">
-    <div class="column" @click="editKeybind('toggleDeafen')">
+  <SettingsSection>
+    <SettingsUnit @click="editKeybind('toggleDeafen')">
       <TypographyLabel :text="$t('pages.settings.keybinds.deafen')" />
       <InteractablesInput
         readonly
         type="primary"
         :placeholder="settings.keybinds.toggleDeafen"
       />
-    </div>
-    <div class="column" @click="editKeybind('callActiveChat')">
+    </SettingsUnit>
+    <SettingsUnit @click="editKeybind('callActiveChat')">
       <TypographyLabel :text="$t('pages.settings.keybinds.call')" />
       <InteractablesInput
         readonly
         type="primary"
         :placeholder="settings.keybinds.callActiveChat"
       />
-    </div>
-  </div>
+    </SettingsUnit>
+  </SettingsSection>
 
   <InteractablesButton
     :text="$t('pages.settings.keybinds.reset_all')"
@@ -90,4 +90,4 @@
     type="primary"
     :action="resetKeybinds"
   />
-</div>
+</SettingsPage>

--- a/components/views/settings/pages/network/Network.html
+++ b/components/views/settings/pages/network/Network.html
@@ -1,22 +1,22 @@
-<div id="network-settings">
-  <div class="columns is-desktop">
-    <div class="column">
+<SettingsPage>
+  <SettingsSection>
+    <SettingsUnit>
       <TypographyTitle :size="6" :text="$t('pages.settings.network.title')" />
       <TypographySubtitle
         :size="6"
         :text="$t('pages.settings.network.subtitle')"
       />
-    </div>
-  </div>
+    </SettingsUnit>
+  </SettingsSection>
 
-  <div class="columns is-desktop">
-    <div class="column">
+  <SettingsSection>
+    <SettingsUnit>
       <InteractablesSelect
         v-model="network"
         :label="$t('pages.settings.network.network')"
         :options="[{ text: 'Testnet', value: 'testnet' }]"
         show-label
       />
-    </div>
-  </div>
-</div>
+    </SettingsUnit>
+  </SettingsSection>
+</SettingsPage>

--- a/components/views/settings/pages/notifications/Notifications.html
+++ b/components/views/settings/pages/notifications/Notifications.html
@@ -1,6 +1,6 @@
-<div id="developer-settings">
-  <div class="columns is-desktop">
-    <div class="column">
+<SettingsPage>
+  <SettingsSection>
+    <SettingsUnit>
       <TypographyTitle
         :size="6"
         :text="$t('pages.settings.notifications.title')"
@@ -9,15 +9,15 @@
         :size="6"
         :text="$t('pages.settings.notifications.notes')"
       />
-    </div>
-  </div>
+    </SettingsUnit>
+  </SettingsSection>
   <TypographyLabel
     :text="$t('pages.settings.notifications.labels.current_platform')"
   /><TypographyText :text="Platform" />
   <br />
 
-  <div class="columns is-desktop">
-    <div class="column">
+  <SettingsSection>
+    <SettingsUnit>
       <span
         v-if="Platform === PlatformTypeEnum.WEB || Platform === PlatformTypeEnum.ELECTRON"
       >
@@ -70,8 +70,8 @@
           <arrow-right-icon size="1x" />
         </InteractablesInputGroup>
       </span>
-    </div>
-  </div>
+    </SettingsUnit>
+  </SettingsSection>
 
   <SettingsPagesNotificationsSounds />
-</div>
+</SettingsPage>

--- a/components/views/settings/pages/personalize/Personalize.html
+++ b/components/views/settings/pages/personalize/Personalize.html
@@ -1,6 +1,6 @@
-<div id="personalize-settings">
-  <div class="columns is-desktop">
-    <div class="column">
+<SettingsPage>
+  <SettingsSection>
+    <SettingsUnit>
       <TypographyTitle
         :size="6"
         :text="$t('pages.settings.personalize.title')"
@@ -9,22 +9,22 @@
         :size="6"
         :text="$t('pages.settings.personalize.subtitle')"
       />
-    </div>
-  </div>
+    </SettingsUnit>
+  </SettingsSection>
 
-  <div class="columns is-desktop">
-    <div class="column">
+  <SettingsSection>
+    <SettingsUnit>
       <InteractablesSelect
         v-model="theme"
         :options="themes"
         :label="$t('pages.settings.personalize.theme')"
         show-label
       />
-    </div>
-  </div>
+    </SettingsUnit>
+  </SettingsSection>
 
-  <div class="columns is-desktop">
-    <div class="column">
+  <SettingsSection>
+    <SettingsUnit>
       <InteractablesSelect
         v-model="flair"
         :options="flairOptions"
@@ -32,17 +32,17 @@
         :disabled="theme === ThemeNames.DEFAULT"
         show-label
       />
-    </div>
-  </div>
+    </SettingsUnit>
+  </SettingsSection>
 
-  <div class="columns is-desktop">
-    <div class="column">
+  <SettingsSection>
+    <SettingsUnit>
       <InteractablesSelect
         v-model="language"
         :options="[{ text: 'English (USA)', value: 'en_US' }]"
         :label="$t('pages.settings.personalize.language')"
         show-label
       />
-    </div>
-  </div>
-</div>
+    </SettingsUnit>
+  </SettingsSection>
+</SettingsPage>

--- a/components/views/settings/pages/privacy/Privacy.html
+++ b/components/views/settings/pages/privacy/Privacy.html
@@ -1,13 +1,13 @@
-<div id="privacy-settings">
-  <div class="columns is-desktop">
-    <div class="column">
+<SettingsPage>
+  <SettingsSection>
+    <SettingsUnit>
       <TypographyTitle :size="6" :text="$t('pages.privacy.title')" />
       <TypographySubtitle :size="6" :text="$t('pages.privacy.subtitle')" />
-    </div>
-  </div>
+    </SettingsUnit>
+  </SettingsSection>
   <UiLoadersGenericContent :count="3" v-if="!getInitialized" />
   <template v-else>
-    <div class="columns is-desktop">
+    <SettingsSection>
       <SettingsUnit
         :title="$t('pages.privacy.register.title')"
         :text="$t('pages.privacy.register.subtitle')"
@@ -20,8 +20,8 @@
       >
         <InteractablesSwitch v-model="storePin" />
       </SettingsUnit>
-    </div>
-    <div class="columns is-desktop">
+    </SettingsSection>
+    <SettingsSection>
       <SettingsUnit
         :title="$t('pages.privacy.embeds.title')"
         :text="$t('pages.privacy.embeds.subtitle')"
@@ -34,8 +34,8 @@
       >
         <InteractablesSwitch v-model="displayCurrentActivity" />
       </SettingsUnit>
-    </div>
-    <div class="columns is-desktop">
+    </SettingsSection>
+    <SettingsSection>
       <SettingsUnit
         :title="$t('pages.privacy.consentScan.title')"
         :text="$t('pages.privacy.consentScan.subtitle')"
@@ -54,25 +54,25 @@
           :isLocked="loading.includes('blockNsfw')"
         />
       </SettingsUnit>
-    </div>
+    </SettingsSection>
     <TypographyText
       v-if="loading.length"
       :text="$t('pages.privacy.updating')"
     />
-    <!-- <div class="columns is-desktop">
-    <SettingsUnit
-      :title="$t('pages.privacy.serverType.title')"
-      :text="$t('pages.privacy.serverType.subtitle')"
-    >
-      <InteractablesSelect
-        v-model="serverType"
-        :options="serverTypes"
-        class="form-control"
-      />
-    </SettingsUnit>
-  </div> -->
+    <!-- <SettingsSection>
+      <SettingsUnit
+        :title="$t('pages.privacy.serverType.title')"
+        :text="$t('pages.privacy.serverType.subtitle')"
+      >
+        <InteractablesSelect
+          v-model="serverType"
+          :options="serverTypes"
+          class="form-control"
+        />
+      </SettingsUnit>
+    </SettingsSection> -->
 
-    <div
+    <SettingsSection
       v-if="serverType === 'own'"
       class="columns is-desktop ownInfo-input-part"
     >
@@ -115,6 +115,6 @@
           />
         </span>
       </SettingsUnit>
-    </div>
+    </SettingsSection>
   </template>
-</div>
+</SettingsPage>

--- a/components/views/settings/pages/profile/Profile.html
+++ b/components/views/settings/pages/profile/Profile.html
@@ -1,4 +1,4 @@
-<div id="profile-settings" :class="isSmallScreen? 'profile-small-screen' : ''">
+<SettingsPage>
   <SettingsProfileBanner />
 
   <div class="profile-layout">
@@ -97,4 +97,4 @@
       </div> -->
     </div>
   </div>
-</div>
+</SettingsPage>

--- a/components/views/settings/pages/profile/Profile.less
+++ b/components/views/settings/pages/profile/Profile.less
@@ -1,32 +1,6 @@
 @size: 75px;
 @size-mobile: 55px;
 
-// .profile-small-screen {
-//   display: flex;
-//   flex-wrap: wrap;
-//   flex-direction: column;
-//   &:extend(.full-width);
-//   .profile-left {
-//     padding: @normal-spacing 0;
-//   }
-//   .profile-layout {
-//     &:extend(.full-width);
-//     display: flex;
-//     flex-wrap: wrap;
-//     .profile-left {
-//       &:extend(.full-width);
-//       margin-top: 0;
-//     }
-//   }
-//   .profile-photo-column {
-//     max-width: 75px;
-//     .profile-photo {
-//       height: @size-mobile;
-//       width: @size-mobile;
-//     }
-//   }
-// }
-
 .profile-layout {
   &:extend(.full-width);
   display: flex;

--- a/components/views/settings/pages/profile/Profile.less
+++ b/components/views/settings/pages/profile/Profile.less
@@ -1,31 +1,31 @@
 @size: 75px;
 @size-mobile: 55px;
 
-.profile-small-screen {
-  display: flex;
-  flex-wrap: wrap;
-  flex-direction: column;
-  &:extend(.full-width);
-  .profile-left {
-    padding: @normal-spacing 0;
-  }
-  .profile-layout {
-    &:extend(.full-width);
-    display: flex;
-    flex-wrap: wrap;
-    .profile-left {
-      &:extend(.full-width);
-      margin-top: 0;
-    }
-  }
-  .profile-photo-column {
-    max-width: 75px;
-    .profile-photo {
-      height: @size-mobile;
-      width: @size-mobile;
-    }
-  }
-}
+// .profile-small-screen {
+//   display: flex;
+//   flex-wrap: wrap;
+//   flex-direction: column;
+//   &:extend(.full-width);
+//   .profile-left {
+//     padding: @normal-spacing 0;
+//   }
+//   .profile-layout {
+//     &:extend(.full-width);
+//     display: flex;
+//     flex-wrap: wrap;
+//     .profile-left {
+//       &:extend(.full-width);
+//       margin-top: 0;
+//     }
+//   }
+//   .profile-photo-column {
+//     max-width: 75px;
+//     .profile-photo {
+//       height: @size-mobile;
+//       width: @size-mobile;
+//     }
+//   }
+// }
 
 .profile-layout {
   &:extend(.full-width);

--- a/components/views/settings/pages/realms/Realms.html
+++ b/components/views/settings/pages/realms/Realms.html
@@ -1,16 +1,16 @@
-<div id="network-settings">
-  <div class="columns is-desktop">
-    <div class="column">
+<SettingsPage>
+  <SettingsSection>
+    <SettingsUnit>
       <TypographyTitle :size="6" :text="$t('pages.settings.realms.title')" />
       <TypographySubtitle
         :size="6"
         :text="$t('pages.settings.realms.subtitle')"
       />
-    </div>
-  </div>
+    </SettingsUnit>
+  </SettingsSection>
 
-  <div class="columns is-desktop">
-    <div class="column">
+  <SettingsSection>
+    <SettingsUnit>
       <TypographyLabel :text="$t('pages.settings.realms.chain')" />
       <br />
       <SettingsPagesRealmsRealm
@@ -18,6 +18,6 @@
         :realm="realm"
         :key="realm.id"
       />
-    </div>
-  </div>
-</div>
+    </SettingsUnit>
+  </SettingsSection>
+</SettingsPage>

--- a/components/views/settings/pages/storage/Storage.html
+++ b/components/views/settings/pages/storage/Storage.html
@@ -1,16 +1,16 @@
-<div id="network-settings">
-  <div class="columns is-desktop">
-    <div class="column">
+<SettingsPage>
+  <SettingsSection>
+    <SettingsUnit>
       <TypographyTitle :size="6" :text="$t('pages.settings.storage.title')" />
       <TypographySubtitle
         :size="6"
         :text="$t('pages.settings.storage.subtitle')"
       />
-    </div>
-  </div>
+    </SettingsUnit>
+  </SettingsSection>
 
-  <div class="columns is-desktop" v-if="featureReadyToShow">
-    <div class="column">
+  <SettingsSection v-if="featureReadyToShow">
+    <SettingsUnit>
       <TypographyTitle
         :size="6"
         :text="$t('pages.settings.storage.export.title')"
@@ -25,11 +25,11 @@
         size="small"
         :text="$t('pages.settings.storage.export.button')"
       />
-    </div>
-  </div>
+    </SettingsUnit>
+  </SettingsSection>
 
-  <div class="columns is-desktop">
-    <div class="column">
+  <SettingsSection>
+    <SettingsUnit>
       <TypographyTitle
         :size="6"
         :text="$t('pages.settings.storage.clear.title')"
@@ -67,6 +67,6 @@
           :action="clearLocalStorage"
         />
       </span>
-    </div>
-  </div>
-</div>
+    </SettingsUnit>
+  </SettingsSection>
+</SettingsPage>

--- a/components/views/settings/section/Section.html
+++ b/components/views/settings/section/Section.html
@@ -1,0 +1,3 @@
+<div class="settings-section">
+  <slot />
+</div>

--- a/components/views/settings/section/Section.less
+++ b/components/views/settings/section/Section.less
@@ -1,0 +1,6 @@
+.settings-section {
+  display: flex;
+  flex-direction: row;
+  gap: @large-spacing;
+  flex-wrap: wrap;
+}

--- a/components/views/settings/section/Section.vue
+++ b/components/views/settings/section/Section.vue
@@ -1,0 +1,9 @@
+<template src="./Section.html"></template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({})
+</script>
+
+<style scoped lang="less" src="./Section.less"></style>

--- a/components/views/settings/unit/Unit.html
+++ b/components/views/settings/unit/Unit.html
@@ -1,6 +1,7 @@
 <div class="settings-unit" @click="$emit('click', $event)">
-  <TypographyTitle v-if="title.length" :size="6" :text="title" />
-  <TypographyText v-if="text.length" :text="text" />
-  <br v-if="text.length" />
+  <div class="text">
+    <TypographyTitle v-if="title.length" :size="6" :text="title" />
+    <TypographyText v-if="text.length" :text="text" />
+  </div>
   <slot></slot>
 </div>

--- a/components/views/settings/unit/Unit.html
+++ b/components/views/settings/unit/Unit.html
@@ -1,4 +1,4 @@
-<div class="column unit is-half-desktop">
+<div class="settings-unit" @click="$emit('click', $event)">
   <TypographyTitle v-if="title.length" :size="6" :text="title" />
   <TypographyText v-if="text.length" :text="text" />
   <br v-if="text.length" />

--- a/components/views/settings/unit/Unit.less
+++ b/components/views/settings/unit/Unit.less
@@ -1,6 +1,11 @@
 .settings-unit {
   flex: 1;
   min-width: 280px;
+
+  .text {
+    margin-bottom: @normal-spacing;
+  }
+
   @media only screen and (max-width: @mobile-breakpoint) {
     flex-basis: 100%;
   }

--- a/components/views/settings/unit/Unit.less
+++ b/components/views/settings/unit/Unit.less
@@ -1,7 +1,7 @@
-.columns.is-desktop {
-  .column.unit.is-half-desktop {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
+.settings-unit {
+  flex: 1;
+  min-width: 280px;
+  @media only screen and (max-width: @mobile-breakpoint) {
+    flex-basis: 100%;
   }
 }

--- a/components/views/settings/unit/Unit.vue
+++ b/components/views/settings/unit/Unit.vue
@@ -1,6 +1,8 @@
-<template src="./Unit.html" />
+<template src="./Unit.html"></template>
+
 <script lang="ts">
 import Vue from 'vue'
+
 export default Vue.extend({
   props: {
     text: {
@@ -14,3 +16,5 @@ export default Vue.extend({
   },
 })
 </script>
+
+<style scoped lang="less" src="./Unit.less"></style>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Adds a `SettingsPage` and `SettingsSection` component to replace the mass of divs and bulma classes.
- Update `SettingsUnit` and `InteractablesVolume` styling
- Updates settings pages to use new components
- Fixes select overflow in settings flexbox layout

**Which issue(s) this PR fixes** 🔨
AP-1889
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
