### PR TITLE
feat(scroll): show scrollbar on hover only option

### DIFF
--- a/assets/styles/base.less
+++ b/assets/styles/base.less
@@ -30,19 +30,43 @@ body {
 *:active {
   outline: none;
 }
+// Scrollbars
 * {
   &::-webkit-scrollbar {
     width: @scroll-bar-size;
+    height: @scroll-bar-size;
   }
   &::-webkit-scrollbar-track {
     background: transparent;
   }
   &::-webkit-scrollbar-thumb {
-    background: @flair-color;
-    &:extend(.round-corners);
+    background-color: transparent;
+    transition: all @animation-speed ease;
   }
+  scrollbar-color: transparent transparent;
   scrollbar-width: thin;
-  scrollbar-color: @flair-color transparent;
+
+  &:hover,
+  &:focus-within {
+    &::-webkit-scrollbar-thumb {
+      background-color: @flair-color;
+      &:extend(.round-corners);
+      &:hover {
+        background: @semitransparent-white-gradient;
+        background-color: @flair-color;
+      }
+    }
+    -ms-overflow-style: -ms-autohiding-scrollbar;
+    scrollbar-color: @flair-color transparent;
+  }
+}
+
+.hidden-scroll {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 code {
@@ -499,18 +523,6 @@ button {
   }
 
   scrollbar-color: @flair-color transparent;
-}
-
-.hidden-scroll {
-  overflow-y: auto;
-  position: relative;
-
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-  &::-webkit-scrollbar {
-    display: none;
-    scrollbar-width: none;
-  }
 }
 
 //Media

--- a/assets/styles/base.less
+++ b/assets/styles/base.less
@@ -40,11 +40,22 @@ body {
     background: transparent;
   }
   &::-webkit-scrollbar-thumb {
+    background-color: @flair-color;
+    &:extend(.round-corners);
+    &:hover {
+      background: @semitransparent-white-gradient;
+    }
+  }
+  scrollbar-color: @flair-color transparent;
+  scrollbar-width: thin;
+}
+
+// only show scroll on hover
+.hover-scroll {
+  &::-webkit-scrollbar-thumb {
     background-color: transparent;
-    transition: all @animation-speed ease;
   }
   scrollbar-color: transparent transparent;
-  scrollbar-width: thin;
 
   &:hover,
   &:focus-within {

--- a/assets/styles/framework/colors.less
+++ b/assets/styles/framework/colors.less
@@ -122,13 +122,11 @@
   rgba(231, 76, 60, 0.5) 0%,
   rgba(192, 57, 43, 0.5) 100%
 );
-
-@semitransparent-red-gradient: linear-gradient(
+@semitransparent-white-gradient: linear-gradient(
   0deg,
-  rgba(231, 76, 60, 0.5) 0%,
-  rgba(192, 57, 43, 0.5) 100%
+  rgba(255, 255, 255, 0.1) 0%,
+  rgba(255, 255, 255, 0.05) 100%
 );
-
 @semitransparent-green-gradient: linear-gradient(
   0deg,
   rgba(0, 184, 148, 0.5) 0%,

--- a/components/views/navigation/sidebar/Sidebar.html
+++ b/components/views/navigation/sidebar/Sidebar.html
@@ -62,54 +62,52 @@
         v-click-outside="()=>toggleModal('quickchat')"
       />
     </div>
-    <div class="scrolling hidden-scroll users" v-scroll-lock="true">
-      <UiSimpleScroll scrollMode="vertical" scrollShow="scroll">
-        <UiLoadersAddress
-          v-if="dataState.friends === DataStateType.Loading"
-          :count="4"
-          inverted
+    <div class="list-container hover-scroll">
+      <UiLoadersAddress
+        v-if="dataState.friends === DataStateType.Loading"
+        :count="4"
+        inverted
+      />
+      <template
+        v-else-if="friends && Object.values(friends.details || {}).length"
+      >
+        <UiInlineNotification
+          v-if="ui.unreadMessage.length"
+          :text="$t('messaging.new_messages')"
         />
-        <template
-          v-else-if="friends && Object.values(friends.details || {}).length"
-        >
-          <UiInlineNotification
-            v-if="ui.unreadMessage.length"
-            :text="$t('messaging.new_messages')"
+        <div v-for="friend in friends.details">
+          <User
+            v-if="friend"
+            :key="friend.did"
+            :user="friend"
+            :isTyping="ui.isTyping.address === friend.did"
+            :isSelected="friend.did === $route.params.did"
           />
-          <div v-for="friend in friends.details">
-            <User
-              v-if="friend"
-              :key="friend.did"
-              :user="friend"
-              :isTyping="ui.isTyping.address === friend.did"
-              :isSelected="friend.did === $route.params.did"
-            />
-            <!-- <GroupClickable
+          <!-- <GroupClickable
               v-else
               :group="thing"
               :key="thing.id"
               :isSelected="thing.id === $route.params.id"
             /> -->
-          </div>
-        </template>
-        <div
-          v-else-if="friends && friends.list && !friends.list.length"
-          class="mascot-container"
-        >
-          <TypographyTitle :text="$t('pages.chat.no_friends_yet')" :size="6" />
-          <TypographyText :text="$t('pages.chat.no_friends_yet_text')" />
-          <img src="~/assets/svg/mascot/sad_curious.svg" class="mascot" />
-          <InteractablesButton
-            :text="$t('friends.add') + 's'"
-            size="small"
-            type="primary"
-            :action="gotoAddFriends"
-          >
-            <user-plus-icon size="1.2x" />
-          </InteractablesButton>
         </div>
-        <UiLoadersAddress v-else :count="4" inverted />
-      </UiSimpleScroll>
+      </template>
+      <div
+        v-else-if="friends && friends.list && !friends.list.length"
+        class="mascot-container"
+      >
+        <TypographyTitle :text="$t('pages.chat.no_friends_yet')" :size="6" />
+        <TypographyText :text="$t('pages.chat.no_friends_yet_text')" />
+        <img src="~/assets/svg/mascot/sad_curious.svg" class="mascot" />
+        <InteractablesButton
+          :text="$t('friends.add') + 's'"
+          size="small"
+          type="primary"
+          :action="gotoAddFriends"
+        >
+          <user-plus-icon size="1.2x" />
+        </InteractablesButton>
+      </div>
+      <UiLoadersAddress v-else :count="4" inverted />
     </div>
   </div>
   <div class="controls">

--- a/components/views/navigation/sidebar/Sidebar.less
+++ b/components/views/navigation/sidebar/Sidebar.less
@@ -50,6 +50,10 @@
       }
     }
 
+    .list-container {
+      overflow-y: scroll;
+    }
+
     .users {
       flex: 1;
       position: relative;

--- a/pages/files/browse/Browse.html
+++ b/pages/files/browse/Browse.html
@@ -1,9 +1,4 @@
-<div
-  id="files"
-  data-cy="files-screen"
-  class="hidden-scroll"
-  v-scroll-lock="true"
->
+<div id="files" data-cy="files-screen">
   <FilesAside v-if="$device.isMobile" class="mobile-file-aside" />
   <div class="files-top">
     <FilesFilepath />

--- a/pages/files/browse/Browse.less
+++ b/pages/files/browse/Browse.less
@@ -1,5 +1,6 @@
 #files {
   padding: @normal-spacing;
+  overflow-y: scroll;
 
   .files-container {
     display: flex;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
I initially made a [huge PR](https://github.com/Satellite-im/Core-PWA/pull/3783) that affected all scrolls on the app, but then we switched main branches. This is a small chunk of that large pr

- global scroll style rules
- add lighter color on hover for webkit (thanks Thomas)
- I think being able to hide the scrollbar until you hover/focus within an element is useful functionality, but I don't think it should be applied to every scrollbar in the entire app. I created a class (.hover-scroll) which will do this. for now, I added it to the chat sidebar. You can test by manually creating elements via the inspector to trigger the overflow

<img width="541" alt="image" src="https://user-images.githubusercontent.com/33670767/178682883-33918bba-90f3-4501-9f34-009862c3af9a.png">

![image](https://user-images.githubusercontent.com/33670767/178683289-e0dacec8-5aa6-441e-b5bd-9cddda9a32d1.png)


**Which issue(s) this PR fixes** 🔨
AP-1929
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
