### PR TITLE
fix(files): remove leftover ui blockers and fix exports

### DIFF
--- a/components/views/files/aside/List/List.html
+++ b/components/views/files/aside/List/List.html
@@ -1,8 +1,8 @@
 <ul class="menu-list">
   <li
     v-for="item in items"
-    :class="[{'is-active' : isActiveRoute(item.route)}, {'disabled' : isFilesIndexLoading}]"
-    @click="!isFilesIndexLoading &&  setActive(item.route)"
+    :class="{'is-active' : isActiveRoute(item.route)}"
+    @click="setActive(item.route)"
   >
     <component v-if="item.icon" :is="icons[item.icon]" size="1x" />
     {{item.text}}

--- a/components/views/files/aside/List/List.vue
+++ b/components/views/files/aside/List/List.vue
@@ -2,7 +2,6 @@
 
 <script lang="ts">
 import Vue, { PropType } from 'vue'
-import { mapGetters } from 'vuex'
 import {
   ClockIcon,
   TrashIcon,
@@ -28,7 +27,6 @@ export default Vue.extend({
     },
   },
   computed: {
-    ...mapGetters('ui', ['isFilesIndexLoading']),
     icons() {
       return {
         [FileIconsEnum.CLOCK]: ClockIcon,

--- a/components/views/files/controls/Controls.vue
+++ b/components/views/files/controls/Controls.vue
@@ -43,7 +43,6 @@ export default Vue.extend({
       consentToScan: (state) =>
         (state as RootState).textile.userThread.consentToScan,
     }),
-    ...mapGetters('ui', ['isFilesIndexLoading']),
   },
   methods: {
     /**

--- a/components/views/files/file/File.vue
+++ b/components/views/files/file/File.vue
@@ -1,7 +1,7 @@
 <template src="./File.html"></template>
 <script lang="ts">
 import Vue, { PropType } from 'vue'
-import { mapState, mapGetters } from 'vuex'
+import { mapState } from 'vuex'
 import {
   LinkIcon,
   HeartIcon,
@@ -41,7 +41,6 @@ export default Vue.extend({
   },
   data() {
     return {
-      fileSize: '' as string,
       fileHover: false as boolean,
       linkHover: false as boolean,
       heartHover: false as boolean,
@@ -52,7 +51,6 @@ export default Vue.extend({
       ui: (state) => (state as RootState).ui,
       blockNsfw: (state) => (state as RootState).textile.userThread.blockNsfw,
     }),
-    ...mapGetters('ui', ['isFilesIndexLoading']),
     /**
      * @returns {string} if directory, child count. if file, size
      */

--- a/components/views/files/filepath/Filepath.vue
+++ b/components/views/files/filepath/Filepath.vue
@@ -1,7 +1,6 @@
 <template src="./Filepath.html"></template>
 <script lang="ts">
 import Vue from 'vue'
-import { mapGetters } from 'vuex'
 import { HomeIcon } from 'satellite-lucide-icons'
 import fileSystem from '~/libraries/Files/FilSystem'
 
@@ -10,7 +9,6 @@ export default Vue.extend({
     HomeIcon,
   },
   computed: {
-    ...mapGetters('ui', ['isFilesIndexLoading']),
     /**
      * @returns string array of file paths to current directory (not including root)
      */

--- a/components/views/files/list/List.html
+++ b/components/views/files/list/List.html
@@ -1,8 +1,4 @@
-<table
-  class="table"
-  data-cy="files-table"
-  :class="{'disabled' : isFilesIndexLoading}"
->
+<table class="table" data-cy="files-table">
   <thead>
     <th @click="setSort(FileSortEnum.NAME)">
       {{ $t('pages.files.browse.name') }}

--- a/components/views/files/list/List.vue
+++ b/components/views/files/list/List.vue
@@ -38,7 +38,6 @@ export default Vue.extend({
     }
   },
   computed: {
-    ...mapGetters('ui', ['isFilesIndexLoading']),
     FileSortEnum: () => FileSortEnum,
   },
   mounted() {

--- a/components/views/files/list/row/Row.html
+++ b/components/views/files/list/row/Row.html
@@ -1,7 +1,4 @@
-<tr
-  ref="row"
-  v-on="isFilesIndexLoading ? {} : { click: handle, contextmenu: contextMenu }"
->
+<tr ref="row" @click="handle" @contextmenu="contextMenu">
   <td class="filename">
     <template v-if="!$device.isMobile">
       <folder-icon
@@ -25,7 +22,7 @@
     @mouseover="menuHover=true"
     @mouseleave="menuHover=false"
     data-cy="file-item-options"
-    v-on="isFilesIndexLoading ? {} : { click: contextMenu }"
+    @click="contextMenu"
   >
     <more-vertical-icon size="1x" />
   </td>

--- a/components/views/files/list/row/Row.vue
+++ b/components/views/files/list/row/Row.vue
@@ -41,7 +41,6 @@ export default Vue.extend({
   },
   computed: {
     ...mapState(['ui']),
-    ...mapGetters('ui', ['isFilesIndexLoading']),
     /**
      * @returns {boolean} if item has discrete MIME type of image
      */

--- a/components/views/files/rename/Rename.html
+++ b/components/views/files/rename/Rename.html
@@ -5,7 +5,6 @@
     type="primary"
     v-model="text"
     :action="rename"
-    :loading="isFilesIndexLoading"
     ref="inputGroup"
     data-cy="files-rename-input"
   >

--- a/components/views/files/rename/Rename.vue
+++ b/components/views/files/rename/Rename.vue
@@ -2,11 +2,12 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import { mapState, mapGetters } from 'vuex'
+import { mapState } from 'vuex'
 import { SaveIcon } from 'satellite-lucide-icons'
 import { RootState } from '~/types/store/store'
 import { Directory } from '~/libraries/Files/Directory'
 import fileSystem from '~/libraries/Files/FilSystem'
+import iridium from '~/libraries/Iridium/IridiumManager'
 
 export default Vue.extend({
   components: {
@@ -30,7 +31,6 @@ export default Vue.extend({
     ...mapState({
       renameItem: (state) => (state as RootState).ui.renameItem,
     }),
-    ...mapGetters('ui', ['isFilesIndexLoading']),
   },
   mounted() {
     if (!this.renameItem) {
@@ -74,7 +74,7 @@ export default Vue.extend({
         'ui/setFilesUploadStatus',
         this.$t('pages.files.status.index'),
       )
-      // await this.$store.dispatch('textile/exportFileSystem')
+      iridium.files?.exportFs()
       this.$store.commit('ui/setFilesUploadStatus', '')
     },
   },

--- a/components/views/files/view/View.html
+++ b/components/views/files/view/View.html
@@ -24,8 +24,7 @@
       <a
         v-tooltip.bottom="$t('controls.share_link')"
         class="control"
-        :class="{'disabled' : isFilesIndexLoading}"
-        v-on="isFilesIndexLoading ? {} : {click: share}"
+        @click="share"
       >
         <link-icon size="1x" />
       </a> -->

--- a/components/views/files/view/View.vue
+++ b/components/views/files/view/View.vue
@@ -1,7 +1,7 @@
 <template src="./View.html"></template>
 <script lang="ts">
 import Vue from 'vue'
-import { mapState, mapGetters } from 'vuex'
+import { mapState } from 'vuex'
 import {
   FileIcon,
   DownloadIcon,
@@ -28,7 +28,6 @@ export default Vue.extend({
       fileDownloadList: (state) => (state as RootState).ui.fileDownloadList,
       blockNsfw: (state) => (state as RootState).textile.userThread.blockNsfw,
     }),
-    ...mapGetters('ui', ['isFilesIndexLoading']),
     isDownloading(): boolean {
       return this.file?.name
         ? this.fileDownloadList.includes(this.file.name)

--- a/layouts/files.vue
+++ b/layouts/files.vue
@@ -109,7 +109,7 @@ export default Vue.extend({
       consentToScan: (state) =>
         (state as RootState).textile.userThread.consentToScan,
     }),
-    ...mapGetters('ui', ['showSidebar', 'isFilesIndexLoading']),
+    ...mapGetters('ui', ['showSidebar']),
     ...mapGetters('textile', ['getInitialized']),
     ...mapGetters('webrtc', ['isBackgroundCall']),
     flairColor(): string {
@@ -169,10 +169,7 @@ export default Vue.extend({
       }
 
       // if already uploading, return to prevent bucket fast-forward crash
-      if (this.isFilesIndexLoading) {
-        this.$toast.show(this.$t('pages.files.errors.in_progress') as string)
-        return
-      }
+
       if (e?.dataTransfer) {
         const files: (File | null)[] = [...e.dataTransfer.items].map((f) =>
           f.getAsFile(),

--- a/pages/files/browse/index.vue
+++ b/pages/files/browse/index.vue
@@ -9,6 +9,7 @@ import { Fil } from '~/libraries/Files/Fil'
 import { FileAsideRouteEnum, FileSortEnum } from '~/libraries/Enums/enums'
 import { FileSort } from '~/store/ui/types'
 import fileSystem from '~/libraries/Files/FilSystem'
+import iridium from '~/libraries/Iridium/IridiumManager'
 
 export default Vue.extend({
   name: 'Files',
@@ -92,7 +93,8 @@ export default Vue.extend({
         'ui/setFilesUploadStatus',
         this.$t('pages.files.status.index'),
       )
-      // await this.$store.dispatch('textile/exportFileSystem')
+      iridium.files?.exportFs()
+
       item.liked
         ? this.$toast.show(this.$t('pages.files.add_favorite') as string)
         : this.$toast.show(this.$t('pages.files.remove_favorite') as string)
@@ -117,7 +119,7 @@ export default Vue.extend({
         'ui/setFilesUploadStatus',
         this.$t('pages.files.status.index'),
       )
-      // await this.$store.dispatch('textile/exportFileSystem')
+      iridium.files?.exportFs()
       this.$store.commit('ui/setFilesUploadStatus', '')
 
       this.forceRender()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- I missed a few ui blockers in my last PR, this removes any remaining ones. I think it was only a concern with textile having an outdated root. with a direct ipfs connection, I don't think there's a concern about concurrent operations
- export fs after every files operation (like, rename, delete). missed these in my last PR as well

I'm going to attempt to rearchitect this to work more smoothly with our new stack, but this at least returns all functionality while that work is in progress

**Which issue(s) this PR fixes** 🔨
AP-1953
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
