### PR TITLE
refactor(chat): remove array inside chatmanager, use object only

### DIFF
--- a/components/views/chat/conversation/Conversation.vue
+++ b/components/views/chat/conversation/Conversation.vue
@@ -29,6 +29,9 @@ export default Vue.extend({
       return iridium.connector?.id ?? ''
     },
     messages(): ConversationMessage[] {
+      if (!Object.keys(this.conversation).length) {
+        return []
+      }
       return Object.values(this.conversation.message).sort(
         (a, b) => a.at - b.at,
       )

--- a/components/views/chat/conversation/Conversation.vue
+++ b/components/views/chat/conversation/Conversation.vue
@@ -20,14 +20,18 @@ export default Vue.extend({
   },
   data() {
     return {
-      messages: iridium.chat.messages?.[this.$route.params.id] ?? [],
       conversation:
-        iridium.chat.state.conversations?.[this.$route.params.id] ?? [],
+        iridium.chat.state.conversations?.[this.$route.params.id] ?? {},
     }
   },
   computed: {
     myDid(): string {
       return iridium.connector?.id ?? ''
+    },
+    messages(): ConversationMessage[] {
+      return Object.values(this.conversation.message).sort(
+        (a, b) => a.at - b.at,
+      )
     },
     chatItems(): ChatItem[] {
       return this.messages

--- a/components/views/navigation/sidebar/list/List.vue
+++ b/components/views/navigation/sidebar/list/List.vue
@@ -12,7 +12,6 @@ export default Vue.extend({
   },
   data: () => ({
     conversations: iridium.chat.state.conversations,
-    messages: iridium.chat.messages,
   }),
   computed: {
     sortedConversations(): Conversation[] {
@@ -32,7 +31,9 @@ export default Vue.extend({
       }
     },
     lastMessageTimestamp(conversation: Conversation): number {
-      const messages = this.messages[conversation.id]
+      const messages = Object.values(
+        this.conversations[conversation.id].message,
+      ).sort((a, b) => a.at - b.at)
       return messages.at(-1)?.at ?? (conversation.updatedAt || 0)
     },
   },

--- a/components/views/navigation/sidebar/list/item/Item.vue
+++ b/components/views/navigation/sidebar/list/item/Item.vue
@@ -33,7 +33,6 @@ export default Vue.extend({
       timeoutId: undefined as NodeJS.Timeout | undefined,
       friends: iridium.friends.list,
       groups: iridium.groups.state,
-      messages: iridium.chat.messages[this.conversation.id],
     }
   },
   computed: {
@@ -66,19 +65,18 @@ export default Vue.extend({
             },
           ]
     },
-    lastMessage(): ConversationMessage | undefined {
-      if (!this.messages.length) {
-        return undefined
-      }
-
-      return this.messages[this.messages.length - 1]
+    messages(): ConversationMessage[] {
+      return Object.values(this.conversation.message).sort(
+        (a, b) => a.at - b.at,
+      )
     },
 
     lastMessageDisplay(): string {
-      if (!this.lastMessage) {
+      const lastMessage = this.messages.at(-1)
+      if (!lastMessage) {
         return this.$t('messaging.say_hi') as string
       }
-      return this.lastMessage.body || ''
+      return lastMessage.body || ''
 
       // const sender = message.from === iridium.connector?.id ? 'me' : 'user'
 

--- a/components/views/navigation/sidebar/list/item/Item.vue
+++ b/components/views/navigation/sidebar/list/item/Item.vue
@@ -66,6 +66,9 @@ export default Vue.extend({
           ]
     },
     messages(): ConversationMessage[] {
+      if (!Object.keys(this.conversation).length) {
+        return []
+      }
       return Object.values(this.conversation.message).sort(
         (a, b) => a.at - b.at,
       )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
at first we tried an array, pushing new messages to the bottom to avoid needing a sort every time. However, I think having two locations referencing the same message objects will be troublesome to maintain. Maybe this can be refactored into some kind of getter to avoid this repeating sort logic, but then you would need to store active conversation id inside the chat manager

This maintains current functionality, can be refactored later

**Which issue(s) this PR fixes** 🔨
AP-2047
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
