### PR TITLE
fix(files): fix rename reactivity and delete action

### DIFF
--- a/components/views/files/controls/Controls.less
+++ b/components/views/files/controls/Controls.less
@@ -8,6 +8,7 @@
 
     .input-button {
       &.active {
+        color: @satellite-color-secondary;
         filter: drop-shadow(0px 0px 3px @satellite-color-secondary);
       }
 

--- a/libraries/Iridium/files/FilesManager.ts
+++ b/libraries/Iridium/files/FilesManager.ts
@@ -163,7 +163,12 @@ export default class FilesManager extends Emitter {
   private removeFromFileSystem(item: IridiumItem) {
     // if root item
     if (!item.parentId) {
-      const index = this.state.items.indexOf(item)
+      const index = this.state.items.findIndex((e) => e.id === item.id)
+
+      if (index === -1) {
+        throw new Error('item not found')
+      }
+
       this.state.items.splice(index, 1)
       this.set('/items', this.state.items)
       return
@@ -172,10 +177,13 @@ export default class FilesManager extends Emitter {
       | IridiumDirectory
       | undefined
     if (parent) {
-      const index = parent.children.indexOf(item)
-      if (index > -1) {
-        parent.children.splice(index, 1)
+      const index = parent.children.findIndex((e) => e.id === item.id)
+
+      if (index === -1) {
+        throw new Error('item not found')
       }
+
+      parent.children.splice(index, 1)
       this.set('/items', this.state.items)
     }
   }
@@ -226,15 +234,25 @@ export default class FilesManager extends Emitter {
     if (!item) {
       return
     }
-    if (name !== undefined) {
-      const parent = this.flat.find((e) => e.id === item.parentId) as
-        | IridiumDirectory
-        | undefined
-      this.validateName(name, parent)
-      item.name = name
-    } else if (liked !== undefined) {
-      item.liked = liked
+
+    // find item in state
+    const parent = this.flat.find((e) => e.id === item.parentId) as
+      | IridiumDirectory
+      | undefined
+    const target = parent?.children ?? this.state.items
+    const index = target.findIndex((e) => e.id === item.id)
+
+    if (index === -1) {
+      throw new Error('item not found')
     }
+
+    if (name !== undefined) {
+      this.validateName(name, parent)
+      target[index].name = name
+    } else if (liked !== undefined) {
+      target[index].liked = liked
+    }
+
     this.set('/items', this.state.items)
   }
 

--- a/pages/files/index.vue
+++ b/pages/files/index.vue
@@ -32,11 +32,7 @@ export default Vue.extend({
     }),
     directory(): IridiumItem[] {
       const filteredItems = this.searchedItems(this.items, this.searchValue)
-      return this.sortedItems(
-        filteredItems,
-        this.items,
-        this.$route.query.route,
-      )
+      return this.sortedItems(filteredItems, this.$route.query.route)
     },
     searchScope(): string {
       const directoryPath = this.path.map((v) => v.name).join(' › ')

--- a/store/files/getters.ts
+++ b/store/files/getters.ts
@@ -1,7 +1,6 @@
 import Vue from 'vue'
 import { GetterTree } from 'vuex'
 import fuzzysort from 'fuzzysort'
-import { cloneDeep } from 'lodash'
 import { FileRouteEnum, FileSortEnum } from '~/libraries/Enums/enums'
 import { IridiumDirectory, IridiumItem } from '~/libraries/Iridium/files/types'
 import { FilesState } from '~/store/files/types'
@@ -25,7 +24,7 @@ const getters: GetterTree<FilesState, RootState> & FilesGetters = {
         return files
       }
 
-      let items: IridiumItem[] = cloneDeep(files)
+      let items: IridiumItem[] = files
       const itemsFlat = flatDeep(items)
 
       if (state.search.searchAll) {
@@ -59,7 +58,7 @@ const getters: GetterTree<FilesState, RootState> & FilesGetters = {
       const key = state.sort.category
       const searchAllActive = state.search.searchAll && state.search.value
 
-      let items: IridiumItem[] = cloneDeep(filteredFiles)
+      let items: IridiumItem[] = filteredFiles
       const allItems = flatDeep(allFiles)
 
       // If "SearchAll" is inactive, we only want to sort the items that are in the current directory

--- a/store/files/getters.ts
+++ b/store/files/getters.ts
@@ -63,7 +63,7 @@ const getters: GetterTree<FilesState, RootState> & FilesGetters = {
         const recentItems = iridium.files.flat
           .filter((e) => !('children' in e))
           .sort((a, b) => b.modified - a.modified)
-          .slice(1, 14)
+          .slice(0, 14)
 
         if (recentItems) {
           items = recentItems

--- a/store/files/getters.ts
+++ b/store/files/getters.ts
@@ -96,14 +96,4 @@ const getters: GetterTree<FilesState, RootState> & FilesGetters = {
     },
 }
 
-const flatDeep = (list: IridiumItem[]): IridiumItem[] => {
-  return list.reduce((prev: IridiumItem[], curr) => {
-    prev.push(curr)
-    if ('children' in curr) {
-      prev.push(...flatDeep(curr.children))
-    }
-    return prev
-  }, [])
-}
-
 export default getters

--- a/store/files/getters.ts
+++ b/store/files/getters.ts
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import { GetterTree } from 'vuex'
 import fuzzysort from 'fuzzysort'
+import { cloneDeep } from 'lodash'
 import { FileRouteEnum, FileSortEnum } from '~/libraries/Enums/enums'
 import { IridiumDirectory, IridiumItem } from '~/libraries/Iridium/files/types'
 import { FilesState } from '~/store/files/types'
@@ -24,7 +25,7 @@ const getters: GetterTree<FilesState, RootState> & FilesGetters = {
         return files
       }
 
-      let items: IridiumItem[] = structuredClone(files)
+      let items: IridiumItem[] = cloneDeep(files)
       const itemsFlat = flatDeep(items)
 
       if (state.search.searchAll) {
@@ -58,7 +59,7 @@ const getters: GetterTree<FilesState, RootState> & FilesGetters = {
       const key = state.sort.category
       const searchAllActive = state.search.searchAll && state.search.value
 
-      let items: IridiumItem[] = structuredClone(filteredFiles)
+      let items: IridiumItem[] = cloneDeep(filteredFiles)
       const allItems = flatDeep(allFiles)
 
       // If "SearchAll" is inactive, we only want to sort the items that are in the current directory


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Fixes reactivity for file name changes
- Fixes deletion from removing incorrect files

**Which issue(s) this PR fixes** 🔨
AP-2168
<!--AP-X-->

**Special notes for reviewers** 🗒️
- These problems occurred due to the item data in "store/files/getters.ts" becoming cloned to avoid direct mutational changes from happening to the file state. As the file actions (including rename, delete, and like) were relying on directly mutating the file state they stopped working.
- @josephmcg Would you prefer the current fix and prevent direct mutation of the iridium file state to avoid any potential unintended side-effects? Or should we keep the original structure so the state can be directly mutated? Can understand the benefit of not cloning whenever a change is made, but considering the scope of the project it might be a good idea to avoid relying on mutating the state whenever possible.

**Additional comments** 🎤
