### PR TITLE
refactor(files): remove redundant validation

### DIFF
--- a/libraries/Iridium/files/FilesManager.ts
+++ b/libraries/Iridium/files/FilesManager.ts
@@ -9,13 +9,16 @@ import { createWriteStream } from 'streamsaver'
 import { v4 as uuidv4 } from 'uuid'
 import type { IridiumManager } from '../IridiumManager'
 import logger from '~/plugins/local/logger'
-import { IridiumDirectory, IridiumItem } from '~/libraries/Iridium/files/types'
+import {
+  IridiumDirectory,
+  IridiumItem,
+  ItemErrors,
+} from '~/libraries/Iridium/files/types'
 import isNSFW from '~/utilities/NSFW'
 import createThumbnail from '~/utilities/Thumbnail'
 import { blobToStream } from '~/utilities/BlobManip'
 import { FILE_TYPE } from '~/libraries/Files/types/file'
 import { Config } from '~/config'
-import { FileSystemErrors } from '~/libraries/Files/errors/Errors'
 import { DIRECTORY_TYPE } from '~/libraries/Files/types/directory'
 
 export default class FilesManager extends Emitter {
@@ -106,6 +109,9 @@ export default class FilesManager extends Emitter {
     parentId: string
     options?: AddOptions
   }) {
+    if (file.size === 0) {
+      throw new Error(ItemErrors.FILE_SIZE)
+    }
     const parent = this.flat.find((e) => e.id === parentId) as
       | IridiumDirectory
       | undefined
@@ -272,15 +278,15 @@ export default class FilesManager extends Emitter {
    */
   private validateName(name: string, parent?: IridiumDirectory) {
     if (Config.regex.empty.test(name)) {
-      throw new Error(FileSystemErrors.NO_EMPTY_STRING)
+      throw new Error(ItemErrors.NO_EMPTY_STRING)
     }
 
     if (name[0] === '.') {
-      throw new Error(FileSystemErrors.LEADING_DOT)
+      throw new Error(ItemErrors.LEADING_DOT)
     }
 
     if (Config.regex.invalid.test(name)) {
-      throw new Error(FileSystemErrors.INVALID)
+      throw new Error(ItemErrors.INVALID)
     }
 
     // if parent was found, check sibling items. otherwise check root
@@ -294,7 +300,7 @@ export default class FilesManager extends Emitter {
   private isDuplicateName(name: string, items: IridiumItem[]) {
     items.forEach((e) => {
       if (!e.name.localeCompare(name, undefined, { sensitivity: 'base' })) {
-        throw new Error(FileSystemErrors.DUPLICATE_NAME)
+        throw new Error(ItemErrors.DUPLICATE_NAME)
       }
     })
   }

--- a/libraries/Iridium/files/types.ts
+++ b/libraries/Iridium/files/types.ts
@@ -28,3 +28,14 @@ export interface IridiumDirectory extends Shared {
 }
 
 export type IridiumItem = IridiumFile | IridiumDirectory
+
+export enum ItemErrors {
+  // IridiumItem
+  NO_EMPTY_STRING = 'pages.files.errors.no_empty',
+  INVALID = 'pages.files.errors.invalid',
+  DUPLICATE_NAME = 'pages.files.errors.duplicate_name',
+  LEADING_DOT = 'pages.files.errors.leading_dot',
+  // IridiumFile
+  FILE_SIZE = 'pages.files.errors.file_size',
+  LIMIT = 'pages.files.errors.storage_limit',
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- remove component side file upload validation since it's being handled in iridium methods
- switch max upload size limit check to iridium index, was pointing at legacy FilSystem before
- prevent duplicate errors
- switch try catch to more concise promise.catch

**Which issue(s) this PR fixes** 🔨
AP-1288
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
