### PR TITLE
feat(wallet): phantom integration on the Iridium-dev

### DIFF
--- a/libraries/BlockchainClient/BlockchainClient.ts
+++ b/libraries/BlockchainClient/BlockchainClient.ts
@@ -4,7 +4,6 @@ import {
   RpcResponseAndContext,
   SignatureResult,
 } from '@solana/web3.js'
-import SolanaAdapter from './adapters/SolanaAdapter'
 import {
   Account,
   Adapter,
@@ -17,20 +16,48 @@ import {
 
 export default class BlockchainClient {
   private static instance: BlockchainClient // eslint-disable-line no-use-before-define
-  private adapter: Adapter
+  private adapter: Adapter | null = null
   private _account?: Account
-  private _payerAccount?: Keypair
-
-  private constructor(adapter: Adapter) {
-    this.adapter = adapter
-  }
+  private _payerAccount?: Account
 
   public static getInstance(): BlockchainClient {
     if (!BlockchainClient.instance) {
-      BlockchainClient.instance = new BlockchainClient(new SolanaAdapter())
+      BlockchainClient.instance = new BlockchainClient()
     }
 
     return BlockchainClient.instance
+  }
+
+  /**
+   * @method _setAdapter
+   * Set adapter
+   * @param {Adapter} adapter
+   * @returns {void}
+   **/
+  setAdapter(adapter: Adapter): void {
+    this.adapter = adapter
+  }
+
+  /**
+   * @method _getAdapter
+   * Get adapter
+   * @returns {Adapter}
+   */
+  _getAdapter(): Adapter {
+    if (!this.adapter) {
+      throw new Error('Adapter is not set')
+    }
+    return this.adapter
+  }
+
+  /**
+   * @method signMessage
+   * Sign message
+   * @param {string} message
+   * @returns {Promise<Uint8Array>} signature
+   */
+  async signMessage(message: string): Promise<Uint8Array> {
+    return this._getAdapter().signMessage(message)
   }
 
   /**
@@ -48,11 +75,11 @@ export default class BlockchainClient {
 
   /**
    * @method getPayerAccount
-   * Returns the main account as a KeyPair object
-   * @returns {KeyPair}
+   * Returns the main account as a Account object
+   * @returns {Account}
    * @throws {Error} if account is not initialized
    * */
-  get payerAccount(): Keypair {
+  get payerAccount(): Account {
     if (!this._payerAccount) {
       throw new Error('PayerAccount is not initialized')
     }
@@ -73,17 +100,21 @@ export default class BlockchainClient {
    * @param {string} mnemonic
    * @returns {Promise<void>}
    */
-  async initFromMnemonic(mnemonic: string): Promise<void> {
-    await this.adapter.getAccountFromMnemonic(mnemonic).then((account) => {
-      if (account) {
-        this._account = account
-      }
-    })
-    await this.adapter.getActiveAccount().then((account) => {
-      if (account) {
-        this._payerAccount = account
-      }
-    })
+  async initFromMnemonic(mnemonic?: string): Promise<void> {
+    await this._getAdapter()
+      .getAccountFromMnemonic(mnemonic)
+      .then((account) => {
+        if (account) {
+          this._account = account
+        }
+      })
+    await this._getAdapter()
+      .getPayerAccount()
+      .then((account) => {
+        if (account) {
+          this._payerAccount = account
+        }
+      })
   }
 
   /**
@@ -92,7 +123,7 @@ export default class BlockchainClient {
    * @returns {Promise<void>}
    */
   async initRandom(): Promise<void> {
-    this._account = await this.adapter.createRandomAccount()
+    this._account = await this._getAdapter().createRandomAccount()
   }
 
   /**
@@ -108,7 +139,7 @@ export default class BlockchainClient {
     photoHash: string,
     status: string,
   ): Promise<boolean> {
-    return this.adapter.createUser({
+    return this._getAdapter().createUser({
       name,
       photoHash,
       status,
@@ -122,7 +153,7 @@ export default class BlockchainClient {
    * @param {string} photoHash profile picture IPFS hash
    */
   async setPhotoHash(photoHash: string): Promise<string> {
-    return this.adapter.setPhotoHash(photoHash)
+    return this._getAdapter().setPhotoHash(photoHash)
   }
 
   /**
@@ -132,7 +163,7 @@ export default class BlockchainClient {
    * @returns {Promise<User>} user object
    */
   getUser(address: string): Promise<User | null> {
-    return this.adapter.getUserInfo(address)
+    return this._getAdapter().getUserInfo(address)
   }
 
   /**
@@ -141,7 +172,16 @@ export default class BlockchainClient {
    * @returns User[]
    */
   getUsersInfo(addresses: string[]): Promise<User[]> {
-    return this.adapter.getUsersInfo(addresses)
+    return this._getAdapter().getUsersInfo(addresses)
+  }
+
+  /**
+   * @method getConnectionStatus
+   * Gets connection status, principally used with phantom wallet
+   * @returns boolean
+   */
+  getConnectionStatus(): boolean {
+    return this._getAdapter()._getConnectionStatus()
   }
 
   /**
@@ -150,7 +190,7 @@ export default class BlockchainClient {
    * @returns {Promise<User>} user object
    */
   async getCurrentUser(): Promise<User | null> {
-    return this.adapter.getUserInfo(this.account.address)
+    return this._getAdapter().getUserInfo(this.account.address)
   }
 
   /**
@@ -159,7 +199,7 @@ export default class BlockchainClient {
    * @returns {Promise<number | null>} balance amount or null
    */
   async getBalance(): Promise<number | null> {
-    return this.adapter.getAccountBalance(this.account)
+    return this._getAdapter().getAccountBalance(this.account)
   }
 
   /**
@@ -169,7 +209,7 @@ export default class BlockchainClient {
    * @returns {Promise<RpcResponseAndContext<SignatureResult> | null>}
    */
   async requestAirdrop(): Promise<RpcResponseAndContext<SignatureResult> | null> {
-    return this.adapter.requestAirdrop()
+    return this._getAdapter().requestAirdrop()
   }
 
   /**
@@ -179,11 +219,11 @@ export default class BlockchainClient {
    * @returns {Promise<User | null>}
    */
   async getCurrentUserInfo(): Promise<User | null> {
-    return this.adapter.getUserInfo(this.account.address)
+    return this._getAdapter().getUserInfo(this.account.address)
   }
 
   initUserProgram(): Promise<void> {
-    return this.adapter.initUserProgram()
+    return this._getAdapter().initUserProgram()
   }
 
   /**
@@ -193,7 +233,7 @@ export default class BlockchainClient {
    * @returns {Promise<User | null>}
    * */
   async getUserInfo(userAddress: string): Promise<User | null> {
-    return this.adapter.getUserInfo(userAddress)
+    return this._getAdapter().getUserInfo(userAddress)
   }
 
   /**
@@ -207,7 +247,7 @@ export default class BlockchainClient {
     type: FriendsEvents,
     callback: (data?: FriendAccount) => void,
   ): Promise<void> {
-    await this.adapter.addEventListener(type, callback)
+    await this._getAdapter().addEventListener(type, callback)
   }
 
   /**
@@ -219,7 +259,7 @@ export default class BlockchainClient {
   async getFriendsByStatus(
     status: FriendStatus,
   ): Promise<{ incoming: FriendAccount[]; outgoing: FriendAccount[] }> {
-    return this.adapter.getFriendsByStatus(status)
+    return this._getAdapter().getFriendsByStatus(status)
   }
 
   /**
@@ -227,7 +267,7 @@ export default class BlockchainClient {
    *  Subscribe to events
    */
   subscribeToEvents(): void {
-    this.adapter.subscribeToEvents()
+    this._getAdapter().subscribeToEvents()
   }
 
   /**
@@ -241,7 +281,7 @@ export default class BlockchainClient {
     from: PublicKey,
     to: PublicKey,
   ): Promise<{ request: PublicKey; first: PublicKey; second: PublicKey }> {
-    return this.adapter.computeAccountKeys(from, to)
+    return this._getAdapter().computeAccountKeys(from, to)
   }
 
   /**
@@ -249,8 +289,8 @@ export default class BlockchainClient {
    * Retrieve the active account from Solana wallet
    * @returns the payer account
    */
-  async getFriendsPayer(): Promise<Keypair> {
-    return this.adapter.getFriendsPayer()
+  async getFriendsPayer(): Promise<Account> {
+    return this._getAdapter().getFriendsPayer()
   }
 
   /**
@@ -259,7 +299,7 @@ export default class BlockchainClient {
    * @returns {Promise<FriendStatus>}
    */
   async getAccountStatus(accountKey: PublicKey): Promise<FriendStatus> {
-    return this.adapter.getAccountStatus(accountKey)
+    return this._getAdapter().getAccountStatus(accountKey)
   }
 
   /**
@@ -277,7 +317,7 @@ export default class BlockchainClient {
     second: PublicKey,
     k: String,
   ): Promise<string> {
-    return this.adapter.makeFriendRequest(request, first, second, k)
+    return this._getAdapter().makeFriendRequest(request, first, second, k)
   }
 
   /**
@@ -287,7 +327,7 @@ export default class BlockchainClient {
    * @returns the raw friend account object
    */
   async getFriendAccount(accountKey: PublicKey): Promise<FriendAccount | null> {
-    return this.adapter.getFriendAccount(accountKey)
+    return this._getAdapter().getFriendAccount(accountKey)
   }
 
   /**
@@ -298,7 +338,7 @@ export default class BlockchainClient {
    * @returns transaction hash of accept friend request
    */
   async acceptFriendRequest(request: PublicKey, k: String): Promise<string> {
-    return this.adapter.acceptFriendRequest(request, k)
+    return this._getAdapter().acceptFriendRequest(request, k)
   }
 
   /**
@@ -307,7 +347,7 @@ export default class BlockchainClient {
    * @param request friend request account public key
    */
   async removeFriendRequest(request: PublicKey): Promise<string> {
-    return this.adapter.removeFriendRequest(request)
+    return this._getAdapter().removeFriendRequest(request)
   }
 
   /**
@@ -317,7 +357,7 @@ export default class BlockchainClient {
    * @returns transaction hash string of deny friend request
    */
   async denyFriendRequest(request: PublicKey): Promise<string> {
-    return this.adapter.denyFriendRequest(request)
+    return this._getAdapter().denyFriendRequest(request)
   }
 
   /**
@@ -326,7 +366,7 @@ export default class BlockchainClient {
    * @param request friend request account public key
    */
   async removeFriend(friend: PublicKey): Promise<string> {
-    return this.adapter.removeFriend(friend)
+    return this._getAdapter().removeFriend(friend)
   }
 
   /**
@@ -335,7 +375,7 @@ export default class BlockchainClient {
    * @param request friend request account public key
    */
   async closeFriendRequest(request: PublicKey): Promise<string> {
-    return this.adapter.closeFriendRequest(request)
+    return this._getAdapter().closeFriendRequest(request)
   }
 
   /**
@@ -345,7 +385,7 @@ export default class BlockchainClient {
    * @param name Group name
    */
   async createGroup(groupId: string, name: string): Promise<Group> {
-    return this.adapter.createGroup(groupId, name)
+    return this._getAdapter().createGroup(groupId, name)
   }
 
   /**
@@ -355,13 +395,13 @@ export default class BlockchainClient {
    * @returns Promise<Group[]>
    */
   async getUserGroups(address: string | PublicKey): Promise<Group[]> {
-    return this.adapter.getUserGroups(address)
+    return this._getAdapter().getUserGroups(address)
   }
 
   async getGroupsUsers(
     groupIds: string[],
   ): Promise<{ id: string; users: string[] }[]> {
-    return this.adapter.getGroupsUsers(groupIds)
+    return this._getAdapter().getGroupsUsers(groupIds)
   }
 
   /**
@@ -371,7 +411,7 @@ export default class BlockchainClient {
    * @param recipient: recipient address
    */
   async inviteToGroup(groupId: string, recipient: string): Promise<void> {
-    await this.adapter.inviteToGroup(groupId, recipient)
+    await this._getAdapter().inviteToGroup(groupId, recipient)
   }
 
   /**
@@ -380,7 +420,7 @@ export default class BlockchainClient {
    * @param cb
    */
   async addGroupInviteListener(cb: (group: Group) => void): Promise<string> {
-    return this.adapter.addGroupInviteListener(cb)
+    return this._getAdapter().addGroupInviteListener(cb)
   }
 
   /**
@@ -390,7 +430,7 @@ export default class BlockchainClient {
    * @returns Promise<void>
    */
   async unsubscribeGroupInvite(id: number): Promise<void> {
-    return this.adapter.unsubscribeGroupInviteListener(id)
+    return this._getAdapter().unsubscribeGroupInviteListener(id)
   }
 
   /**
@@ -404,7 +444,7 @@ export default class BlockchainClient {
     id: string,
     cb: (value: Group) => void,
   ): Promise<string> {
-    return this.adapter.addGroupListener(id, cb)
+    return this._getAdapter().addGroupListener(id, cb)
   }
 
   /**
@@ -412,7 +452,7 @@ export default class BlockchainClient {
    * @param keys
    */
   async removeGroupListeners(keys: string[]): Promise<void> {
-    return this.adapter.removeGroupListeners(keys)
+    return this._getAdapter().removeGroupListeners(keys)
   }
 
   /**
@@ -422,7 +462,7 @@ export default class BlockchainClient {
    * @returns Promise<Group>
    */
   async getGroupById(groupId: string): Promise<Group> {
-    return this.adapter.getGroupById(groupId)
+    return this._getAdapter().getGroupById(groupId)
   }
 
   /**
@@ -431,7 +471,7 @@ export default class BlockchainClient {
    * @returns Promise<string[]> array of user addresses
    */
   async getGroupUsers(groupId: string): Promise<string[]> {
-    return this.adapter.getGroupUsers(groupId)
+    return this._getAdapter().getGroupUsers(groupId)
   }
 
   /**
@@ -440,6 +480,6 @@ export default class BlockchainClient {
    * @returns {string[]} array of addresses for unsubscribe
    */
   addGroupsListener(cb: (value: Group) => void): Promise<string[]> {
-    return this.adapter.addGroupsListener(cb)
+    return this._getAdapter().addGroupsListener(cb)
   }
 }

--- a/libraries/BlockchainClient/adapters/Phantom/PhantomAdapter.ts
+++ b/libraries/BlockchainClient/adapters/Phantom/PhantomAdapter.ts
@@ -1,0 +1,284 @@
+import {
+  RpcResponseAndContext,
+  SignatureResult,
+  Keypair,
+  PublicKey,
+} from '@solana/web3.js'
+
+import {
+  Account,
+  Adapter,
+  CreateUserParams,
+  FriendAccount,
+  FriendsEvents,
+  FriendStatus,
+  Group,
+  User,
+} from '../../interfaces'
+
+import PhantomManager from '~/libraries/Phantom/PhantomManager'
+import PhantomUser from '~/libraries/Phantom/PhantomUser'
+import PhantomFriend from '~/libraries/Phantom/PhantomFriends'
+import PhantomGroup from '~/libraries/Phantom/PhantomGroup'
+
+export default class PhantomAdapter implements Adapter {
+  private readonly $PhantomManager: PhantomManager = new PhantomManager()
+  private phantomUser: PhantomUser | null = null
+  private phantomFriend: PhantomFriend | null = null
+  private phantomGroup: PhantomGroup | null = null
+
+  constructor() {
+    this.$PhantomManager = new PhantomManager()
+  }
+
+  initUserProgram(): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+
+  _getPhantomUser(): PhantomUser {
+    if (!this.phantomUser) {
+      if (this.$PhantomManager.getAdapter().connected) {
+        this.phantomUser = new PhantomUser(this.$PhantomManager)
+        return this.phantomUser
+      }
+      throw new Error('Phantom user is not initialized')
+    }
+    return this.phantomUser
+  }
+
+  _getPhantomFriend(): PhantomFriend {
+    if (!this.phantomFriend) {
+      if (this.$PhantomManager.getAdapter().connected) {
+        this.phantomFriend = new PhantomFriend(this.$PhantomManager)
+        return this.phantomFriend
+      }
+      throw new Error('Phantom friend is not initialized')
+    }
+    return this.phantomFriend
+  }
+
+  _getPhantomGroup(): PhantomGroup {
+    if (!this.phantomGroup) {
+      if (this.$PhantomManager.getAdapter().connected) {
+        this.phantomGroup = new PhantomGroup(this.$PhantomManager)
+        return this.phantomGroup
+      }
+      throw new Error('Phantom group is not initialized')
+    }
+    return this.phantomGroup
+  }
+
+  _getConnectionStatus(): boolean {
+    return this.$PhantomManager.$PhantomWalletAdapter.connected
+  }
+
+  async signMessage(_message: string): Promise<Uint8Array> {
+    return this.$PhantomManager.signMessage(_message)
+  }
+
+  async setPhotoHash(_photoHash: string): Promise<string> {
+    return await this._getPhantomUser().setPhotoHash(_photoHash)
+  }
+
+  createRandomAccount(): Promise<Account | undefined> {
+    throw new Error('Method not implemented.')
+  }
+
+  // here we don't need the mnemonic, since this function only triggers the wallet connection
+  async getAccountFromMnemonic(_mnemonic?: string): Promise<Account | null> {
+    try {
+      await this.$PhantomManager.initWallet()
+      const account: Account = {
+        address: this.$PhantomManager.getwalletPublicKey().toBase58(),
+        publicKey: this.$PhantomManager.getwalletPublicKey(),
+      }
+      return account
+    } catch (e) {
+      return null
+    }
+  }
+
+  async getAccountBalance(_account: Account): Promise<number | null> {
+    return await this.$PhantomManager.getCurrentAccountBalance()
+  }
+
+  requestAirdrop(): Promise<RpcResponseAndContext<SignatureResult> | null> {
+    throw new Error('This method dose not exist in Phantom')
+  }
+
+  async createUser(_params: CreateUserParams): Promise<boolean> {
+    if (_params) {
+      this._getPhantomUser().create(
+        _params.name,
+        _params.photoHash,
+        _params.status,
+      )
+      return true
+    }
+    return false
+  }
+
+  async getActiveAccount(): Promise<Account | undefined> {
+    if (this._getConnectionStatus()) {
+      return {
+        address: this.$PhantomManager.getwalletPublicKey().toBase58(),
+        publicKey: this.$PhantomManager.getwalletPublicKey(),
+      }
+    }
+    return undefined
+  }
+
+  async getCurrentUserInfo(): Promise<User | null> {
+    return await this._getPhantomUser().getCurrentUserInfo()
+  }
+
+  async getUserInfo(_address: string): Promise<User | null> {
+    try {
+      const e = await this._getPhantomUser().getUserInfo(_address)
+      return e
+    } catch (e) {
+      return null
+    }
+  }
+
+  async getUsersInfo(_addresses: string[]): Promise<User[]> {
+    try {
+      const users = await this._getPhantomUser().getUsersInfo(_addresses)
+      return users.map(
+        (user) =>
+          <User>{
+            ...user,
+          },
+      )
+    } catch (e) {
+      throw new Error("Couldn't get users info")
+    }
+  }
+
+  async getFriendsByStatus(
+    _status: FriendStatus,
+  ): Promise<{ incoming: FriendAccount[]; outgoing: FriendAccount[] }> {
+    return await this._getPhantomFriend().getAccountsByStatus(_status)
+  }
+
+  async subscribeToEvents(): Promise<void> {
+    this._getPhantomFriend().subscribeToEvents()
+  }
+
+  addEventListener(
+    _type: FriendsEvents,
+    _callback: (data?: FriendAccount | undefined) => void,
+  ): void {
+    this._getPhantomFriend().addEventListener(_type, _callback)
+  }
+
+  async computeAccountKeys(
+    _from: PublicKey,
+    _to: PublicKey,
+  ): Promise<{ request: PublicKey; first: PublicKey; second: PublicKey }> {
+    return this._getPhantomFriend().computeAccountKeys(_from, _to)
+  }
+
+  async getFriendsPayer(): Promise<Account> {
+    const account = await this.getActiveAccount()
+    if (!account) throw new Error('No account found')
+    return account
+  }
+
+  getAccountStatus(_accountKey: PublicKey): Promise<FriendStatus> {
+    return this._getPhantomFriend().getAccountStatus(_accountKey)
+  }
+
+  async makeFriendRequest(
+    _request: PublicKey,
+    _first: PublicKey,
+    _second: PublicKey,
+    _k: String,
+  ): Promise<string> {
+    return await this._getPhantomFriend().makeRequest(
+      _request,
+      _first,
+      _second,
+      _k,
+    )
+  }
+
+  async getFriendAccount(
+    _accountKey: PublicKey,
+  ): Promise<FriendAccount | null> {
+    return await this._getPhantomFriend().getAccount(_accountKey)
+  }
+
+  async acceptFriendRequest(_request: PublicKey, _k: String): Promise<string> {
+    return await this._getPhantomFriend().acceptRequest(_request, _k)
+  }
+
+  async denyFriendRequest(_request: PublicKey): Promise<string> {
+    return await this._getPhantomFriend().denyRequest(_request)
+  }
+
+  async removeFriendRequest(_request: PublicKey): Promise<string> {
+    return await this._getPhantomFriend().removeRequest(_request)
+  }
+
+  async removeFriend(_request: PublicKey): Promise<string> {
+    return await this._getPhantomFriend().removeFriend(_request)
+  }
+
+  async closeFriendRequest(_request: PublicKey): Promise<string> {
+    return await this._getPhantomFriend().closeRequest(_request)
+  }
+
+  async getPayerAccount(): Promise<Account | undefined> {
+    return await this.getActiveAccount()
+  }
+
+  async createGroup(_groupId: string, _name: string): Promise<Group> {
+    return await this._getPhantomGroup().create(_groupId, _name)
+  }
+
+  async getUserGroups(_address: string | PublicKey): Promise<Group[]> {
+    return await this._getPhantomGroup().getUserGroups(_address)
+  }
+
+  async getGroupsUsers(
+    _groupIds: string[],
+  ): Promise<{ id: string; users: string[] }[]> {
+    return await this._getPhantomGroup().getGroupsUsers(_groupIds)
+  }
+
+  async inviteToGroup(_groupId: string, _recipient: string): Promise<void> {
+    return await this._getPhantomGroup().invite(_groupId, _recipient)
+  }
+
+  async addGroupInviteListener(_cb: (group: Group) => void): Promise<string> {
+    return this._getPhantomGroup().addInviteListener(_cb)
+  }
+
+  unsubscribeGroupInviteListener(_id: number): Promise<void> {
+    return this._getPhantomGroup().unsubscribe(_id)
+  }
+
+  async addGroupListener(
+    _id: string,
+    _cb: (value: Group) => void,
+  ): Promise<string> {
+    return this._getPhantomGroup().addGroupListener(_id, _cb)
+  }
+
+  removeGroupListeners(_keys: string[]): Promise<void> {
+    return this._getPhantomGroup().removeGroupListeners(_keys)
+  }
+
+  getGroupById(_id: string): Promise<Group> {
+    return this._getPhantomGroup().getGroupById(_id)
+  }
+
+  getGroupUsers(_groupId: string): Promise<string[]> {
+    return this._getPhantomGroup().getGroupUsers(_groupId)
+  }
+
+  addGroupsListener(_cb: (value: Group) => void): Promise<string[]> {
+    return this._getPhantomGroup().addGroupsListener(_cb)
+  }
+}

--- a/libraries/BlockchainClient/adapters/SolanaAdapter/SolanaAdapter.ts
+++ b/libraries/BlockchainClient/adapters/SolanaAdapter/SolanaAdapter.ts
@@ -4,6 +4,7 @@ import {
   RpcResponseAndContext,
   SignatureResult,
 } from '@solana/web3.js'
+import nacl from 'tweetnacl'
 import {
   Account,
   Adapter,
@@ -12,7 +13,11 @@ import {
   User,
   Group,
 } from '../../interfaces'
-import { accountFromWallet, walletFromAccount } from './utils'
+import {
+  accountFromKeyapair,
+  accountFromWallet,
+  walletFromAccount,
+} from './utils'
 import SolanaManager from '~/libraries/Solana/SolanaManager/SolanaManager'
 import FriendsProgram from '~/libraries/Solana/FriendsProgram/FriendsProgram'
 import GroupChatsProgram from '~/libraries/Solana/GroupChatsProgram/GroupChatsProgram'
@@ -22,7 +27,6 @@ import {
 } from '~/libraries/Solana/FriendsProgram/FriendsProgram.types'
 import { AccountsError } from '~/store/accounts/types'
 import UsersProgram from '~/libraries/Solana/UsersProgram/UsersProgram'
-
 export default class SolanaAdapter implements Adapter {
   private readonly solanaManager: SolanaManager
   private usersProgram: UsersProgram | null = null
@@ -32,6 +36,23 @@ export default class SolanaAdapter implements Adapter {
   constructor() {
     this.solanaManager = new SolanaManager()
     this.usersProgram = null
+  }
+
+  async signMessage(message: string): Promise<Uint8Array> {
+    const messageBytes = Buffer.from(message, 'utf8')
+    const wallet = await this.getPayerAccount()
+    if (!wallet?.secretKey) {
+      throw new Error(AccountsError.PAYER_NOT_PRESENT)
+    }
+    // eslint-disable-next-line import/no-named-as-default-member
+    return nacl.sign.detached(messageBytes, wallet?.secretKey)
+  }
+
+  _getConnectionStatus(): boolean {
+    if (this.solanaManager.isInitialized()) {
+      return true
+    }
+    return false
   }
 
   get friendsProgram(): FriendsProgram {
@@ -74,7 +95,10 @@ export default class SolanaAdapter implements Adapter {
     return this.solanaManager.getCurrentAccountBalance()
   }
 
-  async getAccountFromMnemonic(mnemonic: string): Promise<Account | null> {
+  async getAccountFromMnemonic(mnemonic?: string): Promise<Account | null> {
+    if (!mnemonic) {
+      throw new Error('Mnemonic is required when working with Solana directly')
+    }
     await this.solanaManager.initializeFromMnemonic(mnemonic)
     const wallet = this.solanaManager.getMainSolanaWalletInstance()
     if (wallet) {
@@ -140,8 +164,9 @@ export default class SolanaAdapter implements Adapter {
     }
   }
 
-  async getActiveAccount(): Promise<Keypair | undefined> {
-    return this.solanaManager.getActiveAccount()
+  async getActiveAccount(): Promise<Account | undefined> {
+    const account = this.solanaManager.getActiveAccount()
+    return !account ? undefined : accountFromKeyapair(account)
   }
 
   async getCurrentUserInfo(): Promise<User | null> {
@@ -155,8 +180,9 @@ export default class SolanaAdapter implements Adapter {
     return null
   }
 
-  async getPayerAccount(): Promise<Keypair | undefined> {
-    return this.solanaManager.payerAccount
+  async getPayerAccount(): Promise<Account | undefined> {
+    const account = this.solanaManager.payerAccount
+    return !account ? undefined : accountFromKeyapair(account)
   }
 
   async setPhotoHash(photoHash: string): Promise<string> {
@@ -194,8 +220,8 @@ export default class SolanaAdapter implements Adapter {
     return await this.friendsProgram.computeAccountKeys(from, to)
   }
 
-  async getFriendsPayer(): Promise<Keypair> {
-    return this.friendsProgram.getPayer()
+  async getFriendsPayer(): Promise<Account> {
+    return accountFromKeyapair(this.friendsProgram.getPayer())
   }
 
   async getAccountStatus(accountKey: PublicKey): Promise<FriendStatus> {

--- a/libraries/BlockchainClient/adapters/SolanaAdapter/utils.test.ts
+++ b/libraries/BlockchainClient/adapters/SolanaAdapter/utils.test.ts
@@ -1,6 +1,6 @@
 import * as utils from '~/libraries/BlockchainClient/adapters/SolanaAdapter/utils'
 
-describe('utils.accountFromWallet', () => {
+describe.skip('utils.accountFromWallet', () => {
   test('0', () => {
     const result: any = utils.accountFromWallet({
       keypair: { secretKey: '$p3onyycat' },

--- a/libraries/BlockchainClient/adapters/SolanaAdapter/utils.ts
+++ b/libraries/BlockchainClient/adapters/SolanaAdapter/utils.ts
@@ -9,6 +9,8 @@ export const accountFromWallet = (wallet: SolanaWallet): Account => {
     address: wallet.address,
     mnemonic: wallet.mnemonic,
     path: wallet.path,
+    publicKey: wallet.keypair.publicKey,
+    secretKey: wallet.keypair.secretKey,
   }
 }
 
@@ -17,6 +19,7 @@ export const publicKeyFromAddress = (address: string): PublicKey => {
 }
 
 export const walletFromAccount = (account: Account): SolanaWallet => {
+  if (!account.privateKey) throw new Error('Account must have a private key')
   const keyPair = Keypair.fromSecretKey(base58decode(account.privateKey), {
     skipValidation: true,
   })
@@ -25,5 +28,16 @@ export const walletFromAccount = (account: Account): SolanaWallet => {
     address: account.address,
     mnemonic: account.mnemonic,
     path: account.path,
+  }
+}
+
+export const accountFromKeyapair = (keypair: Keypair): Account => {
+  return {
+    privateKey: base58encode(keypair.secretKey),
+    address: keypair.publicKey.toBase58(),
+    publicKey: keypair.publicKey,
+    secretKey: keypair.secretKey,
+    mnemonic: '',
+    path: '',
   }
 }

--- a/libraries/BlockchainClient/interfaces.ts
+++ b/libraries/BlockchainClient/interfaces.ts
@@ -5,6 +5,7 @@ import {
   PublicKey,
   ConfirmOptions,
 } from '@solana/web3.js'
+import { PrivateKey } from '@textile/hub'
 
 export interface RawUser {
   name: string
@@ -36,8 +37,10 @@ export interface Group {
 
 export interface Account {
   mnemonic?: string
-  privateKey: string
+  privateKey?: string
   path?: string
+  publicKey: PublicKey
+  secretKey?: Uint8Array
   address: string
 }
 
@@ -122,14 +125,17 @@ export interface OutgoingFriendRequest extends FriendAccount {
 }
 
 export interface Adapter {
+  _getConnectionStatus(): boolean
+  initUserProgram(): Promise<void>
   setPhotoHash(photoHash: string): Promise<string>
   createRandomAccount(): Promise<Account | undefined>
-  initUserProgram(): Promise<void>
-  getAccountFromMnemonic(mnemonic: string): Promise<Account | null>
+  signMessage(message: string): Promise<Uint8Array>
+
+  getAccountFromMnemonic(mnemonic?: string): Promise<Account | null>
   getAccountBalance(account: Account): Promise<number | null>
   requestAirdrop(): Promise<RpcResponseAndContext<SignatureResult> | null>
   createUser(params: CreateUserParams): Promise<boolean>
-  getActiveAccount(): Promise<Keypair | undefined>
+  getActiveAccount(): Promise<Account | undefined>
 
   getCurrentUserInfo(): Promise<User | null>
   getUserInfo(address: string): Promise<User | null>
@@ -147,7 +153,7 @@ export interface Adapter {
     from: PublicKey,
     to: PublicKey,
   ): Promise<{ request: PublicKey; first: PublicKey; second: PublicKey }>
-  getFriendsPayer(): Promise<Keypair>
+  getFriendsPayer(): Promise<Account>
   getAccountStatus(accountKey: PublicKey): Promise<FriendStatus>
   makeFriendRequest(
     request: PublicKey,
@@ -162,7 +168,7 @@ export interface Adapter {
   removeFriend(request: PublicKey): Promise<string>
   closeFriendRequest(request: PublicKey): Promise<string>
 
-  getPayerAccount(): Promise<Keypair | undefined>
+  getPayerAccount(): Promise<Account | undefined>
   createGroup(groupId: string, name: string): Promise<Group>
   getUserGroups(address: string | PublicKey): Promise<Group[]>
   getGroupsUsers(groupIds: string[]): Promise<{ id: string; users: string[] }[]>

--- a/libraries/Iridium/IridiumManager.ts
+++ b/libraries/Iridium/IridiumManager.ts
@@ -9,6 +9,7 @@ import logger from '~/plugins/local/logger'
 import { Config } from '~/config'
 import FilesManager from '~/libraries/Iridium/files/FilesManager'
 import SettingsManager from '~/libraries/Iridium/settings/SettingsManager'
+import Crypto from '~/libraries/Crypto/Crypto'
 
 export class IridiumManager extends Emitter {
   ready: boolean = false
@@ -44,6 +45,73 @@ export class IridiumManager extends Emitter {
     }
 
     const seed = await IdentityManager.seedFromWallet(pass, wallet)
+    this.connector = await Iridium.fromSeed(seed, {
+      logger,
+      config: {
+        syncNodes: Config.iridium.syncNodes,
+        ipfs: Config.iridium.ipfs,
+      },
+    })
+
+    logger.log('iridium/manager', 'connector initialized', {
+      id: this.connector.id,
+      peerId: this.connector.peerId,
+    })
+
+    logger.log('iridium/manager', 'starting IPFS')
+    await this.connector.start()
+
+    // check for existing root document
+    let doc = (await this.connector.get('/')) || {}
+    if (!doc.id) {
+      logger.log('iridium/manager', 'creating new root document', doc)
+      doc = {
+        id: this.connector.id,
+        profile: { name: 'guest' },
+        groups: {},
+        friends: {},
+        conversations: {},
+        files: {},
+        settings: {},
+        indexes: {},
+      }
+    } else {
+      logger.log('iridium/manager', 'loaded root document', doc)
+    }
+    doc.seen = Date.now()
+    await this.connector.set('/', doc)
+
+    logger.log('iridium/manager', 'initializing profile')
+    await this.profile.init()
+    logger.log('iridium/manager', 'initializing groups')
+    await this.groups.init()
+    logger.log('iridium/friends', 'initializing friends')
+    await this.friends.init()
+    logger.log('iridium/manager', 'initializing chat')
+    await this.chat.init()
+    logger.log('iridium/manager', 'initializing files')
+    await this.files.init()
+    logger.log('iridium/manager', 'initializing settings')
+    await this.settings.init()
+    logger.log('iridium/manager', 'ready')
+
+    this.ready = true
+  }
+
+  /**
+   * @method
+   * Initialization function that creates a Textile identity
+   * and initializes the Mailbox
+   * @param param0 Textile Configuration that includes id, password and SolanaWallet instance
+   * @returns a promise that resolves when the initialization completes
+   */
+  async initFromEntropy(entropy: Uint8Array) {
+    logger.log('iridium/manager', 'init()')
+    if (!entropy) {
+      throw new Error('Entropy not valid')
+    }
+
+    const seed = await Crypto.sha256(entropy)
     this.connector = await Iridium.fromSeed(seed, {
       logger,
       config: {

--- a/libraries/Phantom/PhantomFriends.ts
+++ b/libraries/Phantom/PhantomFriends.ts
@@ -1,0 +1,685 @@
+import { EventEmitter } from 'events'
+import { Program, utils, IdlTypes } from '@project-serum/anchor'
+
+import {
+  GetProgramAccountsFilter,
+  KeyedAccountInfo,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+} from '@solana/web3.js'
+import { TypeDef } from '@project-serum/anchor/dist/cjs/program/namespace/types'
+import base58 from 'micro-base58'
+import {
+  FriendAccount,
+  FriendsEvents,
+  FriendStatus,
+} from '../Solana/FriendsProgram/FriendsProgram.types'
+import { Friends, IDL } from '../Solana/FriendsProgram/FriendsProgram.idl'
+import { Config } from '../../config'
+import PhantomManager from './PhantomManager'
+
+export const FRIENDS_PROGRAM_ID = new PublicKey(
+  Config.solana.friendsProgramExId,
+)
+
+export default class PhantomFriends extends EventEmitter {
+  phantomManager?: PhantomManager
+  program?: Program<Friends>
+  subscriptions?: { [eventName: string]: number }
+
+  constructor(phantomManager: PhantomManager) {
+    super()
+    if (phantomManager) {
+      this.init(phantomManager)
+    }
+  }
+
+  init(phantomManager: PhantomManager) {
+    this.phantomManager = phantomManager
+
+    const provider = this._getPhantomManager()._getProvider()
+
+    this.program = new Program<Friends>(IDL, FRIENDS_PROGRAM_ID, provider)
+  }
+
+  /**
+   * @method _getPhantomManager
+   * Retrieve the phantom manager instance
+   */
+  protected _getPhantomManager() {
+    if (!this.phantomManager) {
+      throw new Error('Phantom Manager not initialized')
+    }
+    return this.phantomManager
+  }
+
+  /**
+   * @method _getProgram
+   * Returns the anchor program instance for group chat
+   * @returns the anchor program instance
+   */
+  protected _getProgram() {
+    if (!this.program) {
+      throw new Error('Group Chat Manager not initialized')
+    }
+
+    return this.program
+  }
+
+  /**
+   * @method _getPayer
+   * Retrieve the active account from Solana wallet
+   * @returns the payer account
+   */
+  protected _getPayer() {
+    const payer = this._getPhantomManager().getwalletPublicKey()
+    if (!payer) {
+      throw new Error('Missing payer')
+    }
+
+    return payer
+  }
+
+  /**
+   * @method _parseAccount
+   * Parse the account as FriendAccount
+   * @param account
+   * @returns the account
+   */
+  protected _parseAccount({
+    publicKey,
+    account,
+  }: {
+    publicKey: PublicKey
+    account: TypeDef<Friends['accounts'][0], IdlTypes<Friends>>
+  }): FriendAccount {
+    const {
+      from,
+      to,
+      status: statusObject,
+      fromEncryptedKey,
+      toEncryptedKey,
+    }: {
+      from: PublicKey
+      to: PublicKey
+      status: any
+      fromEncryptedKey: any
+      toEncryptedKey: any
+    } = account
+    const status = statusObject.pending
+      ? FriendStatus.PENDING
+      : statusObject.accepted
+      ? FriendStatus.ACCEPTED
+      : statusObject.denied
+      ? FriendStatus.DENIED
+      : statusObject.removed
+      ? FriendStatus.REMOVED
+      : FriendStatus.UNINITIALIZED
+    return {
+      accountId: publicKey.toString(),
+      from: from.toString(),
+      status,
+      to: to.toString(),
+      fromMailboxId: fromEncryptedKey as string,
+      toMailboxId: toEncryptedKey as string,
+    }
+  }
+
+  /**
+   * @method makeRequest
+   * Make friend request
+   * @param request friend request account publickey
+   * @param first sender or recipient public key, whichever is greater (in bytes)
+   * @param second sender or recipient public key, whichever is smaller (in bytes)
+   * @param k textile encryption key for sender
+   * @returns transaction hash string of make friend request
+   */
+  async makeRequest(
+    request: PublicKey,
+    first: PublicKey,
+    second: PublicKey,
+    k: String,
+  ) {
+    const program = this._getProgram()
+
+    const payer = this._getPayer()
+
+    // Throws if Adapter is not set
+    const $PhantomWalletAdapter = this._getPhantomManager().getAdapter()
+
+    const tx = program.transaction.makeRequest(first, second, k, {
+      accounts: {
+        request,
+        user: payer,
+        payer,
+        systemProgram: SystemProgram.programId,
+      },
+    })
+
+    tx.recentBlockhash = (
+      await this._getPhantomManager().connection.getLatestBlockhash()
+    ).blockhash
+
+    tx.feePayer = payer
+    const signed = await $PhantomWalletAdapter?.signTransaction(tx)
+    const sent = await $PhantomWalletAdapter?.sendTransaction(
+      signed,
+      this._getPhantomManager().connection,
+    )
+
+    return sent
+  }
+
+  /**
+   * @method denyRequest
+   * Deny friend request
+   * @param request friend request account public key
+   * @returns transaction hash string of deny friend request
+   */
+  async denyRequest(request: PublicKey) {
+    const program = this._getProgram()
+
+    const payer = this._getPayer()
+
+    // Throws if Adapter is not set
+    const $PhantomWalletAdapter = this._getPhantomManager().getAdapter()
+
+    const tx = program.transaction.denyRequest({
+      accounts: {
+        request,
+        user: payer,
+      },
+    })
+    tx.recentBlockhash = (
+      await this._getPhantomManager().connection.getLatestBlockhash()
+    ).blockhash
+
+    tx.feePayer = payer
+    const signed = await $PhantomWalletAdapter?.signTransaction(tx)
+    const sent = await $PhantomWalletAdapter?.sendTransaction(
+      signed,
+      this._getPhantomManager().connection,
+    )
+
+    return sent
+  }
+
+  /**
+   * @method acceptRequest
+   * Accept friend request
+   * @param request friend request account public key
+   * @param k textile encryption key for recipient
+   * @returns transaction hash of accept friend request
+   */
+  async acceptRequest(request: PublicKey, k: String) {
+    const program = this._getProgram()
+
+    const payer = this._getPayer()
+
+    // Throws if Adapter is not set
+    const $PhantomWalletAdapter = this._getPhantomManager().getAdapter()
+
+    const tx = program.transaction.acceptRequest(k, {
+      accounts: {
+        request,
+        user: payer,
+      },
+    })
+
+    tx.feePayer = payer
+    const signed = await $PhantomWalletAdapter?.signTransaction(tx)
+    const sent = await $PhantomWalletAdapter?.sendTransaction(
+      signed,
+      this._getPhantomManager().connection,
+    )
+
+    return sent
+  }
+
+  /**
+   * @method removeRequest
+   * Remove friend request
+   * @param request friend request account public key
+   */
+  async removeRequest(request: PublicKey) {
+    const program = this._getProgram()
+
+    const payer = this._getPayer()
+
+    // Throws if Adapter is not set
+    const $PhantomWalletAdapter = this._getPhantomManager().getAdapter()
+
+    const tx = program.transaction.removeRequest({
+      accounts: {
+        request,
+        user: payer,
+      },
+    })
+
+    tx.feePayer = payer
+    const signed = await $PhantomWalletAdapter?.signTransaction(tx)
+    const sent = await $PhantomWalletAdapter?.sendTransaction(
+      signed,
+      this._getPhantomManager().connection,
+    )
+
+    return sent
+  }
+
+  /**
+   * @method closeRequest
+   * Close friend request from sender's side
+   * @param request friend request account public key
+   */
+  async closeRequest(request: PublicKey) {
+    const program = this._getProgram()
+
+    const payer = this._getPayer()
+
+    // Throws if Adapter is not set
+    const $PhantomWalletAdapter = this._getPhantomManager().getAdapter()
+
+    const tx = program.transaction.closeRequest({
+      accounts: {
+        request,
+        user: payer,
+        payer,
+      },
+    })
+
+    tx.feePayer = payer
+    const signed = await $PhantomWalletAdapter?.signTransaction(tx)
+    const sent = await $PhantomWalletAdapter?.sendTransaction(
+      signed,
+      this._getPhantomManager().connection,
+    )
+
+    return sent
+  }
+
+  /**
+   * @method removeFriend
+   * Remove friend
+   * @param request friend request account public key
+   */
+  async removeFriend(request: PublicKey) {
+    const program = this._getProgram()
+
+    const payer = this._getPayer()
+
+    // Throws if Adapter is not set
+    const $PhantomWalletAdapter = this._getPhantomManager().getAdapter()
+
+    const tx = program.transaction.removeFriend({
+      accounts: {
+        request,
+        user: payer,
+      },
+    })
+
+    tx.feePayer = payer
+    const signed = await $PhantomWalletAdapter?.signTransaction(tx)
+    const sent = await $PhantomWalletAdapter?.sendTransaction(
+      signed,
+      this._getPhantomManager().connection,
+    )
+
+    return sent
+  }
+
+  /**
+   * @method removeFriendAndCloseAccount
+   * Remove friend and close friend request account
+   * @param request friend request account public key
+   * @param closeAccountAndRefund original sender public key to refund after closing the account
+   */
+  async removeFriendAndCloseAccount(
+    request: PublicKey,
+    closeAccountAndRefund?: PublicKey,
+  ) {
+    const program = this._getProgram()
+
+    const payer = this._getPayer()
+
+    // Throws if Adapter is not set
+    const $PhantomWalletAdapter = this._getPhantomManager().getAdapter()
+
+    const removeFriendInstruction = program.instruction.removeFriend({
+      accounts: {
+        request,
+        user: payer,
+      },
+    })
+
+    const atomicTransaction = new Transaction()
+
+    atomicTransaction.add(removeFriendInstruction)
+
+    if (closeAccountAndRefund) {
+      const closeRequestInstruction = program.instruction.closeRequest({
+        accounts: {
+          request,
+          user: payer,
+          payer: closeAccountAndRefund,
+        },
+      })
+
+      atomicTransaction.add(closeRequestInstruction)
+    }
+
+    atomicTransaction.feePayer = payer
+    const signed = await $PhantomWalletAdapter?.signTransaction(
+      atomicTransaction,
+    )
+
+    const sent = await $PhantomWalletAdapter?.sendTransaction(
+      signed,
+      this._getPhantomManager().connection,
+    )
+
+    return sent
+  }
+
+  /**
+   * @method computeAccountKeys
+   * Computes the friend account public key from 2 given public keys
+   * @param from the public key to be used at position 0
+   * @param to the public key to be used at position 1
+   * @returns the computed public key
+   */
+  public computeAccountKeys(from: PublicKey, to: PublicKey) {
+    const program = this._getProgram()
+
+    const [first, second] = [from, to].sort((a: PublicKey, b: PublicKey) => {
+      const aValue = parseInt(a.toBuffer().toString('hex'), 16)
+      const bValue = parseInt(b.toBuffer().toString('hex'), 16)
+      return bValue - aValue
+    })
+
+    const request = utils.publicKey.findProgramAddressSync(
+      [first.toBuffer(), second.toBuffer()],
+      program.programId,
+    )
+    return { request: request[0], first, second }
+  }
+
+  /**
+   * @method getIncomingAccountsByStatus
+   * Gets all incoming friend accounts related to the program, filtered by the given status code
+   * @param status the status code to filter
+   * (0 not assigned, 1 pending, 2 accepted, 3 refused, 4 removed)
+   * @returns a list of incoming filtered by status
+   */
+  async getIncomingAccountsByStatus(
+    status: FriendStatus,
+  ): Promise<FriendAccount[]> {
+    const program = this._getProgram()
+
+    const payer = this._getPayer()
+
+    const statusAndToKey = base58(Buffer.from([status, ...payer.toBytes()]))
+
+    try {
+      const incomingTemp = await program.account.friendRequest.all([
+        {
+          memcmp: { offset: 32 + 8, bytes: statusAndToKey },
+        },
+      ])
+    } catch (e) {
+      window.console.log(e)
+    }
+
+    const incomingTemp = await program.account.friendRequest.all([
+      {
+        memcmp: { offset: 32 + 8, bytes: statusAndToKey },
+      },
+    ])
+    const incoming = incomingTemp.map(this._parseAccount)
+    return incoming
+  }
+
+  /**
+   * @method getOutgoingAccountsByStatus
+   * Gets all outgoing friend accounts related to the program, filtered by given status code
+   * @param status the status code to filter
+   * (0 not assigned, 1 pending, 2 accepted, 3 refused, 4 removed)
+   * @returns a list of outgoing filtered by status
+   */
+  async getOutgoingAccountsByStatus(
+    status: FriendStatus,
+  ): Promise<FriendAccount[]> {
+    const program = this._getProgram()
+
+    const payer = this._getPayer()
+
+    const fromKeyAndStatus = base58(Buffer.from([...payer.toBytes(), status]))
+
+    const outgoingTemp = await program.account.friendRequest.all([
+      {
+        memcmp: { offset: 8, bytes: fromKeyAndStatus },
+      },
+    ])
+
+    const outgoing = outgoingTemp.map(this._parseAccount)
+    return outgoing
+  }
+
+  /**
+   * @method getAccountsByStatus
+   * Gets all the friend accounts related to the program, filtered by given status code
+   * @param status the status code to filter
+   * (0 not assigned, 1 pending, 2 accepted, 3 refused, 4 removed)
+   * @returns a list of incoming and outgoing requests filtered by status
+   */
+  async getAccountsByStatus(
+    status: FriendStatus,
+  ): Promise<{ incoming: FriendAccount[]; outgoing: FriendAccount[] }> {
+    const [incoming, outgoing] = await Promise.all([
+      this.getIncomingAccountsByStatus(status),
+      this.getOutgoingAccountsByStatus(status),
+    ])
+    return {
+      incoming,
+      outgoing,
+    }
+  }
+
+  /**
+   * @method getAccount
+   * Retrieves a friend account from a given public key
+   * @param accountKey the public key of the friend account
+   * @returns the raw friend account object
+   */
+  async getAccount(accountKey: PublicKey) {
+    const program = this._getProgram()
+    try {
+      const account = await program.account.friendRequest.fetch(accountKey)
+      return this._parseAccount({ publicKey: accountKey, account })
+    } catch (error) {
+      return null
+    }
+  }
+
+  /**
+   * @method getAccountStatus
+   * Retrieves a friend account from a given public key
+   * @param accountKey the public key of the friend account
+   * @returns the account status code
+   */
+  async getAccountStatus(accountKey: PublicKey) {
+    const program = this._getProgram()
+    try {
+      const account = await program.account.friendRequest.fetch(accountKey)
+      return this._parseAccount({ publicKey: accountKey, account }).status
+    } catch (error) {
+      return FriendStatus.UNINITIALIZED
+    }
+  }
+
+  /**
+   * @method buildEventHandler
+   * Utility function that is used for building event handlers to
+   * be used together with the emit function inherited from the EventEmitter class
+   * @param friendEvent the friend event to listen
+   * new_request, new_friend, request_denied, request_removed, friend_removed
+   * @returns the event handler
+   */
+  buildEventHandler(friendEvent: FriendsEvents) {
+    return ({ accountId, accountInfo }: KeyedAccountInfo) => {
+      const program = this._getProgram()
+      const account: TypeDef<
+        Friends['accounts'][0],
+        IdlTypes<Friends>
+      > = program.account.friendRequest.coder.accounts.decode(
+        'friendRequest',
+        accountInfo.data,
+      )
+      this.emit(
+        friendEvent,
+        this._parseAccount({ publicKey: accountId, account }),
+      )
+    }
+  }
+
+  /**
+   * @method subscribeToEvents
+   * Subscribes to all friends events internally
+   * External listeners can be registered using the addEventListener function
+   */
+  subscribeToEvents() {
+    // Throws if Adapter is not set
+    const $PhantomManager = this._getPhantomManager()
+
+    const payer = this._getPayer()
+    const connection = $PhantomManager._getConnection()
+
+    const incomingRequestBytes = base58(
+      Buffer.from([FriendStatus.PENDING, ...payer.toBytes()]),
+    )
+
+    const incomingRequestsFilter: GetProgramAccountsFilter = {
+      memcmp: { offset: 32 + 8, bytes: incomingRequestBytes },
+    }
+
+    connection.onProgramAccountChange(
+      FRIENDS_PROGRAM_ID,
+      this.buildEventHandler(FriendsEvents.NEW_REQUEST),
+      Config.solana.defaultCommitment,
+      [incomingRequestsFilter],
+    )
+
+    /** Filter for new friends checks only if an outgoing request has been accepted
+     * because we suppose the incoming request acceptance to be catch directly after the
+     * success of the acceptRequest action
+     * This filter checks the sender public key (our) and the status
+     * [32 bytes (sender public key)][1 byte (status)][32 bytes (recipient public key)]
+     **/
+    const newFriendFromOutgoingBytes = base58(
+      Buffer.from([...payer.toBytes(), FriendStatus.ACCEPTED]),
+    )
+
+    const newFriendFromOutgoingFilter: GetProgramAccountsFilter = {
+      memcmp: { offset: 8, bytes: newFriendFromOutgoingBytes },
+    }
+
+    connection.onProgramAccountChange(
+      FRIENDS_PROGRAM_ID,
+      this.buildEventHandler(FriendsEvents.NEW_FRIEND),
+      Config.solana.defaultCommitment,
+      [newFriendFromOutgoingFilter],
+    )
+
+    /** Filter for new friends checks only if an outgoing request has been denied
+     * This filter checks the sender public key (our) and the status
+     * [32 bytes (sender public key)][1 byte (status)][32 bytes (recipient public key)]
+     **/
+
+    const friendRequestDeniedBytes = base58(
+      Buffer.from([...payer.toBytes(), FriendStatus.DENIED]),
+    )
+
+    const friendRequestDeniedFilter: GetProgramAccountsFilter = {
+      memcmp: { offset: 8, bytes: friendRequestDeniedBytes },
+    }
+
+    connection.onProgramAccountChange(
+      FRIENDS_PROGRAM_ID,
+      this.buildEventHandler(FriendsEvents.REQUEST_DENIED),
+      Config.solana.defaultCommitment,
+      [friendRequestDeniedFilter],
+    )
+
+    /** To listen for friend removal we need to filter from both directions
+     * because the account can be on from or to field depending on who was the
+     * original sender of the friend request
+     * This filter checks the sender public key (our) and the status
+     * [32 bytes (sender public key)][1 byte (status)][32 bytes (recipient public key)]
+     */
+
+    const friendRemovedBytes = base58(
+      Buffer.from([...payer.toBytes(), FriendStatus.REMOVED]),
+    )
+
+    const friendRemovedFilter: GetProgramAccountsFilter = {
+      memcmp: { offset: 8, bytes: friendRemovedBytes },
+    }
+
+    connection.onProgramAccountChange(
+      FRIENDS_PROGRAM_ID,
+      this.buildEventHandler(FriendsEvents.FRIEND_REMOVED),
+      Config.solana.defaultCommitment,
+      [friendRemovedFilter],
+    )
+
+    const friendRemovedMirroredBytes = base58(
+      Buffer.from([FriendStatus.REMOVED, ...payer.toBytes()]),
+    )
+
+    const friendRemovedMirroredFilter: GetProgramAccountsFilter = {
+      memcmp: { offset: 32 + 8, bytes: friendRemovedMirroredBytes },
+    }
+
+    connection.onProgramAccountChange(
+      FRIENDS_PROGRAM_ID,
+      this.buildEventHandler(FriendsEvents.FRIEND_REMOVED),
+      Config.solana.defaultCommitment,
+      [friendRemovedMirroredFilter],
+    )
+
+    /** Filter for remove friend requests checks only if an incoming request has been removed
+     * This filter checks the status and recipient public key
+     * [32 bytes (sender public key)][1 byte (status)][32 bytes (recipient public key)]
+     */
+
+    const friendRequestRemovedBytes = base58(
+      Buffer.from([FriendStatus.REQUEST_REMOVED, ...payer.toBytes()]),
+    )
+
+    const friendRequestRemovedFilter: GetProgramAccountsFilter = {
+      memcmp: { offset: 32 + 8, bytes: friendRequestRemovedBytes },
+    }
+
+    connection.onProgramAccountChange(
+      FRIENDS_PROGRAM_ID,
+      this.buildEventHandler(FriendsEvents.REQUEST_REMOVED),
+      Config.solana.defaultCommitment,
+      [friendRequestRemovedFilter],
+    )
+  }
+
+  /**
+   * @method addEventListener
+   * Adds a new event listener for a specific event. It's a wrapper to the
+   * inherited addListener function from EventEmitter
+   * @param type type of the event to subscribe
+   * @param callback callback function to be invoked when the
+   * event occours
+   */
+  addEventListener(
+    type: FriendsEvents,
+    callback: (friendAccount?: FriendAccount) => void,
+  ) {
+    this.addListener(type, callback)
+  }
+}

--- a/libraries/Phantom/PhantomGroup.ts
+++ b/libraries/Phantom/PhantomGroup.ts
@@ -1,0 +1,702 @@
+import { EventEmitter } from 'events'
+import { Program, Provider, utils, Wallet } from '@project-serum/anchor'
+import {
+  GetProgramAccountsFilter,
+  KeyedAccountInfo,
+  PublicKey,
+  SystemProgram,
+} from '@solana/web3.js'
+import PhantomManager from './PhantomManager'
+import {
+  Group,
+  GroupChats,
+  GroupEvents,
+  GroupEventsFilter,
+  IDL,
+  InvitationAccount,
+  InvitationAccountsFilter,
+  RawGroup,
+  Invitation,
+} from '~/libraries/Solana/GroupChatsProgram/GroupChatsProgram.types'
+import { Config } from '~/config'
+import GroupCrypto from '~/libraries/Solana/GroupChatsProgram/GroupCrypto'
+
+export const GROUPCHATS_PROGRAM_ID = new PublicKey(
+  Config.solana.groupchatsProgramId,
+)
+
+const groupSeed = Buffer.from(utils.bytes.utf8.encode('groupchat'))
+const inviteSeed = Buffer.from(utils.bytes.utf8.encode('invite'))
+
+export default class PhantomGroup extends EventEmitter {
+  phantomManager?: PhantomManager
+  program?: Program<GroupChats>
+  subscriptions?: { [eventName: string]: number }
+  private _crypto?: GroupCrypto
+
+  constructor(phantomManager: PhantomManager) {
+    super()
+    if (phantomManager) {
+      this.init(phantomManager)
+    }
+  }
+
+  init(phantomManager: PhantomManager) {
+    this.phantomManager = phantomManager
+
+    const provider = this._getPhantomManager()._getProvider()
+
+    this.program = new Program<GroupChats>(
+      IDL,
+      GROUPCHATS_PROGRAM_ID.toBase58(),
+      provider,
+    )
+  }
+
+  /**
+   * @method _getPhantomManager
+   * Retrieve the phantom manager instance
+   */
+  protected _getPhantomManager() {
+    if (!this.phantomManager) {
+      throw new Error('Phantom Manager not initialized')
+    }
+    return this.phantomManager
+  }
+
+  /**
+   * @method _getProgram
+   * Returns the anchor program instance for group chat
+   * @returns the anchor program instance
+   */
+  protected _getProgram() {
+    if (!this.program) {
+      throw new Error('Group Chat Manager not initialized')
+    }
+
+    return this.program
+  }
+
+  /**
+   * @method _getPayer
+   * Retrieve the active account from Solana wallet
+   * @returns the payer account
+   */
+  protected _getPayer() {
+    const payer = this._getPhantomManager().getwalletPublicKey()
+    if (!payer) {
+      throw new Error('Missing payer')
+    }
+
+    return payer
+  }
+
+  /**
+   * @method _getGroupHash
+   * Get the hash from Group ID
+   * @param groupId Group Id
+   * @returns the hash
+   */
+  protected _getGroupHash(groupId: string) {
+    return Buffer.from(utils.sha256.hash(groupId), 'hex')
+  }
+
+  /**
+   * @method _groupPDAPublicKey
+   * Computes a group PDA for the given Public Key
+   * @param address String version of the Public Key
+   * @returns the computed PDA
+   */
+  protected _groupPDAPublicKey(groupHash: Buffer) {
+    return utils.publicKey.findProgramAddressSync(
+      [groupHash, groupSeed],
+      this._getProgram().programId,
+    )
+  }
+
+  /**
+   * @method _invitePDAPublicKey
+   * Computes a invite PDA for the given Public Key
+   * @param user Public Key of user
+   * @param group Public Key of group
+   * @returns the computed PDA
+   */
+  protected _invitePDAPublicKey(user: PublicKey, group: PublicKey) {
+    return utils.publicKey.findProgramAddressSync(
+      [user.toBytes(), group.toBytes(), inviteSeed],
+      this._getProgram().programId,
+    )
+  }
+
+  get crypto() {
+    if (!this._crypto) {
+      throw new Error('Group crypto not initialized')
+    }
+    return this._crypto
+  }
+
+  /**
+   * Helper method to get group address(group public key) by group id
+   * @param id {string} group id
+   * @private
+   * @returns {PublicKey}
+   */
+  private groupAddressFromId(id: string): PublicKey {
+    const [address] = this._groupPDAPublicKey(this._getGroupHash(id))
+    return address
+  }
+
+  /**
+   * Get group by address
+   * @param groupAddress
+   * @returns {Promise<RawGroup>}
+   */
+  async getGroup(groupAddress: PublicKey | string): Promise<RawGroup> {
+    try {
+      return (await this._getProgram().account.group.fetch(
+        groupAddress,
+      )) as RawGroup
+    } catch (e: any) {
+      throw new Error('Unable to fetch group: ' + e.message)
+    }
+  }
+
+  async getInvitation(invitationAddress: PublicKey | string) {
+    return await this._getProgram().account.invitation.fetch(invitationAddress)
+  }
+
+  /**
+   * @method create
+   * Create a new group
+   * @param groupId Group id
+   * @param name Group name
+   */
+  async create(groupId: string, name: string): Promise<Group> {
+    // Throws if the payer is not set
+    const payer = this._getPayer()
+
+    // Throws if Adapter is not set
+    const $PhantomWalletAdapter = this._getPhantomManager().getAdapter()
+
+    const groupHash = this._getGroupHash(groupId)
+
+    const groupPDA = this._groupPDAPublicKey(groupHash)
+    const inviterPDA = this._invitePDAPublicKey(payer, groupPDA[0])
+
+    const encryptionKey = this.crypto.generateEncryptionKey()
+
+    const encrypted = await this.crypto.encryptInvite({
+      groupId,
+      encryptionKey,
+      sender: payer,
+      recipient: payer,
+      groupKey: groupPDA[0],
+    })
+
+    const tx = this._getProgram().transaction.create(
+      groupHash,
+      encrypted.groupId,
+      true,
+      name,
+      encrypted.encryptionKey,
+      1,
+      {
+        accounts: {
+          group: groupPDA[0],
+          invitation: inviterPDA[0],
+          signer: payer,
+          payer,
+          systemProgram: SystemProgram.programId,
+        },
+      },
+    )
+
+    tx.recentBlockhash = (
+      await this._getPhantomManager().connection.getLatestBlockhash()
+    ).blockhash
+
+    tx.feePayer = payer
+    const signed = await $PhantomWalletAdapter?.signTransaction(tx)
+    const sent = await $PhantomWalletAdapter?.sendTransaction(
+      signed,
+      this._getPhantomManager().connection,
+    )
+
+    return {
+      id: groupId,
+      address: groupPDA[0].toBase58(),
+      name,
+      admin: payer.toBase58(),
+      creator: payer.toBase58(),
+      membersCount: 1,
+      openInvites: true,
+      encryptionKey,
+    }
+  }
+
+  buildInvitationAccountFilter(
+    filter: InvitationAccountsFilter,
+  ): GetProgramAccountsFilter[] {
+    const filters = []
+    const offsets: { [key: string]: number } = {
+      sender: 8,
+      groupKey: 40,
+      recipient: 72,
+    }
+
+    for (const [key, value] of Object.entries(filter)) {
+      filters.push({
+        memcmp: {
+          offset: offsets[key],
+          bytes: value.toString(),
+        },
+      })
+    }
+    return filters
+  }
+
+  /**
+   * Returns invitation accounts with optional filtering
+   * @param filter {InvitationAccountsFilter}
+   * @returns Promise<InvitationAccount[]>
+   */
+  async getInvitationAccounts(
+    filter: InvitationAccountsFilter = {},
+  ): Promise<InvitationAccount[]> {
+    const filters = this.buildInvitationAccountFilter(filter)
+    const accounts = await this._getProgram().account.invitation.all(filters)
+
+    return accounts as InvitationAccount[]
+  }
+
+  /**
+   * Returns group by given id
+   * @param id {string} id of the group
+   * @returns Promise<Group>
+   */
+  async getGroupById(id: string): Promise<Group> {
+    const groupKey = this.groupAddressFromId(id)
+
+    const rawGroup = await this.getGroup(groupKey)
+    const invite = await this.getInviteByGroupId(id)
+
+    return this.populateGroup(invite, rawGroup)
+  }
+
+  /**
+   * Get user invite by group id
+   * @param id {string} group id
+   * @returns Promise<Invitation>
+   */
+  async getInviteByGroupId(id: string): Promise<Invitation> {
+    const [invite] = await this.getInvitationAccounts({
+      groupKey: this.groupAddressFromId(id),
+      recipient: this._getPayer(),
+    })
+    if (!invite) throw new Error('Invitation account not found')
+
+    return await this.crypto.decryptInvite(invite.account)
+  }
+
+  /**
+   * Returns groups the user is a member of
+   * @param address {string} user address
+   * @returns Promise<Group[]>
+   */
+  async getUserGroups(address: string | PublicKey): Promise<Group[]> {
+    const inviteAccounts = await this.getInvitationAccounts({
+      recipient: address,
+    })
+    const invites = await Promise.all(
+      inviteAccounts.map((it) => this.crypto.decryptInvite(it.account)),
+    )
+
+    const rawGroups = (await this._getProgram().account.group.fetchMultiple(
+      inviteAccounts.map((acc) => acc.account.groupKey),
+    )) as RawGroup[]
+
+    return invites
+      .map((it, i) => this.populateGroup(it, rawGroups[i]))
+      .filter((group) => !!group) as Group[]
+  }
+
+  /**
+   * Helper method to create typed Group from invitation account and raw group
+   * @param invite
+   * @param group
+   * @protected
+   */
+  protected populateGroup(invite: Invitation, group: RawGroup): Group {
+    return {
+      id: invite.groupId,
+      name: group.name,
+      admin: group.admin.toString(),
+      creator: group.creator.toString(),
+      address: invite.groupKey.toBase58(),
+      encryptionKey: invite.encryptionKey,
+      openInvites: group.openInvites,
+      membersCount: group.members,
+    }
+  }
+
+  /**
+   * Returns members of given group
+   * @param groupId {string} group id
+   * @returns Promise<string[]> array of user addresses
+   */
+  async getGroupUsers(groupId: string): Promise<string[]> {
+    const inviteAccounts = await this.getInvitationAccounts({
+      groupKey: this.groupAddressFromId(groupId),
+    })
+    return inviteAccounts.map((it) => it.account.recipient.toBase58())
+  }
+
+  /**
+   * Returns user addresses who are members of given groups
+   * @param groupIds {string[]} array of group id
+   * @returns Promise<{ id: string, users: string[] }[]>
+   */
+  async getGroupsUsers(
+    groupIds: string[],
+  ): Promise<{ id: string; users: string[] }[]> {
+    const users = await Promise.all(groupIds.map(this.getGroupUsers.bind(this)))
+    return groupIds.map((id, i) => ({
+      id,
+      users: users[i],
+    }))
+  }
+
+  /**
+   * @method invite
+   * Invite new user into Group
+   * @param groupId group id
+   * @param recipient: recipient address
+   */
+  async invite(groupId: string, recipient: string) {
+    const payer = this._getPayer()
+
+    // Throws if Adapter is not set
+    const $PhantomWalletAdapter = this._getPhantomManager().getAdapter()
+    const user = new PublicKey(recipient)
+
+    const groupKey = this.groupAddressFromId(groupId)
+
+    const inviterPDA = this._invitePDAPublicKey(payer, groupKey)
+    const inviteePDA = this._invitePDAPublicKey(user, groupKey)
+
+    const creatorInvite = await this.getInviteByGroupId(groupId)
+    if (!creatorInvite) throw new Error('Group not found')
+
+    const encrypted = await this.crypto.encryptInvite({
+      ...creatorInvite,
+      recipient: user,
+    })
+
+    const tx = await this._getProgram().transaction.invite(
+      encrypted.groupId,
+      user,
+      encrypted.encryptionKey,
+      0,
+      {
+        accounts: {
+          newInvitation: inviteePDA[0],
+          group: groupKey,
+          invitation: inviterPDA[0],
+          signer: payer,
+          payer,
+          systemProgram: SystemProgram.programId,
+        },
+      },
+    )
+
+    tx.recentBlockhash = (
+      await this._getPhantomManager().connection.getLatestBlockhash()
+    ).blockhash
+
+    tx.feePayer = payer
+    const signed = await $PhantomWalletAdapter?.signTransaction(tx)
+    const sent = await $PhantomWalletAdapter?.sendTransaction(
+      signed,
+      this._getPhantomManager().connection,
+    )
+  }
+
+  /**
+   * @method modify
+   * Modifies the Group settings
+   * @param groupId
+   * @param openInvites
+   */
+  async modifyOpenInvites(groupId: string, openInvites: boolean) {
+    const payer = this._getPayer()
+    // Throws if Adapter is not set
+    const $PhantomWalletAdapter = this._getPhantomManager().getAdapter()
+
+    const tx = await this._getProgram().transaction.modifyOpenIvites(
+      openInvites,
+      {
+        accounts: {
+          group: this.groupAddressFromId(groupId),
+          admin: this._getPayer(),
+        },
+      },
+    )
+
+    tx.recentBlockhash = (
+      await this._getPhantomManager().connection.getLatestBlockhash()
+    ).blockhash
+
+    tx.feePayer = payer
+    const signed = await $PhantomWalletAdapter?.signTransaction(tx)
+    const sent = await $PhantomWalletAdapter?.sendTransaction(
+      signed,
+      this._getPhantomManager().connection,
+    )
+  }
+
+  /**
+   * @method adminLeave
+   * Admin leaves group
+   * @param groupId
+   */
+  async adminLeave(groupId: string, receipient: string) {
+    const payer = this._getPayer()
+
+    // Throws if Adapter is not set
+    const $PhantomWalletAdapter = this._getPhantomManager().getAdapter()
+    const successor = new PublicKey(receipient)
+    const groupKey = this.groupAddressFromId(groupId)
+
+    const inviterPDA = this._invitePDAPublicKey(payer, groupKey)
+    const successorPDA = this._invitePDAPublicKey(successor, groupKey)
+
+    const tx = this._getProgram().transaction.adminLeave({
+      accounts: {
+        group: groupKey,
+        invitation: inviterPDA[0],
+        successor: successorPDA[0],
+        signer: payer,
+        invitationSender: payer,
+      },
+    })
+
+    tx.recentBlockhash = (
+      await this._getPhantomManager().connection.getLatestBlockhash()
+    ).blockhash
+
+    tx.feePayer = payer
+    const signed = await $PhantomWalletAdapter?.signTransaction(tx)
+    const sent = await $PhantomWalletAdapter?.sendTransaction(
+      signed,
+      this._getPhantomManager().connection,
+    )
+  }
+
+  /**
+   * @method leave
+   * User leaves group
+   * @param groupId
+   */
+  async leave(groupId: string) {
+    const payer = this._getPayer()
+
+    // Throws if Adapter is not set
+    const $PhantomWalletAdapter = this._getPhantomManager().getAdapter()
+    const groupKey = this.groupAddressFromId(groupId)
+
+    const group = await this.getGroup(groupKey)
+
+    const inviteePDA = this._invitePDAPublicKey(payer, groupKey)
+
+    const tx = this._getProgram().transaction.leave({
+      accounts: {
+        group: groupKey,
+        invitation: inviteePDA[0],
+        signer: payer,
+        invitationSender: group.admin,
+      },
+    })
+
+    tx.recentBlockhash = (
+      await this._getPhantomManager().connection.getLatestBlockhash()
+    ).blockhash
+
+    tx.feePayer = payer
+    const signed = await $PhantomWalletAdapter?.signTransaction(tx)
+    const sent = await $PhantomWalletAdapter?.sendTransaction(
+      signed,
+      this._getPhantomManager().connection,
+    )
+  }
+
+  /**
+   * Update group name
+   * @param id {string} group id
+   * @param name {string} new group name
+   * @returns Promise<void>
+   */
+  async updateGroupName(id: string, name: string): Promise<void> {
+    const address = this.groupAddressFromId(id)
+    const payer = this._getPayer()
+    // Throws if Adapter is not set
+    const $PhantomWalletAdapter = this._getPhantomManager().getAdapter()
+
+    const tx = this._getProgram().transaction.modifyName(name, {
+      accounts: {
+        group: address,
+        admin: this._getPayer(),
+      },
+    })
+
+    tx.recentBlockhash = (
+      await this._getPhantomManager().connection.getLatestBlockhash()
+    ).blockhash
+
+    tx.feePayer = payer
+    const signed = await $PhantomWalletAdapter?.signTransaction(tx)
+    const sent = await $PhantomWalletAdapter?.sendTransaction(
+      signed,
+      this._getPhantomManager().connection,
+    )
+  }
+
+  protected buildEventFilter(
+    type: GroupEvents,
+    filter: GroupEventsFilter,
+  ): GetProgramAccountsFilter[] {
+    switch (type) {
+      case GroupEvents.GROUP_INVITE:
+        return this.buildInvitationAccountFilter(filter)
+      default:
+        throw new Error('Invalid event type')
+    }
+  }
+
+  private decodeEventPayload(
+    type: GroupEvents,
+    info: KeyedAccountInfo,
+  ): InvitationAccount {
+    const coder = this._getProgram().coder
+    const { accountId, accountInfo } = info
+    switch (type) {
+      case GroupEvents.GROUP_INVITE:
+        return {
+          publicKey: accountId,
+          account: coder.accounts.decode('invitation', accountInfo.data),
+        }
+      default:
+        throw new Error('Invalid event type')
+    }
+  }
+
+  /**
+   * Unsubscribe from group invite events
+   * @param id {number} event subscription id
+   * @returns Promise<void>
+   */
+  async unsubscribe(id: number): Promise<void> {
+    try {
+      return await this._getPhantomManager()
+        ._getConnection()
+        .removeProgramAccountChangeListener(id)
+    } catch (e) {}
+  }
+
+  /**
+   * Register event listener for new group invites
+   * @param cb
+   */
+  addInviteListener(cb: (group: Group) => void): string {
+    const type = GroupEvents.GROUP_INVITE
+    const filter = this.buildInvitationAccountFilter({
+      recipient: this._getPayer().toBase58(),
+    })
+    const handler = async (payload: InvitationAccount) => {
+      const invite = await this.crypto.decryptInvite(payload.account)
+      const rawGroup = await this.getGroup(payload.account.groupKey)
+      const group = this.populateGroup(invite, rawGroup)
+
+      if (group) cb(group)
+    }
+
+    const id = this._getPhantomManager()
+      ._getConnection()
+      .onProgramAccountChange(
+        GROUPCHATS_PROGRAM_ID,
+        (info) => handler(this.decodeEventPayload(type, info)),
+        Config.solana.defaultCommitment,
+        filter,
+      )
+
+    return String(id)
+  }
+
+  /**
+   * Register event listener for group updates
+   * @param cb
+   * @returns {string[]} array of addresses for unsubscribe
+   */
+  async addGroupsListener(cb: (value: Group) => void): Promise<string[]> {
+    const inviteAccounts = await this.getInvitationAccounts({
+      recipient: this._getPayer().toBase58(),
+    })
+    const invites = await Promise.all(
+      inviteAccounts.map((it) => this.crypto.decryptInvite(it.account)),
+    )
+
+    const handler = (payload: RawGroup, invite: Invitation) => {
+      const group = this.populateGroup(invite, payload)
+
+      if (group) cb(group)
+    }
+
+    invites.forEach((invite) => {
+      this._getProgram()
+        .account.group.subscribe(invite.groupKey)
+        .on('change', (payload) => handler(payload, invite))
+    })
+
+    return invites.map((it) => it.groupKey.toBase58())
+  }
+
+  /**
+   * Remove group updates listeners
+   * @param keys
+   */
+  async removeGroupListeners(keys: string[]): Promise<void> {
+    await Promise.all(keys.map((key) => this.removeGroupListener(key)))
+  }
+
+  /**
+   * Register update listener for single group
+   * @param id {string} group id
+   * @param cb
+   * @returns {string} address for unsubscribe
+   */
+  async addGroupListener(
+    id: string,
+    cb: (value: Group) => void,
+  ): Promise<string> {
+    const invite = await this.getInviteByGroupId(id)
+
+    const handler = (payload: RawGroup) => {
+      const group = this.populateGroup(invite, payload)
+      if (group) cb(group)
+    }
+
+    this._getProgram()
+      .account.group.subscribe(invite.groupKey)
+      .on('change', handler)
+    return invite.groupKey.toString()
+  }
+
+  /**
+   * Remove group event listener for given address
+   * @param address {string}
+   */
+  async removeGroupListener(address: string): Promise<void> {
+    try {
+      await this._getProgram().account.group.unsubscribe(address).catch()
+    } catch (e) {}
+  }
+}

--- a/libraries/Phantom/PhantomManager.ts
+++ b/libraries/Phantom/PhantomManager.ts
@@ -1,0 +1,114 @@
+import { PhantomWalletAdapter } from '@solana/wallet-adapter-wallets'
+import { Connection, PublicKey } from '@solana/web3.js'
+import { Config } from '~/config'
+import { getClusterFromNetworkConfig } from '~/libraries/Solana/Solana'
+import { AccountsError } from '~/store/accounts/types'
+
+export default class PhantomManager {
+  clusterApiUrl: string
+  connection: Connection
+  walletPublicKey: PublicKey | null
+  provider = this._getProvider()
+  $PhantomWalletAdapter: PhantomWalletAdapter = new PhantomWalletAdapter()
+
+  constructor() {
+    this.clusterApiUrl = getClusterFromNetworkConfig(Config.solana.network)
+    this.connection = new Connection(this.clusterApiUrl, {
+      commitment: Config.solana.defaultCommitment,
+      httpHeaders: Config.solana.httpHeaders,
+    })
+    this.walletPublicKey = null
+  }
+
+  /**
+   * @method initWallet
+   * @description Initializes the wallet
+   **/
+  async initWallet() {
+    if (this.provider.isPhantom) {
+      await this.$PhantomWalletAdapter.connect()
+      this.$PhantomWalletAdapter.on('error', (error) => {
+        throw new Error('Phantom wallet error: ' + error)
+      })
+      this.walletPublicKey = this.$PhantomWalletAdapter.publicKey
+    }
+  }
+
+  /**
+   * @method _getProvider
+   * @returns a provider for the wallet
+   */
+  _getProvider() {
+    if ('solana' in window) {
+      // @ts-ignore
+      const provider = window.solana
+      if (provider.isPhantom) {
+        return provider
+      }
+    }
+    throw new Error(AccountsError.MNEMONIC_NOT_PRESENT)
+  }
+
+  /**
+   * @method _getConnection
+   * @returns return the connectiomn
+   */
+  _getConnection(): Connection {
+    if (!this.connection) {
+      throw new Error('PhantomManager is not initialized')
+    }
+    return this.connection
+  }
+
+  /**
+   * @method walletPublicKey
+   * @returns the account public key
+   */
+  getwalletPublicKey(): PublicKey {
+    if (!this.walletPublicKey) {
+      throw new Error('Wallet not initialized')
+    }
+    return this.walletPublicKey
+  }
+
+  /**
+   * @method getCurrentAccountBalance
+   * @returns the current account balance
+   */
+  async getCurrentAccountBalance(): Promise<number | null> {
+    if (this.$PhantomWalletAdapter.connected) {
+      return this.connection.getBalance(
+        this.getwalletPublicKey(),
+        Config.solana.defaultCommitment,
+      )
+    }
+    return null
+  }
+
+  /**
+   * @method getAccountBalance
+   * @returns the balance of the given account
+   */
+  getAccountBalance(account: PublicKey) {
+    return this.connection.getBalance(account, Config.solana.defaultCommitment)
+  }
+
+  getAdapter(): PhantomWalletAdapter {
+    if (this.$PhantomWalletAdapter.connected) {
+      return this.$PhantomWalletAdapter
+    }
+    throw new Error('Phantom wallet not connected')
+  }
+
+  /**
+   * @method signMessage
+   * @returns the signature of the given message
+   * @param message
+   **/
+  async signMessage(message: string): Promise<Uint8Array> {
+    if (this.$PhantomWalletAdapter.connected) {
+      return this.$PhantomWalletAdapter.signMessage(Buffer.from(message))
+    }
+    throw new Error('Phantom wallet not connected')
+  }
+}

--- a/libraries/Phantom/PhantomUser.ts
+++ b/libraries/Phantom/PhantomUser.ts
@@ -1,0 +1,403 @@
+import { EventEmitter } from 'events'
+import { Program, web3, utils } from '@project-serum/anchor'
+
+import PhantomManager from './PhantomManager'
+import { Config } from '~/config'
+import { IDL, Users } from '~/libraries/Solana/UsersProgram/UsersProgram.types'
+
+const { PublicKey, SystemProgram } = web3
+
+export const USERS_PROGRAM_ID = new PublicKey(Config.solana.usersProgramId)
+
+const userSeed = Buffer.from(utils.bytes.utf8.encode('user'))
+
+export default class PhantomUser extends EventEmitter {
+  phantomManager?: PhantomManager
+  program?: Program<Users>
+  subscriptions?: { [eventName: string]: number }
+
+  constructor(phantomManager: PhantomManager) {
+    super()
+    if (phantomManager) {
+      this.init(phantomManager)
+    }
+  }
+
+  init(phantomManager: PhantomManager) {
+    this.phantomManager = phantomManager
+
+    const provider = this._getPhantomManager()._getProvider()
+
+    this.program = new Program<Users>(
+      IDL,
+      USERS_PROGRAM_ID.toBase58(),
+      provider,
+    )
+  }
+
+  /**
+   * @method _userPDAPublicKey
+   * Computes a user PDA for the given Public Key
+   * @param address String version of the Public Key
+   * @returns the computed PDA
+   */
+  protected async _userPDAPublicKey(address: string) {
+    const program = this._getProgram()
+
+    const user = new PublicKey(address)
+
+    return utils.publicKey.findProgramAddressSync(
+      [user.toBytes(), userSeed],
+      program.programId,
+    )
+  }
+
+  /**
+   * @method _getProgram
+   * Returns the anchor program instance for group chat
+   * @returns the anchor program instance
+   */
+  protected _getProgram() {
+    if (!this.program) {
+      throw new Error('Group Chat Manager not initialized')
+    }
+
+    return this.program
+  }
+
+  /**
+   * @method _getPayer
+   * Retrieve the active account from Solana wallet
+   * @returns the payer account
+   */
+  protected _getPayer() {
+    const payer = this._getPhantomManager().getwalletPublicKey()
+    if (!payer) {
+      throw new Error('Missing payer')
+    }
+
+    return payer
+  }
+
+  /**
+   * @method _getPhantomManager
+   * Retrieve the phantom manager instance
+   */
+  protected _getPhantomManager() {
+    if (!this.phantomManager) {
+      throw new Error('Phantom Manager not initialized')
+    }
+    return this.phantomManager
+  }
+
+  /**
+   * @method _getUpdateOpts
+   * Get multiple information useful for the update functions
+   * @returns program instance, payer account, user info and user PDA
+   */
+  protected async _getUpdateOpts() {
+    const program = this._getProgram()
+    const payer = this._getPayer()
+
+    const userPDA = await this._userPDAPublicKey(payer.toBase58())
+
+    const userInfo = await this.getCurrentUserInfo()
+
+    if (!userInfo) {
+      throw new Error('Non existent account')
+    }
+
+    return { program, payer, userPDA, userInfo }
+  }
+
+  /**
+   * @method create
+   * Create a new user
+   * @param name Username
+   * @param photoHash Profile picture IPFS hash
+   * @param statusMessage Status message string
+   */
+  async create(name: string, photoHash: string, statusMessage: string) {
+    // Throws if the program is not set
+    const program = this._getProgram()
+
+    // Throws if the payer is not set
+    const payer = this._getPayer()
+
+    // Throws if Adapter is not set
+    const $PhantomWalletAdapter = this._getPhantomManager().getAdapter()
+
+    const userPDA = utils.publicKey.findProgramAddressSync(
+      [payer.toBytes(), userSeed],
+      program.programId,
+    )
+
+    const tx = program.transaction.create(name, photoHash, statusMessage, {
+      accounts: {
+        user: userPDA[0],
+        signer: payer,
+        payer,
+        systemProgram: SystemProgram.programId,
+      },
+    })
+
+    tx.recentBlockhash = (
+      await this._getPhantomManager()._getConnection().getLatestBlockhash()
+    ).blockhash
+
+    tx.feePayer = payer
+
+    const signed = await $PhantomWalletAdapter.signTransaction(tx)
+    window.console.log(signed)
+    const sent = await $PhantomWalletAdapter.sendTransaction(
+      signed,
+      this._getPhantomManager()._getConnection(),
+    )
+  }
+
+  /**
+   * @method getUserInfo
+   * Fetch the user information from the user program
+   * @param address string representation of the Public key
+   * @returns the parsed user info
+   */
+  async getUserInfo(address: string) {
+    const program = this._getProgram()
+
+    const userPDA = await this._userPDAPublicKey(address)
+
+    const userInfo = await program.account.user.fetchNullable(userPDA[0])
+
+    if (!userInfo) {
+      return null
+    }
+    return {
+      address,
+      name: userInfo.name as string,
+      photoHash: userInfo.photoHash as string,
+      status: userInfo.status as string,
+      bannerImageHash: userInfo.bannerImageHash as string,
+      extra1: userInfo.extra1 as string,
+      extra2: userInfo.extra2 as string,
+    }
+  }
+
+  /**
+   * @method getUsersInfo
+   * Fetch multiple users information from the user program
+   * @param addresses array af user addresses
+   * @returns the parsed users info
+   */
+  async getUsersInfo(addresses: string[]) {
+    const program = this._getProgram()
+    const pubKeys = await Promise.all(
+      addresses.map(async (it) => (await this._userPDAPublicKey(it))[0]),
+    )
+    const users = await program.account.user.fetchMultiple(pubKeys)
+    return users.map((it, i) => ({ ...it, address: addresses[i] }))
+  }
+
+  /**
+   * @method getCurrentUserInfo
+   * Returns the user info for the active account
+   * @returns the user info object for the current
+   */
+  async getCurrentUserInfo() {
+    const payer = this._getPayer()
+
+    return this.getUserInfo(payer.toBase58())
+  }
+
+  /**
+   * @method setName
+   * Allow the user to update the user name
+   * @param name user name
+   * @returns the transaction to update the status message
+   */
+  async setName(name: string) {
+    const { program, userPDA, payer } = await this._getUpdateOpts()
+    // Throws if Adapter is not set
+    const $PhantomWalletAdapter = this._getPhantomManager().getAdapter()
+
+    const tx = program.transaction.setName(name, {
+      accounts: {
+        user: userPDA[0],
+        signer: payer,
+        payer,
+      },
+    })
+
+    tx.recentBlockhash = (
+      await this._getPhantomManager()._getConnection().getLatestBlockhash()
+    ).blockhash
+
+    tx.feePayer = payer
+    const signed = await $PhantomWalletAdapter.signTransaction(tx)
+    const sent = await $PhantomWalletAdapter.sendTransaction(
+      signed,
+      this._getPhantomManager()._getConnection(),
+    )
+  }
+
+  /**
+   * @method setPhotoHash
+   * Allow the user to update the profile picture
+   * @param photoHash profile picture IPFS hash
+   * @returns the transaction to update the photo hash
+   */
+  async setPhotoHash(photoHash: string) {
+    const { program, userPDA, payer } = await this._getUpdateOpts()
+    // Throws if Adapter is not set
+    const $PhantomWalletAdapter = this._getPhantomManager().getAdapter()
+    const tx = program.transaction.setPhotoHash(photoHash, {
+      accounts: {
+        user: userPDA[0],
+        signer: payer,
+        payer,
+      },
+    })
+    tx.recentBlockhash = (
+      await this._getPhantomManager()._getConnection().getLatestBlockhash()
+    ).blockhash
+
+    tx.feePayer = payer
+    const signed = await $PhantomWalletAdapter.signTransaction(tx)
+    return await $PhantomWalletAdapter.sendTransaction(
+      signed,
+      this._getPhantomManager()._getConnection(),
+    )
+  }
+
+  /**
+   * @method setStatusMessage
+   * Allow the user to update the status message
+   * @param statusMessage status message
+   * @returns the transaction to update the status message
+   */
+  async setStatusMessage(statusMessage: string) {
+    const { program, userPDA, payer } = await this._getUpdateOpts()
+
+    // Throws if Adapter is not set
+    const $PhantomWalletAdapter = this._getPhantomManager().getAdapter()
+
+    const tx = program.transaction.setStatus(statusMessage, {
+      accounts: {
+        user: userPDA[0],
+        signer: payer,
+        payer,
+      },
+    })
+
+    tx.recentBlockhash = (
+      await this._getPhantomManager()._getConnection().getLatestBlockhash()
+    ).blockhash
+
+    tx.feePayer = payer
+    const signed = await $PhantomWalletAdapter.signTransaction(tx)
+    const sent = await $PhantomWalletAdapter.sendTransaction(
+      signed,
+      this._getPhantomManager()._getConnection(),
+    )
+  }
+
+  /**
+   * @method setBannerImageHash
+   * Allow the user to update the profile banner image
+   * @param bannerImageHash profile banner image IPFS hash
+   * @returns the transaction signature
+   */
+  async setBannerImageHash(bannerImageHash: string): Promise<string> {
+    const { program, userPDA, payer } = await this._getUpdateOpts()
+
+    // Throws if Adapter is not set
+    const $PhantomWalletAdapter = this._getPhantomManager().getAdapter()
+
+    const tx = program.transaction.setBannerImageHash(bannerImageHash, {
+      accounts: {
+        user: userPDA[0],
+        signer: payer,
+        payer,
+      },
+    })
+
+    tx.recentBlockhash = (
+      await this._getPhantomManager()._getConnection().getLatestBlockhash()
+    ).blockhash
+
+    tx.feePayer = payer
+    const signed = await $PhantomWalletAdapter.signTransaction(tx)
+
+    return await $PhantomWalletAdapter.sendTransaction(
+      signed,
+      this._getPhantomManager()._getConnection(),
+    )
+  }
+
+  /**
+   * @method setExtraOne
+   * Allow the user to update the first extra field of profile
+   * @param value extra field value
+   * @returns the transaction signature
+   */
+  async setExtraOne(value: string): Promise<string> {
+    const { program, userPDA, payer } = await this._getUpdateOpts()
+
+    // Throws if Adapter is not set
+    const $PhantomWalletAdapter = this._getPhantomManager().getAdapter()
+
+    const tx = program.transaction.setExtraOne(value, {
+      accounts: {
+        user: userPDA[0],
+        signer: payer,
+        payer,
+      },
+    })
+
+    tx.recentBlockhash = (
+      await this._getPhantomManager()._getConnection().getLatestBlockhash()
+    ).blockhash
+
+    tx.feePayer = payer
+    const signed = await $PhantomWalletAdapter.signTransaction(tx)
+
+    return await $PhantomWalletAdapter.sendTransaction(
+      signed,
+      this._getPhantomManager()._getConnection(),
+    )
+  }
+
+  /**
+   * @method setExtraTwo
+   * Allow the user to update the second extra field of profile
+   * @param value extra field value
+   * @returns the transaction signature
+   */
+  async setExtraTwo(value: string): Promise<string> {
+    const { program, userPDA, payer } = await this._getUpdateOpts()
+
+    // Throws if Adapter is not set
+    const $PhantomWalletAdapter = this._getPhantomManager().getAdapter()
+
+    const tx = program.transaction.setExtraTwo(value, {
+      accounts: {
+        user: userPDA[0],
+        signer: payer,
+        payer,
+      },
+    })
+
+    tx.recentBlockhash = (
+      await this._getPhantomManager()._getConnection().getLatestBlockhash()
+    ).blockhash
+
+    tx.feePayer = payer
+    const signed = await $PhantomWalletAdapter.signTransaction(tx)
+
+    return await $PhantomWalletAdapter.sendTransaction(
+      signed,
+      this._getPhantomManager()._getConnection(),
+    )
+  }
+}
+
+export type UserInfo = Awaited<ReturnType<PhantomUser['getUserInfo']>>

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -228,6 +228,7 @@ export default {
       create: 'Create Account',
       or: 'Or',
       import: 'Import Account',
+      connect: 'Connect Wallet',
     },
     inputAccount: {
       title: 'Import Account',

--- a/pages/setup/disclaimer/Disclaimer.html
+++ b/pages/setup/disclaimer/Disclaimer.html
@@ -13,6 +13,13 @@
     />
     <InteractablesButton
       full-width
+      data-cy="create-account-button"
+      type="dark"
+      :action="() => { connectAccount() }"
+      :text="$t('pages.disclaimer.connect')"
+    />
+    <InteractablesButton
+      full-width
       data-cy="import-account-button"
       type="dark"
       :action="() => { importAccount() }"

--- a/pages/setup/disclaimer/index.vue
+++ b/pages/setup/disclaimer/index.vue
@@ -18,6 +18,10 @@ export default Vue.extend({
     importAccount() {
       this.$router.push('importAccount')
     },
+    async connectAccount() {
+      await this.$store.dispatch('accounts/connectWallet')
+      this.$router.push('/')
+    },
   },
 })
 </script>

--- a/store/accounts/__snapshots__/state.test.ts.snap
+++ b/store/accounts/__snapshots__/state.test.ts.snap
@@ -3,7 +3,9 @@
 exports[`init should return the initial settings state 1`] = `
 Object {
   "active": "",
+  "adapter": "",
   "encryptedPhrase": "",
+  "entropyMessage": "",
   "error": "",
   "gasPrice": "",
   "initialized": false,

--- a/store/accounts/actions.ts
+++ b/store/accounts/actions.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { Keypair } from '@solana/web3.js'
 import Vue from 'vue'
 import {
@@ -12,6 +13,9 @@ import iridium from '~/libraries/Iridium/IridiumManager'
 import { ActionsArguments } from '~/types/store/store'
 import BlockchainClient from '~/libraries/BlockchainClient'
 import logger from '~/plugins/local/logger'
+import PhantomAdapter from '~/libraries/BlockchainClient/adapters/Phantom/PhantomAdapter'
+import IdentityManager from '~/libraries/Iridium/IdentityManager'
+import SolanaAdapter from '~/libraries/BlockchainClient/adapters/SolanaAdapter'
 
 export default {
   /**
@@ -87,7 +91,9 @@ export default {
       throw new Error(AccountsError.INVALID_PIN)
     }
 
+    await commit('setAdapter', 'Solana')
     const $BlockchainClient: BlockchainClient = BlockchainClient.getInstance()
+    $BlockchainClient.setAdapter(new SolanaAdapter())
 
     await $BlockchainClient.initRandom()
     const userWallet = $BlockchainClient.account
@@ -97,6 +103,13 @@ export default {
     }
 
     await commit('setPhrase', userWallet.mnemonic)
+
+    const { pinHash } = state
+    const entropyMessage = IdentityManager.generateEntropyMessage(
+      $BlockchainClient.account.publicKey.toBase58(),
+      pinHash,
+    )
+    commit('setEntropy', entropyMessage)
 
     const encryptedPhrase = await Crypto.encryptWithPassword(
       userWallet.mnemonic,
@@ -145,6 +158,13 @@ export default {
   }: ActionsArguments<AccountsState>) {
     console.info('loadAccount')
     const $BlockchainClient: BlockchainClient = BlockchainClient.getInstance()
+    if (state.adapter === 'Solana') {
+      $BlockchainClient.setAdapter(new SolanaAdapter())
+      window.console.log('Using Solana adapter')
+    } else {
+      $BlockchainClient.setAdapter(new PhantomAdapter())
+      window.console.log('Using Phantom adapter')
+    }
     const mnemonic = state.phrase
     if (mnemonic === '') {
       console.info('empty mnemonic')
@@ -158,19 +178,13 @@ export default {
       throw new Error(AccountsError.USER_DERIVATION_FAILED)
     }
 
-    const payerAccount = $BlockchainClient.payerAccount
-
     if (!iridium.ready) {
       console.info('initializing iridium')
-      const { pin } = state
-      await dispatch(
-        'iridium/initialize',
-        {
-          pass: pin,
-          wallet: $BlockchainClient.account,
-        },
-        { root: true },
-      )
+      const { entropyMessage } = state
+      const entropy = await $BlockchainClient.signMessage(entropyMessage)
+      await dispatch('iridium/initializFromEntropy', entropy, {
+        root: true,
+      })
     }
 
     commit('setActiveAccount', iridium.connector?.id)
@@ -182,13 +196,12 @@ export default {
     }
 
     console.info('user registered, dispatching')
-    dispatch('initializeEncryptionEngine', payerAccount)
     commit('setUserDetails', {
       username: userInfo.name,
       ...userInfo,
     })
     commit('setRegistrationStatus', RegistrationStatus.REGISTERED)
-    dispatch('startup', payerAccount)
+    dispatch('startup')
   },
   /**
    * @method registerUser
@@ -255,7 +268,6 @@ export default {
       photoHash: imagePath,
       address: walletAccount.publicKey.toBase58(),
     })
-    dispatch('initializeEncryptionEngine', walletAccount)
     dispatch('startup', walletAccount)
   },
 
@@ -297,59 +309,80 @@ export default {
     await $Crypto.init(userAccount)
   },
 
-  async startup(
-    { commit, dispatch, rootState, state }: ActionsArguments<AccountsState>,
-    payerAccount: Keypair,
-  ) {
-    const $BlockchainClient: BlockchainClient = BlockchainClient.getInstance()
-
+  async startup({
+    dispatch,
+    rootState,
+    state,
+  }: ActionsArguments<AccountsState>) {
     db.initializeSearchIndexes()
 
     const { pin } = state
     await dispatch('loadIridium', {
       pin,
     })
-    await dispatch('friends/initialize', {}, { root: true })
-    if ($BlockchainClient.payerAccount?.secretKey) {
-      dispatch(
-        'webrtc/initialize',
-        {
-          privateKeyInfo: {
-            type: 'ed25519',
-            privateKey: iridium.connector?.peerId,
-          },
-          originator: iridium.connector?.peerId,
-        },
-        {
-          root: true,
-        },
-      )
+
+    if (!iridium.connector?.peerId) {
+      return
     }
+
+    dispatch(
+      'webrtc/initialize',
+      {
+        privateKeyInfo: {
+          type: 'ed25519',
+          privateKey: iridium.connector?.peerId,
+        },
+        originator: iridium.connector?.peerId,
+      },
+      {
+        root: true,
+      },
+    )
+
     dispatch('sounds/setMuteSounds', rootState.audio.deafened, { root: true })
   },
-  async loadIridium({
-    commit,
-    dispatch,
-    state,
-  }: ActionsArguments<AccountsState>) {
+  async loadIridium({ dispatch, state }: ActionsArguments<AccountsState>) {
     if (!iridium.ready) {
       logger.log(
         'accounts/loadIridium',
         'Loading Iridium from accounts startup',
       )
       const $BlockchainClient: BlockchainClient = BlockchainClient.getInstance()
-      const { pin } = state
-      await dispatch(
-        'iridium/initialize',
-        {
-          pass: pin,
-          wallet: $BlockchainClient.account,
-        },
-        { root: true },
-      )
+      const { entropyMessage } = state
+      const entropy = await $BlockchainClient.signMessage(entropyMessage)
+      await dispatch('iridium/initializFromEntropy', entropy, { root: true })
     }
 
     await dispatch('groups/initialize', {}, { root: true })
+  },
+  async connectWallet({
+    commit,
+    dispatch,
+    state,
+  }: ActionsArguments<AccountsState>) {
+    const { pin } = state
+
+    if (!pin) {
+      throw new Error(AccountsError.INVALID_PIN)
+    }
+
+    commit('setAdapter', 'Phantom')
+    const $BlockchainClient: BlockchainClient = BlockchainClient.getInstance()
+    $BlockchainClient.setAdapter(new PhantomAdapter())
+    await $BlockchainClient.initFromMnemonic()
+
+    const { pinHash } = state
+    const entropyMessage = IdentityManager.generateEntropyMessage(
+      $BlockchainClient.account.publicKey.toBase58(),
+      pinHash,
+    )
+    commit('setEntropy', entropyMessage)
+
+    const fakeMnemonic = 'fake mnemonic to bypass checks'
+    commit('setPhrase', 'fake mnemonic to bypass checks')
+    const encryptedPhrase = await Crypto.encryptWithPassword(fakeMnemonic, pin)
+
+    commit('setEncryptedPhrase', encryptedPhrase)
   },
 }
 

--- a/store/accounts/mutations.ts
+++ b/store/accounts/mutations.ts
@@ -79,6 +79,12 @@ const mutations = {
   setLastVisited(state: AccountsState, lastVisited: string) {
     state.lastVisited = lastVisited
   },
+  setAdapter(state: AccountsState, adapter: string) {
+    state.adapter = adapter
+  },
+  setEntropy(state: AccountsState, entropyMessage: string) {
+    state.entropyMessage = entropyMessage
+  },
 }
 
 export default mutations

--- a/store/accounts/state.ts
+++ b/store/accounts/state.ts
@@ -15,6 +15,8 @@ const InitialAccountsState = (): AccountsState => ({
   registered: false,
   registrationStatus: RegistrationStatus.UNKNOWN,
   lastVisited: '/',
+  adapter: '',
+  entropyMessage: '',
 })
 
 export default InitialAccountsState

--- a/store/accounts/types.ts
+++ b/store/accounts/types.ts
@@ -9,6 +9,8 @@ export enum RegistrationStatus {
 }
 
 export interface AccountsState {
+  adapter: string
+  entropyMessage: string
   initialized: boolean
   storePin: boolean
   registry: boolean

--- a/store/iridium/actions.ts
+++ b/store/iridium/actions.ts
@@ -30,4 +30,29 @@ export default {
     logger.log('CSAM Consent Data', 'CSAM', iridium.profile?.state)
     commit('setInitialized', true)
   },
+  /**
+   * @description Initializes the TextileManager class and retrieves the
+   * Textile public key that must be shared to friends in order to receive
+   * messages
+   * @param param0 Entropy
+   * @param config Textile configuration (id, pass, wallet)
+   */
+  async initializFromEntropy(
+    { commit }: ActionsArguments<IridiumState>,
+    entropy: Uint8Array,
+  ) {
+    await iridium.initFromEntropy(entropy)
+    commit(
+      'accounts/setAccountIds',
+      {
+        did: iridium.connector?.id,
+        peerId: iridium.connector?.peerId,
+      },
+      { root: true },
+    )
+
+    /* Log CSAM Consent Data for future ticket as Hogan requested */
+    logger.log('CSAM Consent Data', 'CSAM', iridium.profile?.state)
+    commit('setInitialized', true)
+  },
 }


### PR DESCRIPTION
As the name implies, this PR introduces Phantom Wallet to the Satellite, allowing users to sign up and run Iridium with it.
This PR also modifies the classic initialization of Iridium.

Now both by connecting the external wallet and using the internal wallet, iridium starts up by signing a message.

I corrected the tests that I could correct, those related to my PR, but according to Manuel's directives, I completely disabled the non-working tests.

This PR is temporary, as much as it does its job, it is only a small part, as we still have to modify the store and part of the workflow.