### PR TITLE
fix(settings): improve settings modal styles, remove old swiper package

### DIFF
--- a/components/interactables/AsideMenu/AsideMenu.less
+++ b/components/interactables/AsideMenu/AsideMenu.less
@@ -14,7 +14,6 @@
     top: 2.4rem;
   }
 
-  padding: @xlarge-spacing;
   position: relative;
   -webkit-user-drag: none;
   &:extend(.no-select);

--- a/components/typography/NumberedWord/NumberedWord.less
+++ b/components/typography/NumberedWord/NumberedWord.less
@@ -18,6 +18,7 @@
     text-align: center;
     border-radius: 4px 0 2px 0;
     line-height: 1.4;
+    &:extend(.no-select);
   }
   .remove-word {
     position: absolute;

--- a/components/views/settings/Sidebar.vue
+++ b/components/views/settings/Sidebar.vue
@@ -114,4 +114,8 @@ export default Vue.extend({
   },
 })
 </script>
-<style scoped lang="less"></style>
+<style scoped lang="less">
+.aside-menu {
+  overflow-y: auto;
+}
+</style>

--- a/components/views/settings/modal/Modal.html
+++ b/components/views/settings/modal/Modal.html
@@ -1,68 +1,47 @@
-<UiModal class="settings-modal" :closeModal="closeModal" nopad>
-  <div id="settings" class="with-sidebar">
-    <swiper-slide class="sidebar is-secondary-background">
-      <UiSimpleScroll scrollMode="vertical" scrollShow="scroll">
-        <SettingsSidebar
-          :title="$t('pages.settings.settings')"
-          :toggle="toggleSidebar"
-          :handleRouteChange="changeRoute"
-        />
-      </UiSimpleScroll>
-    </swiper-slide>
-    <swiper-slide class="not-sidebar hidden-scroll" v-scroll-lock="true">
-      <UiSimpleScroll
-        containerClass="modal-container"
-        scrollMode="vertical"
-        scrollShow="scroll"
-      >
-        <menu-icon
-          v-if="$device.isMobile"
-          size="1.5x"
-          v-on:click="toggleSidebar"
-          class="menu-toggle"
-        />
-        <SettingsBreadcrumbs />
-        <InteractablesClose
-          data-cy="settings-close-button"
-          :action="closeModal"
-        />
-        <SettingsPagesPersonalize
-          v-if="this.ui.settingsRoute === SettingsRoutes.PERSONALIZE"
-        />
-        <SettingsPagesAccounts
-          v-if="this.ui.settingsRoute === SettingsRoutes.ACCOUNTS_AND_DEVICES"
-        />
-        <SettingsPagesAudio
-          v-if="this.ui.settingsRoute === SettingsRoutes.AUDIO_AND_VIDEO"
-        />
-        <SettingsPagesDeveloper
-          v-if="this.ui.settingsRoute === SettingsRoutes.DEVELOPER"
-        />
-        <SettingsPagesInfo
-          v-if="this.ui.settingsRoute === SettingsRoutes.INFO"
-        />
-        <SettingsPagesKeybinds
-          v-if="this.ui.settingsRoute === SettingsRoutes.KEY_BINDS"
-        />
-        <SettingsPagesNotifications
-          v-if="this.ui.settingsRoute === SettingsRoutes.NOTIFICATIONS"
-        />
-        <SettingsPagesProfile
-          v-if="this.ui.settingsRoute === SettingsRoutes.PROFILE"
-        />
-        <SettingsPagesStorage
-          v-if="this.ui.settingsRoute === SettingsRoutes.STORAGE"
-        />
-        <SettingsPagesNetwork
-          v-if="this.ui.settingsRoute === SettingsRoutes.NETWORK"
-        />
-        <SettingsPagesRealms
-          v-if="this.ui.settingsRoute === SettingsRoutes.REALMS"
-        />
-        <SettingsPagesPrivacy
-          v-if="this.ui.settingsRoute === SettingsRoutes.PRIVACY"
-        />
-      </UiSimpleScroll>
-    </swiper-slide>
+<UiModal :closeModal="closeModal" nopad>
+  <div class="settings">
+    <SettingsSidebar
+      class="sidebar"
+      :title="$t('pages.settings.settings')"
+      :toggle="toggleSidebar"
+      :handleRouteChange="changeRoute"
+    />
+    <div class="page">
+      <SettingsPagesPersonalize
+        v-if="this.ui.settingsRoute === SettingsRoutes.PERSONALIZE"
+      />
+      <SettingsPagesAccounts
+        v-if="this.ui.settingsRoute === SettingsRoutes.ACCOUNTS_AND_DEVICES"
+      />
+      <SettingsPagesAudio
+        v-if="this.ui.settingsRoute === SettingsRoutes.AUDIO_AND_VIDEO"
+      />
+      <SettingsPagesDeveloper
+        v-if="this.ui.settingsRoute === SettingsRoutes.DEVELOPER"
+      />
+      <SettingsPagesInfo v-if="this.ui.settingsRoute === SettingsRoutes.INFO" />
+      <SettingsPagesKeybinds
+        v-if="this.ui.settingsRoute === SettingsRoutes.KEY_BINDS"
+      />
+      <SettingsPagesNotifications
+        v-if="this.ui.settingsRoute === SettingsRoutes.NOTIFICATIONS"
+      />
+      <SettingsPagesProfile
+        v-if="this.ui.settingsRoute === SettingsRoutes.PROFILE"
+      />
+      <SettingsPagesStorage
+        v-if="this.ui.settingsRoute === SettingsRoutes.STORAGE"
+      />
+      <SettingsPagesNetwork
+        v-if="this.ui.settingsRoute === SettingsRoutes.NETWORK"
+      />
+      <SettingsPagesRealms
+        v-if="this.ui.settingsRoute === SettingsRoutes.REALMS"
+      />
+      <SettingsPagesPrivacy
+        v-if="this.ui.settingsRoute === SettingsRoutes.PRIVACY"
+      />
+    </div>
+    <InteractablesClose data-cy="settings-close-button" :action="closeModal" />
   </div>
 </UiModal>

--- a/components/views/settings/modal/Modal.less
+++ b/components/views/settings/modal/Modal.less
@@ -1,161 +1,20 @@
-#settings {
+.settings {
+  display: flex;
+  flex-direction: row;
+  overflow: hidden;
   width: calc(100vw - 96px);
   height: calc(100vh - 96px);
   max-width: 1528px;
   max-height: 888px;
-  margin: auto;
-}
-
-#settings.is-collapsed
-  > div.sidebar.is-secondary-background
-  > section
-  > div.aside-menu.hidden-scroll
-  > svg {
-  right: 0.9rem !important;
-}
-
-#settings.is-collapsed
-  > div.sidebar.is-secondary-background
-  > section
-  > div.aside-menu.hidden-scroll
-  > aside {
-  display: none;
-}
-
-p {
-  font-family: @secondary-font;
-  font-size: 16px;
-  word-spacing: 1px;
-  -ms-text-size-adjust: @full;
-  -webkit-text-size-adjust: @full;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-  box-sizing: border-box;
-}
-
-.with-sidebar {
-  display: flex;
-  flex-wrap: wrap;
-  flex-direction: row;
-  overflow: hidden;
-}
-
-.setting-swiper {
-  width: 100%;
-  height: 100%;
-  .swiper-wrapper {
-    box-sizing: border-box;
-  }
+  gap: @xlarge-spacing;
 
   .sidebar {
-    width: @sidebar-width;
-    box-sizing: border-box;
+    padding: @xlarge-spacing;
   }
 
-  .not-sidebar {
-    width: 100%;
-    box-sizing: border-box;
-    &:extend(.background-semitransparent-dark);
-
-    #simple-scrollbar.modal-container {
-      position: relative;
-      width: calc(@full - @sidebar-width);
-      height: @full;
-      padding: @xlarge-spacing;
-      box-sizing: border-box;
-    }
-
-    @media only screen and (max-width: @mobile-breakpoint) {
-      #simple-scrollbar.modal-container {
-        width: @full;
-        padding-bottom: @mobile-nav-height;
-      }
-    }
-  }
-}
-
-.sidebar {
-  height: @full;
-  transition: transform @animation-speed;
-  position: relative;
-
-  .sidebar-word {
-    position: absolute;
-    transform: rotate(90deg);
-    top: 8rem;
-    right: -2.6rem;
-    letter-spacing: 7px;
-    text-transform: uppercase;
-    display: none;
-    opacity: 0;
-  }
-}
-
-.not-sidebar {
-  white-space: pre-line;
-  height: @full;
-  font-size: @text-size;
-  transition: margin-left @animation-speed;
-
-  .title,
-  .subtitle {
-    font-size: @text-size;
-  }
-  .ps {
-    width: 100%;
-    padding: @normal-spacing * 2;
-    margin: 0;
-  }
-  .is-primary.input,
-  .is-dark.input {
-    background: @semitransparent-lightest-gradient !important;
-  }
-}
-
-@media only screen and (max-width: @mobile-breakpoint) {
-  .settings-modal #settings {
-    width: 100vw;
-    height: 100%;
-
-    .sidebar {
-      flex-basis: 100%;
-    }
-  }
-
-  .sidebar {
-    .ps {
-      padding-top: @normal-spacing;
-    }
-    .menu-toggle {
-      top: @normal-spacing;
-    }
-  }
-
-  .not-sidebar {
-    height: 100%;
-    .close-button {
-      top: @normal-spacing * 3;
-      right: @normal-spacing * 2;
-    }
-
-    .ps {
-      padding-top: @normal-spacing * 3;
-      padding-bottom: @normal-spacing * 5;
-      width: 100%;
-    }
-    .menu-toggle {
-      margin-top: @light-spacing * 3;
-    }
-  }
-
-  .is-collapsed {
-    .not-sidebar {
-      .ps {
-        padding: @normal-spacing;
-      }
-    }
-    .menu-toggle {
-      right: 1.5rem !important;
-    }
+  .page {
+    padding: @large-spacing;
+    flex: 1;
+    overflow-y: scroll;
   }
 }

--- a/components/views/settings/pages/accounts/Accounts.html
+++ b/components/views/settings/pages/accounts/Accounts.html
@@ -1,27 +1,23 @@
 <SettingsPage>
-  <SettingsSection>
-    <SettingsUnit>
-      <TypographyTitle :size="6" :text="$t('pages.settings.accounts.title')" />
-      <TypographySubtitle
-        :size="6"
-        :text="$t('pages.settings.accounts.subtitle')"
-      />
-    </SettingsUnit>
-  </SettingsSection>
+  <SettingsUnit>
+    <TypographyTitle :size="6" :text="$t('pages.settings.accounts.title')" />
+    <TypographySubtitle
+      :size="6"
+      :text="$t('pages.settings.accounts.subtitle')"
+    />
+  </SettingsUnit>
 
-  <SettingsSection>
-    <SettingsUnit>
-      <TypographyLabel :text="$t('pages.settings.accounts.active')" />
-      <InteractablesInputGroup
-        readonly
-        type="primary"
-        :action="copyAddress"
-        :text="accounts.active"
-      >
-        <clipboard-icon size="1x" />
-      </InteractablesInputGroup>
-    </SettingsUnit>
-  </SettingsSection>
+  <SettingsUnit>
+    <TypographyLabel :text="$t('pages.settings.accounts.active')" />
+    <InteractablesInputGroup
+      readonly
+      type="primary"
+      :action="copyAddress"
+      :text="accounts.active"
+    >
+      <clipboard-icon size="1x" />
+    </InteractablesInputGroup>
+  </SettingsUnit>
 
   <!-- <SettingsSection>
     <SettingsUnit>
@@ -30,51 +26,44 @@
     </SettingsUnit>
   </SettingsSection> -->
 
-  <SettingsSection>
-    <SettingsUnit>
-      <TypographyTitle
-        :size="6"
-        :text="$t('pages.settings.accounts.devices')"
-      />
-      <TypographySubtitle
-        :size="6"
-        :text="$t('pages.settings.accounts.no_devices')"
-      />
-    </SettingsUnit>
-  </SettingsSection>
+  <SettingsUnit>
+    <TypographyTitle :size="6" :text="$t('pages.settings.accounts.devices')" />
+    <TypographySubtitle
+      :size="6"
+      :text="$t('pages.settings.accounts.no_devices')"
+    />
+  </SettingsUnit>
 
-  <SettingsSection>
-    <SettingsUnit>
-      <TypographyTitle
-        :size="6"
-        :text="$t('pages.settings.profile.phrase.title')"
+  <SettingsUnit>
+    <TypographyTitle
+      :size="6"
+      :text="$t('pages.settings.profile.phrase.title')"
+    />
+    <TypographySubtitle
+      :size="6"
+      :text="$t('pages.settings.profile.phrase.subtitle')"
+    />
+    <div class="button-container">
+      <InteractablesButton
+        :text="showPhrase ? $t('pages.settings.accounts.hide_phrase') : $t('pages.settings.accounts.reveal_phrase')"
+        size="normal"
+        type="primary"
+        :action="togglePhrase"
       />
-      <TypographySubtitle
-        :size="6"
-        :text="$t('pages.settings.profile.phrase.subtitle')"
+      <InteractablesButton
+        :text="$t('pages.settings.accounts.copy_phrase')"
+        size="normal"
+        type="primary"
+        :action="copyPhrase"
       />
-      <div class="button-container">
-        <InteractablesButton
-          :text="showPhrase ? $t('pages.settings.accounts.hide_phrase') : $t('pages.settings.accounts.reveal_phrase')"
-          size="normal"
-          type="primary"
-          :action="togglePhrase"
-        />
-        <InteractablesButton
-          :text="$t('pages.settings.accounts.copy_phrase')"
-          size="normal"
-          type="primary"
-          :action="copyPhrase"
-        />
-      </div>
-      <div v-if="showPhrase" class="tag-wrap">
-        <TypographyNumberedWord
-          v-for="word, i in splitPhrase"
-          :key="i"
-          :word="word"
-          :number="i + 1"
-        />
-      </div>
-    </SettingsUnit>
-  </SettingsSection>
+    </div>
+    <div v-if="showPhrase" class="tag-wrap">
+      <TypographyNumberedWord
+        v-for="word, i in splitPhrase"
+        :key="i"
+        :word="word"
+        :number="i + 1"
+      />
+    </div>
+  </SettingsUnit>
 </SettingsPage>

--- a/components/views/settings/pages/info/Developer.html
+++ b/components/views/settings/pages/info/Developer.html
@@ -1,19 +1,13 @@
 <SettingsPage>
-  <SettingsSection>
-    <SettingsUnit>
-      <TypographyTitle :size="6" :text="$t('pages.settings.info.title')" />
-      <TypographySubtitle
-        :size="6"
-        :text="$t('pages.settings.info.subtitle')"
-      />
-    </SettingsUnit>
-  </SettingsSection>
+  <SettingsUnit>
+    <TypographyTitle :size="6" :text="$t('pages.settings.info.title')" />
+    <TypographySubtitle :size="6" :text="$t('pages.settings.info.subtitle')" />
+  </SettingsUnit>
 
-  <SettingsSection>
-    <SettingsUnit>
-      <TypographyLabel :text="$t('pages.settings.app_info')" />
-      <br />
-      <pre>
+  <SettingsUnit>
+    <TypographyLabel :text="$t('pages.settings.app_info')" />
+    <br />
+    <pre>
         App Version: {{ this.$config.clientVersion }}
         Browser:     {{ this.$envinfo.navigator.vendor }}, {{ this.$envinfo.navigator.product }}
         Language:    {{ this.$envinfo.navigator.product }}
@@ -21,15 +15,12 @@
         <span v-if="renderer">Processor:   {{renderer}}</span>
         Online:      {{ this.$envinfo.navigator.onLine }}
       </pre>
-    </SettingsUnit>
-  </SettingsSection>
-  <SettingsSection>
-    <SettingsUnit>
-      <TypographyLabel :text="$t('pages.settings.changelog')" />
-      <br />
-      <pre>
+  </SettingsUnit>
+  <SettingsUnit>
+    <TypographyLabel :text="$t('pages.settings.changelog')" />
+    <br />
+    <pre>
         <vue-markdown :source="releaseData && releaseData.body" :breaks="false"/>
       </pre>
-    </SettingsUnit>
-  </SettingsSection>
+  </SettingsUnit>
 </SettingsPage>

--- a/components/views/settings/pages/network/Network.html
+++ b/components/views/settings/pages/network/Network.html
@@ -1,22 +1,18 @@
 <SettingsPage>
-  <SettingsSection>
-    <SettingsUnit>
-      <TypographyTitle :size="6" :text="$t('pages.settings.network.title')" />
-      <TypographySubtitle
-        :size="6"
-        :text="$t('pages.settings.network.subtitle')"
-      />
-    </SettingsUnit>
-  </SettingsSection>
+  <SettingsUnit>
+    <TypographyTitle :size="6" :text="$t('pages.settings.network.title')" />
+    <TypographySubtitle
+      :size="6"
+      :text="$t('pages.settings.network.subtitle')"
+    />
+  </SettingsUnit>
 
-  <SettingsSection>
-    <SettingsUnit>
-      <InteractablesSelect
-        v-model="network"
-        :label="$t('pages.settings.network.network')"
-        :options="[{ text: 'Testnet', value: 'testnet' }]"
-        show-label
-      />
-    </SettingsUnit>
-  </SettingsSection>
+  <SettingsUnit>
+    <InteractablesSelect
+      v-model="network"
+      :label="$t('pages.settings.network.network')"
+      :options="[{ text: 'Testnet', value: 'testnet' }]"
+      show-label
+    />
+  </SettingsUnit>
 </SettingsPage>

--- a/components/views/settings/pages/realms/Realms.html
+++ b/components/views/settings/pages/realms/Realms.html
@@ -1,23 +1,19 @@
 <SettingsPage>
-  <SettingsSection>
-    <SettingsUnit>
-      <TypographyTitle :size="6" :text="$t('pages.settings.realms.title')" />
-      <TypographySubtitle
-        :size="6"
-        :text="$t('pages.settings.realms.subtitle')"
-      />
-    </SettingsUnit>
-  </SettingsSection>
+  <SettingsUnit>
+    <TypographyTitle :size="6" :text="$t('pages.settings.realms.title')" />
+    <TypographySubtitle
+      :size="6"
+      :text="$t('pages.settings.realms.subtitle')"
+    />
+  </SettingsUnit>
 
-  <SettingsSection>
-    <SettingsUnit>
-      <TypographyLabel :text="$t('pages.settings.realms.chain')" />
-      <br />
-      <SettingsPagesRealmsRealm
-        v-for="realm in realms"
-        :realm="realm"
-        :key="realm.id"
-      />
-    </SettingsUnit>
-  </SettingsSection>
+  <SettingsUnit>
+    <TypographyLabel :text="$t('pages.settings.realms.chain')" />
+    <br />
+    <SettingsPagesRealmsRealm
+      v-for="realm in realms"
+      :realm="realm"
+      :key="realm.id"
+    />
+  </SettingsUnit>
 </SettingsPage>

--- a/components/views/settings/pages/storage/Storage.html
+++ b/components/views/settings/pages/storage/Storage.html
@@ -1,72 +1,66 @@
 <SettingsPage>
-  <SettingsSection>
-    <SettingsUnit>
-      <TypographyTitle :size="6" :text="$t('pages.settings.storage.title')" />
-      <TypographySubtitle
-        :size="6"
-        :text="$t('pages.settings.storage.subtitle')"
-      />
-    </SettingsUnit>
-  </SettingsSection>
+  <SettingsUnit>
+    <TypographyTitle :size="6" :text="$t('pages.settings.storage.title')" />
+    <TypographySubtitle
+      :size="6"
+      :text="$t('pages.settings.storage.subtitle')"
+    />
+  </SettingsUnit>
 
-  <SettingsSection v-if="featureReadyToShow">
-    <SettingsUnit>
-      <TypographyTitle
+  <SettingsUnit v-if="false">
+    <TypographyTitle
+      :size="6"
+      :text="$t('pages.settings.storage.export.title')"
+    />
+    <TypographySubtitle
+      :size="6"
+      :text="$t('pages.settings.storage.export.subtitle')"
+    />
+    <br />
+    <InteractablesButton
+      type="primary"
+      size="small"
+      :text="$t('pages.settings.storage.export.button')"
+    />
+  </SettingsUnit>
+
+  <SettingsUnit>
+    <TypographyTitle
+      :size="6"
+      :text="$t('pages.settings.storage.clear.title')"
+    />
+    <TypographySubtitle
+      :size="6"
+      :text="$t('pages.settings.storage.clear.subtitle')"
+    />
+    <br />
+    <InteractablesButton
+      v-if="!deleteVerify"
+      type="danger"
+      size="small"
+      :loading="isLoading"
+      :text="$t('pages.settings.storage.clear.button')"
+      :action="() => deleteVerify = true"
+    />
+    <span v-if="deleteVerify">
+      <TypographyText
+        :text="$t('pages.settings.storage.clear.subtitle_warning1')"
+        class="detail color-danger no-bottom-pad"
         :size="6"
-        :text="$t('pages.settings.storage.export.title')"
       />
-      <TypographySubtitle
+      <TypographyText
+        :text="$t('pages.settings.storage.clear.subtitle_warning2')"
+        class="detail color-danger"
         :size="6"
-        :text="$t('pages.settings.storage.export.subtitle')"
       />
       <br />
       <InteractablesButton
-        type="primary"
-        size="small"
-        :text="$t('pages.settings.storage.export.button')"
-      />
-    </SettingsUnit>
-  </SettingsSection>
-
-  <SettingsSection>
-    <SettingsUnit>
-      <TypographyTitle
-        :size="6"
-        :text="$t('pages.settings.storage.clear.title')"
-      />
-      <TypographySubtitle
-        :size="6"
-        :text="$t('pages.settings.storage.clear.subtitle')"
-      />
-      <br />
-      <InteractablesButton
-        v-if="!deleteVerify"
         type="danger"
         size="small"
         :loading="isLoading"
-        :text="$t('pages.settings.storage.clear.button')"
-        :action="() => deleteVerify = true"
+        :text="$t('pages.settings.storage.clear.confirm_button')"
+        :action="clearLocalStorage"
       />
-      <span v-if="deleteVerify">
-        <TypographyText
-          :text="$t('pages.settings.storage.clear.subtitle_warning1')"
-          class="detail color-danger no-bottom-pad"
-          :size="6"
-        />
-        <TypographyText
-          :text="$t('pages.settings.storage.clear.subtitle_warning2')"
-          class="detail color-danger"
-          :size="6"
-        />
-        <br />
-        <InteractablesButton
-          type="danger"
-          size="small"
-          :loading="isLoading"
-          :text="$t('pages.settings.storage.clear.confirm_button')"
-          :action="clearLocalStorage"
-        />
-      </span>
-    </SettingsUnit>
-  </SettingsSection>
+    </span>
+  </SettingsUnit>
 </SettingsPage>

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@capacitor/core": "^3.6.0",
     "@capacitor/cli": "^3.6.0",
+    "@capacitor/core": "^3.6.0",
     "@capacitor/local-notifications": "^1.1.0",
     "@nuxtjs/device": "^2.1.0",
     "@nuxtjs/pwa": "^3.3.5",
@@ -83,7 +83,6 @@
     "v-calendar": "^2.4.1",
     "v-click-outside": "^3.1.2",
     "v-scroll-lock": "^1.3.1",
-    "vue-awesome-swiper": "^4.1.1",
     "vue-croppie": "^2.0.2",
     "vue-emoji-picker": "git+https://git@github.com/Satellite-im/vue-emoji-picker#build-satellite",
     "vue-markdown": "^2.2.4",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- improve settings modal styles
- remove settings breadcrumbs since they're not adding a lot of value. not clickable, plus the sidebar tells you where you are
- remove swiper and scroll components from settings modal
- remove 50% limit some pages were getting from the settings layout components

**Which issue(s) this PR fixes** 🔨
AP-2041
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
