### PR TITLE
refactor(layout): move droppable wrapper up to desktop layout

### DIFF
--- a/pages/chat/Chat.html
+++ b/pages/chat/Chat.html
@@ -1,22 +1,20 @@
-<UiDroppableWrapper @handle-drop-prop="handleDrop">
-  <div class="chat-container">
-    <Toolbar />
-    <Media
-      v-if="$device.isMobile"
-      :fullscreen="ui.fullscreen"
-      :users="$mock.callUsers"
-      :max-viewable-users="10"
-      :fullscreen-max-viewable-users="6"
-    />
-    <Media
-      v-else
-      :fullscreen="ui.fullscreen"
-      :users="$mock.callUsers"
-      :max-viewable-users="10"
-      :fullscreen-max-viewable-users="20"
-    />
-    <Conversation />
-    <Chatbar ref="chatbar" />
-    <WalletMini v-if="ui.modals.walletMini" />
-  </div>
-</UiDroppableWrapper>
+<div class="chat-container">
+  <Toolbar />
+  <Media
+    v-if="$device.isMobile"
+    :fullscreen="ui.fullscreen"
+    :users="$mock.callUsers"
+    :max-viewable-users="10"
+    :fullscreen-max-viewable-users="6"
+  />
+  <Media
+    v-else
+    :fullscreen="ui.fullscreen"
+    :users="$mock.callUsers"
+    :max-viewable-users="10"
+    :fullscreen-max-viewable-users="20"
+  />
+  <Conversation />
+  <Chatbar ref="chatbar" />
+  <WalletMini v-if="ui.modals.walletMini" />
+</div>

--- a/pages/chat/_id.vue
+++ b/pages/chat/_id.vue
@@ -3,8 +3,6 @@
 <script lang="ts">
 import Vue from 'vue'
 import { mapState } from 'vuex'
-import { ChatbarRef } from '~/components/views/chat/chatbar/Chatbar.vue'
-import iridium from '~/libraries/Iridium/IridiumManager'
 import { RootState } from '~/types/store/store'
 
 export default Vue.extend({
@@ -15,29 +13,6 @@ export default Vue.extend({
     ...mapState({
       ui: (state) => (state as RootState).ui,
     }),
-    consentToScan(): boolean {
-      return iridium.settings.state.privacy.consentToScan
-    },
-  },
-  methods: {
-    /**
-     * @method handleDrop
-     * @description Allows the drag and drop of files into the chatbar
-     * @param e Drop event data object
-     * @example v-on:drop="handleDrop"
-     */
-    handleDrop(e: DragEvent) {
-      e.preventDefault()
-      if (!this.consentToScan) {
-        this.$store.dispatch('ui/displayConsentSettings')
-        return
-      }
-      if (e?.dataTransfer && this.$refs.chatbar) {
-        ;(this.$refs.chatbar as ChatbarRef).handleUpload([
-          ...e.dataTransfer.items,
-        ])
-      }
-    },
   },
 })
 </script>

--- a/pages/files/browse/Browse.html
+++ b/pages/files/browse/Browse.html
@@ -1,45 +1,40 @@
-<UiDroppableWrapper @handle-drop-prop="handleDrop" style="overflow-y: scroll">
-  <div class="files-container" data-cy="files-screen">
-    <div class="files-top">
-      <InteractablesSidebarToggle v-if="!showSidebar" />
-      <FilesFilepath />
-    </div>
-    <FilesControls ref="controls" class="controls" />
-    <div class="files-aside-container">
-      <FilesAside />
-    </div>
-    <div class="files-view">
-      <TypographyText
-        v-if="!directory.length"
-        :text="$t('pages.files.empty')"
-      />
-      <FilesMobileList
-        v-else-if="$device.isMobile"
-        :directory="directory"
-        @like="like"
-        @share="share"
-        @rename="rename"
-        @remove="remove"
-        @handle="handle"
-      />
-      <FilesGrid
-        v-else-if="gridLayout"
-        :directory="directory"
-        @like="like"
-        @share="share"
-        @rename="rename"
-        @remove="remove"
-        @handle="handle"
-      />
-      <FilesList
-        v-else-if="!gridLayout"
-        :directory="directory"
-        @like="like"
-        @share="share"
-        @rename="rename"
-        @remove="remove"
-        @handle="handle"
-      />
-    </div>
+<div class="files-container" data-cy="files-screen">
+  <div class="files-top">
+    <InteractablesSidebarToggle v-if="!showSidebar" />
+    <FilesFilepath />
   </div>
-</UiDroppableWrapper>
+  <FilesControls ref="controls" class="controls" />
+  <div class="files-aside-container">
+    <FilesAside />
+  </div>
+  <div class="files-view">
+    <TypographyText v-if="!directory.length" :text="$t('pages.files.empty')" />
+    <FilesMobileList
+      v-else-if="$device.isMobile"
+      :directory="directory"
+      @like="like"
+      @share="share"
+      @rename="rename"
+      @remove="remove"
+      @handle="handle"
+    />
+    <FilesGrid
+      v-else-if="gridLayout"
+      :directory="directory"
+      @like="like"
+      @share="share"
+      @rename="rename"
+      @remove="remove"
+      @handle="handle"
+    />
+    <FilesList
+      v-else-if="!gridLayout"
+      :directory="directory"
+      @like="like"
+      @share="share"
+      @rename="rename"
+      @remove="remove"
+      @handle="handle"
+    />
+  </div>
+</div>

--- a/pages/files/browse/Browse.less
+++ b/pages/files/browse/Browse.less
@@ -10,6 +10,7 @@
     'controls files-aside-container'
     'files-view files-aside-container';
   margin: @normal-spacing @normal-spacing 0;
+  overflow-y: scroll;
 
   .files-top {
     grid-area: files-top;

--- a/pages/files/browse/index.vue
+++ b/pages/files/browse/index.vue
@@ -29,9 +29,6 @@ export default Vue.extend({
     ...mapGetters({
       sortedItems: 'files/sortedItems',
     }),
-    consentToScan(): boolean {
-      return iridium.settings.state.privacy.consentToScan
-    },
     directory(): IridiumItem[] {
       return this.sortedItems(this.items, this.$route.query.route)
     },

--- a/pages/files/browse/index.vue
+++ b/pages/files/browse/index.vue
@@ -8,7 +8,6 @@ import { IridiumItem } from '~/libraries/Iridium/files/types'
 import { RootState } from '~/types/store/store'
 import { ModalWindows } from '~/store/ui/types'
 import { FileRouteEnum } from '~/libraries/Enums/enums'
-import { FilesControlsRef } from '~/components/views/files/controls/Controls.vue'
 
 export default Vue.extend({
   name: 'Files',
@@ -100,27 +99,6 @@ export default Vue.extend({
      */
     share(item: IridiumItem) {
       this.$toast.show(this.$t('todo - share') as string)
-    },
-    /**
-     * @method handleDrop
-     * @description Allows the drag and drop of files into the filesystem
-     * @param e Drop event data object
-     */
-    handleDrop(e: DragEvent) {
-      e.preventDefault()
-
-      if (!this.consentToScan) {
-        this.$store.dispatch('ui/displayConsentSettings')
-        return
-      }
-
-      // if already uploading, return to prevent bucket fast-forward crash
-      if (e.dataTransfer) {
-        const files: (File | null)[] = [...e.dataTransfer.items].map((f) =>
-          f.getAsFile(),
-        )
-        ;(this.$refs.controls as FilesControlsRef).handleFile(files)
-      }
     },
   },
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- we plan on using the same pages for mobile, but a different layout.
- this moves droppable wrapper logic upto the desktop level
- conditionally render based on path

**Which issue(s) this PR fixes** 🔨
AP-2037
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
