### PR TITLE
fix(build): resolve root import warnings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,7 +39,5 @@
     "electron",
     "android"
   ],
-  "include": [
-  "*.test.ts"
-  ], 
+  "include": ["./**/*.test.ts"]
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Fixes an invalid path in tsconfig to stop invalid root import warnings from being displayed.

**Which issue(s) this PR fixes** 🔨
AP-2170
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
