### PR TITLE
style(sidebar): message preview in sidebar from multi-line to one-line

### DIFF
--- a/components/views/user/User.less
+++ b/components/views/user/User.less
@@ -24,6 +24,15 @@
 
   .user-info {
     height: @user-details-height;
+    flex: 1;
+    min-width: 0;
+    padding-left: @light-spacing;
+    display: inline-flex;
+    flex-direction: column;
+    justify-content: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
     .title {
       height: 20px;
       margin: 0 0 1.25rem 0;
@@ -36,23 +45,14 @@
     }
 
     .subtitle {
-      height: @mini-text-size * 1.2 * 2;
+      height: @mini-text-size * 1.2;
       line-height: 1.2;
       font-size: @mini-text-size;
       color: @text-muted;
       font-family: @secondary-font;
-      pointer-events: none;
-      .multiline-ellipsis(2);
+      .multiline-ellipsis(1);
+      overflow: hidden;
     }
-
-    flex: 1;
-    min-width: 0;
-    padding-left: @light-spacing;
-    display: inline-flex;
-    flex-direction: column;
-    justify-content: center;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 
   .user-chat-details {


### PR DESCRIPTION
What this PR does 📖
Message preview in the sidebar has been changed to one-line to prevent long multi-line text from having a weird line-break that's visually unpleasant especially if containing spoilers

Which issue(s) this PR fixes 🔨
AP-1923

Special notes for reviewers 🗒️

Additional comments 🎤