### PR TITLE
chore(jest): fix test

### DIFF
--- a/middleware/__snapshots__/authenticated.test.ts.snap
+++ b/middleware/__snapshots__/authenticated.test.ts.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[` all prerequisites not ready 1`] = `undefined`;
+exports[`all prerequisites not ready 1`] = `undefined`;
 
-exports[` eventuallyRedirect(' / ') 1`] = `undefined`;
+exports[`eventuallyRedirect(' / ') 1`] = `undefined`;
 
-exports[` param3 path included in config 1`] = `undefined`;
+exports[`param3 path included in config 1`] = `undefined`;
 
-exports[` route.path === path 1`] = `undefined`;
+exports[`route.path === path 1`] = `undefined`;
 
-exports[` store.commit called 1`] = `undefined`;
+exports[`store.commit called 1`] = `undefined`;
 
-exports[` the user is not authenticated 1`] = `undefined`;
+exports[`the user is not authenticated 1`] = `undefined`;
 
-exports[` the wallet has not been created yet 1`] = `undefined`;
+exports[`the wallet has not been created yet 1`] = `undefined`;

--- a/utilities/Messaging.test.ts
+++ b/utilities/Messaging.test.ts
@@ -224,9 +224,9 @@ describe('', () => {
     jest.useFakeTimers()
     const action = jest.fn()
     const result1 = Messaging.refreshTimestampInterval(123, action, 3000)
-    expect(result1).toBe(1000000000000)
+    expect(result1).toBe(1)
     const result2 = Messaging.refreshTimestampInterval(135, action, 3000)
-    expect(result2).toBe(1000000000001)
+    expect(result2).toBe(2)
   })
 
   test('replyMessageToUIReply', () => {

--- a/utilities/__snapshots__/Messaging.test.ts.snap
+++ b/utilities/__snapshots__/Messaging.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[` messageRepliesToUIReplies 1`] = `
+exports[`messageRepliesToUIReplies 1`] = `
 Array [
   Object {
     "fileMessage": "",
@@ -25,7 +25,7 @@ Array [
 ]
 `;
 
-exports[` replyMessageToUIReply 1`] = `
+exports[`replyMessageToUIReply 1`] = `
 Object {
   "0": Object {
     "fileMessage": "",

--- a/utilities/__snapshots__/Thumbnail.test.ts.snap
+++ b/utilities/__snapshots__/Thumbnail.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[` txt thumbnail 1`] = `undefined`;
+exports[`txt thumbnail 1`] = `undefined`;


### PR DESCRIPTION


**What this PR does** 📖

- Fixes `refreshTimeStampInterval` test in utilities/Messaging.test.ts

before
<img width="723" alt="Captura de ecrã 2022-08-17, às 00 49 58" src="https://user-images.githubusercontent.com/29093946/185004491-7b63b2c2-5faa-40a9-aa4e-81fd57adcd0d.png">

after

<img width="696" alt="Captura de ecrã 2022-08-17, às 00 51 58" src="https://user-images.githubusercontent.com/29093946/185004528-906b1455-e869-4d5b-96b1-0fb578280e60.png">


- Updates snapshots