### PR TITLE
feat(files): refactor thumbnails to lazy load

### DIFF
--- a/components/views/files/grid/item/Item.html
+++ b/components/views/files/grid/item/Item.html
@@ -23,11 +23,11 @@
     />
   </div>
   <!-- add container so blur effect doesn't go outside the dimensions of the image -->
-  <div v-if="item.thumbnail" class="image-container">
+  <div v-if="thumbnail" class="image-container">
     <img
       class="image-preview"
       :class="{'blur-image' : item.nsfw && blockNsfw}"
-      :src="item.thumbnail"
+      :src="thumbnail"
       draggable="false"
     />
   </div>

--- a/components/views/files/grid/item/Item.vue
+++ b/components/views/files/grid/item/Item.vue
@@ -16,6 +16,7 @@ import { ContextMenuItem } from '~/store/ui/types'
 import { isMimeArchive } from '~/utilities/FileType'
 import { RootState } from '~/types/store/store'
 import { IridiumItem } from '~/libraries/Iridium/files/types'
+import iridium from '~/libraries/Iridium/IridiumManager'
 
 export default Vue.extend({
   components: {
@@ -29,9 +30,6 @@ export default Vue.extend({
   },
   mixins: [ContextMenu],
   props: {
-    /**
-     * File or Directory to be displayed in detail
-     */
     item: {
       type: Object as PropType<IridiumItem>,
       required: true,
@@ -39,6 +37,7 @@ export default Vue.extend({
   },
   data() {
     return {
+      thumbnail: '',
       fileHover: false as boolean,
       linkHover: false as boolean,
       heartHover: false as boolean,
@@ -57,21 +56,12 @@ export default Vue.extend({
         ? this.$tc('pages.files.item_count', this.item.children.length)
         : this.$filesize(this.item.size)
     },
-    /**
-     * @returns {boolean} if item has discrete MIME type of image
-     */
     isImage(): boolean {
       return this.item.type.includes('image')
     },
-    /**
-     * @returns {boolean} if item has discrete MIME type of video
-     */
     isVideo(): boolean {
       return this.item.type.includes('video')
     },
-    /**
-     * @returns {boolean} if item is archive file type
-     */
     isArchive(): boolean {
       return isMimeArchive(this.item.type)
     },
@@ -93,6 +83,17 @@ export default Vue.extend({
         { text: this.$t('context.delete'), func: this.remove },
       ]
     },
+  },
+  async mounted() {
+    // if item is IridiumFile and has thumbnail cid stored
+    if ('thumbnail' in this.item && this.item.thumbnail) {
+      this.thumbnail = URL.createObjectURL(
+        await iridium.files.fetchThumbnail(this.item.thumbnail, this.item.type),
+      )
+    }
+  },
+  beforeDestroy() {
+    if (this.thumbnail) URL.revokeObjectURL(this.thumbnail)
   },
   methods: {
     /**

--- a/components/views/files/view/View.html
+++ b/components/views/files/view/View.html
@@ -37,11 +37,8 @@
       </button>
     </div>
   </div>
-  <div v-if="file.thumbnail" class="image-container">
-    <img
-      :src="file.thumbnail"
-      :class="{'blur-image' : file.nsfw && blockNsfw}"
-    />
+  <div v-if="thumbnail" class="image-container">
+    <img :src="thumbnail" :class="{'blur-image' : file.nsfw && blockNsfw}" />
   </div>
   <div v-else class="no-preview">
     <UiLoadersSpinner v-if="isDownloading" class="file-icon" spinning />

--- a/components/views/files/view/View.less
+++ b/components/views/files/view/View.less
@@ -52,6 +52,7 @@
     max-height: 60vh;
     &:extend(.round-corners);
     overflow: hidden;
+    background-color: @background;
     img {
       height: 100%;
       width: 100%;

--- a/components/views/files/view/View.vue
+++ b/components/views/files/view/View.vue
@@ -12,7 +12,6 @@ import {
 } from 'satellite-lucide-icons'
 import { RootState } from '~/types/store/store'
 import iridium from '~/libraries/Iridium/IridiumManager'
-
 export default Vue.extend({
   components: {
     FileIcon,
@@ -21,6 +20,11 @@ export default Vue.extend({
     ArchiveIcon,
     XIcon,
     LinkIcon,
+  },
+  data() {
+    return {
+      thumbnail: '',
+    }
   },
   computed: {
     ...mapState({
@@ -34,8 +38,17 @@ export default Vue.extend({
         : false
     },
   },
-  mounted() {
+  async mounted() {
     if (this.$refs.modal) (this.$refs.modal as HTMLElement).focus()
+
+    if (this.file?.thumbnail) {
+      this.thumbnail = URL.createObjectURL(
+        await iridium.files.fetchThumbnail(this.file.thumbnail, this.file.type),
+      )
+    }
+  },
+  beforeDestroy() {
+    if (this.thumbnail) URL.revokeObjectURL(this.thumbnail)
   },
   methods: {
     /**

--- a/libraries/Iridium/files/FilesManager.ts
+++ b/libraries/Iridium/files/FilesManager.ts
@@ -283,8 +283,8 @@ export default class FilesManager extends Emitter {
       throw new Error(FileSystemErrors.INVALID)
     }
 
-    // if no parent, look at root, otherwise look at sibling items
-    this.isDuplicateName(name, !parent ? this.state.items : parent.children)
+    // if parent was found, check sibling items. otherwise check root
+    this.isDuplicateName(name, parent ? parent.children : this.state.items)
   }
 
   /**

--- a/libraries/Iridium/files/FilesManager.ts
+++ b/libraries/Iridium/files/FilesManager.ts
@@ -4,7 +4,7 @@ import type {
   IridiumSetOptions,
 } from '@satellite-im/iridium/src/types'
 import type { IPFS } from 'ipfs-core-types'
-import type { AddOptions } from 'ipfs-core-types/root'
+import type { AddOptions, AddResult } from 'ipfs-core-types/root'
 import { createWriteStream } from 'streamsaver'
 import { v4 as uuidv4 } from 'uuid'
 import type { IridiumManager } from '../IridiumManager'
@@ -12,7 +12,7 @@ import logger from '~/plugins/local/logger'
 import { IridiumDirectory, IridiumItem } from '~/libraries/Iridium/files/types'
 import isNSFW from '~/utilities/NSFW'
 import createThumbnail from '~/utilities/Thumbnail'
-import { blobToStream, blobToBase64 } from '~/utilities/BlobManip'
+import { blobToStream } from '~/utilities/BlobManip'
 import { FILE_TYPE } from '~/libraries/Files/types/file'
 import { Config } from '~/config'
 import { FileSystemErrors } from '~/libraries/Files/errors/Errors'
@@ -110,15 +110,11 @@ export default class FilesManager extends Emitter {
       | IridiumDirectory
       | undefined
     this.validateName(file.name, parent)
-    const res = await (this.iridium.connector?.ipfs as IPFS).add(
-      blobToStream(file),
-      options,
-    )
     const thumbnailBlob = await createThumbnail(file, 400)
 
     const target = parent?.children ?? this.state.items
     target.push({
-      id: res?.path,
+      id: (await this.upload(file, options)).path,
       name: file.name,
       size: file.size,
       nsfw: await isNSFW(file),
@@ -129,8 +125,9 @@ export default class FilesManager extends Emitter {
       type: Object.values(FILE_TYPE).includes(file.type as FILE_TYPE)
         ? (file.type as FILE_TYPE)
         : FILE_TYPE.GENERIC,
-      // TODO- maybe store thumbnail blob in ipfs as second object, then store hash here and lazy load
-      thumbnail: thumbnailBlob ? await blobToBase64(thumbnailBlob) : '',
+      thumbnail: thumbnailBlob
+        ? (await this.upload(thumbnailBlob, options)).path
+        : '',
       extension: file.name
         .slice(((file.name.lastIndexOf('.') - 1) >>> 0) + 2)
         .toLowerCase(),
@@ -138,7 +135,28 @@ export default class FilesManager extends Emitter {
     this.set('/items', this.state.items)
   }
 
+  /**
+   * @description push file to ipfs
+   * @param {Blob} file
+   * @param {AddOptions} options
+   */
+  async upload(file: Blob, options?: AddOptions): Promise<AddResult> {
+    return await (this.iridium.connector?.ipfs as IPFS).add(
+      blobToStream(file),
+      options,
+    )
+  }
+
+  /**
+   * @description unpin file from ipfs and remove from file system index
+   * @param {IridiumItem} item
+   */
   removeItem(item: IridiumItem) {
+    // if file, unpin from ipfs
+    if ('thumbnail' in item) {
+      // TODO - confirm this actually works when we can connect to ipfs
+      this.iridium.connector?.ipfs.pin.rm(item.id)
+    }
     // if root item
     if (!item.parentId) {
       const index = this.state.items.indexOf(item)
@@ -159,6 +177,12 @@ export default class FilesManager extends Emitter {
     this.set('/items', this.state.items)
   }
 
+  /**
+   * @description update item properties based on optional params
+   * @param {IridiumItem} item
+   * @param {string} name potential new name
+   * @param {boolean} liked new liked status
+   */
   updateItem({
     item,
     name,
@@ -184,9 +208,8 @@ export default class FilesManager extends Emitter {
   }
 
   /**
-   * @method download
    * @description fetch file from ipfs and download with streamsaver
-   * @param {string} path file path in bucket
+   * @param {string} path file cid
    * @param {string} name file name
    * @param {number} size file size to show progress in browser
    */
@@ -202,6 +225,21 @@ export default class FilesManager extends Emitter {
       writer.write(bytes)
     }
     writer.close()
+  }
+
+  /**
+   * @description fetch thumbnail from ipfs and return as blob
+   * @param {string} path thumbnail cid
+   * @returns {Promise<Blob>}
+   */
+  async fetchThumbnail(path: string, type?: FILE_TYPE): Promise<Blob> {
+    const data = []
+    for await (const bytes of (this.iridium.connector?.ipfs as IPFS).cat(
+      path,
+    )) {
+      data.push(bytes)
+    }
+    return new Blob(data, { type })
   }
 
   /**
@@ -242,23 +280,15 @@ export default class FilesManager extends Emitter {
       throw new Error(FileSystemErrors.INVALID)
     }
 
-    // if root directory
-    if (!parent) {
-      this.isDuplicateName(name)
-      return
-    }
-    // else, look inside children of current parent item
-    this.isDuplicateName(name, parent.children)
+    // if no parent, look at root, otherwise look at sibling items
+    this.isDuplicateName(name, !parent ? this.state.items : parent.children)
   }
 
   /**
    * @param {string} name new item name
-   * @param {IridiumItem[]} items default to root, sibling items will be provided for nested items
+   * @param {IridiumItem[]} items list of items to compare
    */
-  private isDuplicateName(
-    name: string,
-    items: IridiumItem[] = this.state.items,
-  ) {
+  private isDuplicateName(name: string, items: IridiumItem[]) {
     items.forEach((e) => {
       if (!e.name.localeCompare(name, undefined, { sensitivity: 'base' })) {
         throw new Error(FileSystemErrors.DUPLICATE_NAME)

--- a/libraries/Iridium/files/FilesManager.ts
+++ b/libraries/Iridium/files/FilesManager.ts
@@ -156,6 +156,9 @@ export default class FilesManager extends Emitter {
     if ('thumbnail' in item) {
       // TODO - confirm this actually works when we can connect to ipfs
       this.iridium.connector?.ipfs.pin.rm(item.id)
+      if (item.thumbnail) {
+        this.iridium.connector?.ipfs.pin.rm(item.thumbnail)
+      }
     }
     // if root item
     if (!item.parentId) {

--- a/libraries/Iridium/files/types.ts
+++ b/libraries/Iridium/files/types.ts
@@ -9,13 +9,13 @@ interface Shared {
   name: string
   liked: boolean
   shared: boolean
-  type: FILE_TYPE | DIRECTORY_TYPE
   modified: number
   size: number
   parentId: IridiumDirectory['id'] // empty string if root item
 }
 
 export interface IridiumFile extends Shared {
+  type: FILE_TYPE
   description?: string
   thumbnail: string
   extension: string
@@ -23,6 +23,7 @@ export interface IridiumFile extends Shared {
 }
 
 export interface IridiumDirectory extends Shared {
+  type: DIRECTORY_TYPE
   children: IridiumItem[]
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- if thumbnail can be created, upload to ipfs as a separate file. previously, we were storing base64 thumbnail inside the index. They would typically max out at a few kb, but this makes the index much more lightweight. It wasn't scalable before
- on delete, unpin both file and thumbnail (need to confirm this actually works, left todo)
- on mount, pull thumbnail blob and create object url for display
  - revoke object url beforeDestroy to avoid memory leaks
- add background color for blurred nsfw images, they were slightly translucent before
- removed jsdoc from self explanatory computed
- minor refactoring around upload logic to make it reusable for thumbnails

**Which issue(s) this PR fixes** 🔨
AP-1877
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
