### PR TITLE
chore(reactivity): reactivity without vue set

### DIFF
--- a/components/ui/Chat/TypingIndicator/TypingIndicator.vue
+++ b/components/ui/Chat/TypingIndicator/TypingIndicator.vue
@@ -6,18 +6,13 @@ import { ConversationParticipant } from '~/libraries/Iridium/chat/types'
 import iridium from '~/libraries/Iridium/IridiumManager'
 
 export default Vue.extend({
-  data() {
-    return {
-      chat: iridium.chat,
-    }
-  },
   computed: {
     typingParticipants() {
       const conversationId = this.$route.params.id
       if (!conversationId) {
         return
       }
-      return this.chat.getTypingParticipants(conversationId)
+      return iridium.chat.getTypingParticipants(conversationId)
     },
     text(): string {
       if (!this.typingParticipants.length) {

--- a/components/views/chat/chatbar/Chatbar.vue
+++ b/components/views/chat/chatbar/Chatbar.vue
@@ -26,13 +26,6 @@ const Chatbar = Vue.extend({
   components: {
     TerminalIcon,
   },
-  data() {
-    return {
-      friends: iridium.friends.state.details,
-      groups: iridium.groups.state,
-      webrtc: iridium.webRTC,
-    }
-  },
   computed: {
     ...mapState({
       ui: (state: RootState) => state.ui,
@@ -49,7 +42,7 @@ const Chatbar = Vue.extend({
     },
     recipient(): User | Group | undefined {
       if (this.isGroup) {
-        return this.groups[this.conversation.id]
+        return iridium.groups.state[this.conversation.id]
       }
       const participant = this.conversation.participants.find(
         (f) => f.did !== iridium.connector?.id,
@@ -57,7 +50,9 @@ const Chatbar = Vue.extend({
       if (!participant) {
         return
       }
-      return Object.values(this.friends).find((f) => f.did === participant.did)
+      return Object.values(iridium.friends.state.details).find(
+        (f) => f.did === participant.did,
+      )
     },
     consentToScan(): boolean {
       return iridium.settings.state.privacy.consentToScan
@@ -180,7 +175,7 @@ const Chatbar = Vue.extend({
      * @description Throttles the typing event so that we only send the typing once every two seconds
      */
     throttleTyping: throttle(function (ctx) {
-      this.webrtc.sendTyping({ did: this.recipient.did })
+      iridium.webRTC.sendTyping({ did: this.recipient.did })
     }, Config.chat.typingInputThrottle),
     /**
      * @method smartTypingStart

--- a/components/views/chat/conversation/Conversation.vue
+++ b/components/views/chat/conversation/Conversation.vue
@@ -33,12 +33,15 @@ export default Vue.extend({
       return iridium.connector?.id ?? ''
     },
     messages(): ConversationMessage[] {
-      if (!Object.keys(this.conversation).length) {
+      if (
+        !Object.keys(iridium.chat.state.conversations?.[this.$route.params.id])
+          .length
+      ) {
         return []
       }
-      return Object.values(this.conversation.message).sort(
-        (a, b) => a.at - b.at,
-      )
+      return Object.values(
+        iridium.chat.state.conversations?.[this.$route.params.id].message,
+      ).sort((a, b) => a.at - b.at)
     },
     chatItems(): ChatItem[] {
       return this.messages
@@ -53,7 +56,8 @@ export default Vue.extend({
           const isNextDay = prevMessage
             ? !this.$dayjs(prevMessage.at).isSame(message.at, 'day')
             : false
-          const lastReadAt = this.conversation.lastReadAt
+          const lastReadAt =
+            iridium.chat.state.conversations?.[this.$route.params.id].lastReadAt
           const isFirstUnreadMessage =
             message.at > lastReadAt &&
             (prevMessage ? prevMessage.at <= lastReadAt : true)

--- a/components/views/friends/requests/Requests.vue
+++ b/components/views/friends/requests/Requests.vue
@@ -74,19 +74,14 @@ export default Vue.extend({
   components: {
     MessageCircleIcon,
   },
-  data() {
-    return {
-      friends: iridium.friends.state,
-    }
-  },
   computed: {
     incomingRequests(): FriendRequest[] {
-      return Object.values(this.friends.requests).filter(
+      return Object.values(iridium.friends.state.requests).filter(
         (r: FriendRequest) => r.incoming && r.status !== 'accepted',
       )
     },
     outgoingRequests(): FriendRequest[] {
-      return Object.values(this.friends.requests).filter(
+      return Object.values(iridium.friends.state.requests).filter(
         (r: FriendRequest) => !r.incoming && r.status === 'pending',
       )
     },

--- a/components/views/navigation/sidebar/Sidebar.vue
+++ b/components/views/navigation/sidebar/Sidebar.vue
@@ -17,12 +17,11 @@ export default Vue.extend({
   data() {
     return {
       isQuickchatVisible: false,
-      requests: iridium.friends.state.requests,
     }
   },
   computed: {
     incomingRequestsLength(): number {
-      return Object.values(this.requests).filter(
+      return Object.values(iridium.friends.state.requests).filter(
         (r: FriendRequest) => r.status === 'pending' && r.incoming,
       ).length
     },

--- a/components/views/navigation/sidebar/list/List.vue
+++ b/components/views/navigation/sidebar/list/List.vue
@@ -10,12 +10,9 @@ export default Vue.extend({
   components: {
     UserPlusIcon,
   },
-  data: () => ({
-    conversations: iridium.chat.state.conversations,
-  }),
   computed: {
     sortedConversations(): Conversation[] {
-      return Object.values(this.conversations).sort(
+      return Object.values(iridium.chat.state.conversations).sort(
         (a, b) => this.lastMessageTimestamp(b) - this.lastMessageTimestamp(a),
       )
     },
@@ -23,7 +20,7 @@ export default Vue.extend({
   methods: {
     lastMessageTimestamp(conversation: Conversation): number {
       const messages = Object.values(
-        this.conversations[conversation.id].message,
+        iridium.chat.state.conversations[conversation.id].message,
       ).sort((a, b) => a.at - b.at)
       return messages.at(-1)?.at ?? (conversation.updatedAt || 0)
     },

--- a/libraries/Iridium/chat/types.ts
+++ b/libraries/Iridium/chat/types.ts
@@ -46,6 +46,7 @@ export type Conversation = {
   participants: Friend[]
   createdAt: number
   updatedAt: number
+  lastReadAt: number
   message: {
     [key: string]: ConversationMessage
   }

--- a/libraries/Iridium/friends/FriendsManager.ts
+++ b/libraries/Iridium/friends/FriendsManager.ts
@@ -1,4 +1,3 @@
-import Vue from 'vue'
 import {
   IridiumPeerIdentifier,
   Emitter,
@@ -228,7 +227,7 @@ export default class FriendsManager extends Emitter<IridiumFriendPubsub> {
     const friend = this.getFriend(user.did)
     if (!friend) return
 
-    Vue.set(this.state.details, user.did, user)
+    this.state.details = { ...this.state.details, [user.did]: user }
   }
 
   async send(event: IridiumFriendEvent) {
@@ -289,7 +288,7 @@ export default class FriendsManager extends Emitter<IridiumFriendPubsub> {
       at: Date.now(),
     }
 
-    Vue.set(this.state.requests, did, request)
+    this.state.requests = { ...this.state.requests, [did]: request }
     await this.set(`/requests/${did}`, request)
     logger.info(this.loggerTag, 'friend request created', {
       did,
@@ -333,7 +332,7 @@ export default class FriendsManager extends Emitter<IridiumFriendPubsub> {
       throw new Error(FriendsError.REQUEST_NOT_FOUND)
     }
 
-    Vue.delete(this.state.requests, didUtils.didString(did))
+    delete this.state.requests[didUtils.didString(did)]
     await this.set(`/requests`, this.state.requests)
     logger.info(this.loggerTag, 'request rejected', {
       did,
@@ -415,8 +414,9 @@ export default class FriendsManager extends Emitter<IridiumFriendPubsub> {
     }
 
     request.status = 'accepted'
-    Vue.set(this.state.details, user.did, user)
-    Vue.delete(this.state.requests, didUtils.didString(did))
+    this.state.details = { ...this.state.details, [user.did]: user }
+    delete this.state.requests[didUtils.didString(did)]
+
     await this.set(`/details/${user.did}`, user)
     await this.set(`/requests`, this.state.requests)
 
@@ -471,7 +471,7 @@ export default class FriendsManager extends Emitter<IridiumFriendPubsub> {
 
     const didString = didUtils.didString(did)
 
-    Vue.delete(this.state.details, didString)
+    delete this.state.details[didString]
     await this.set(`/details`, this.state.details)
     const id = this.iridium.chat.directConversationIdFromDid(didString)
     if (id) {

--- a/libraries/Iridium/webrtc/WebRTCManager.ts
+++ b/libraries/Iridium/webrtc/WebRTCManager.ts
@@ -534,7 +534,7 @@ export default class WebRTCManager extends Emitter {
 
       this.timeoutMap[did] = setTimeout(() => {
         this.iridium.chat.updateConversation({
-          ...conversation,
+          ...this.iridium.chat?.getConversation(id),
           participants: conversation.participants.map((participant) => {
             if (participant.did === did) {
               return {

--- a/pages/friends/index.vue
+++ b/pages/friends/index.vue
@@ -13,18 +13,17 @@ export default Vue.extend({
   data() {
     return {
       FriendsTabs,
-      friends: iridium.friends.state,
     }
   },
   computed: {
     friendsList(): Friend[] {
-      return Object.values(this.friends.details)
+      return Object.values(iridium.friends.state.details)
     },
     activeTab(): FriendsTabs {
       return this.$store.state.friends.activeTab
     },
     incomingRequests(): FriendRequest[] {
-      return Object.values(this.friends.requests).filter(
+      return Object.values(iridium.friends.state.requests).filter(
         (r: FriendRequest) => r.incoming && r.status !== 'accepted',
       )
     },


### PR DESCRIPTION
This is just a proof of concept for Vue reactivity.

it seems like we don't have to `Vue.set` in Iridium Managers,
we can simply update the manager state and then reference the state directly in a `computed` method.