### PR TITLE
chore(linkscript): move iridum clone up a level, out of core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,5 +102,3 @@ scratchpad.js
 .vscode/chrome/
 
 solana-localnet
-
-iridium

--- a/linkscript.sh
+++ b/linkscript.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-git clone https://github.com/Satellite-im/iridium.git
-cp .env iridium/.env
-cd iridium
+git clone https://github.com/Satellite-im/iridium.git ../iridium
+cp .env ../iridium/.env
+cd ../iridium
 export SYNC_NODE_ADDR=/ip4/138.197.229.159/tcp/4003/ws,/ip4/138.197.229.159/tcp/4002
 corepack enable
 corepack prepare pnpm@7.9.1 --activate
@@ -9,6 +9,6 @@ pnpm i --unsafe-perm
 pnpm build:ipfs
 pnpm build:browser
 yarn link
-cd ..
+cd ../Core-PWA
 grep -v "@satellite-im/iridium" package.json > tmppackage && mv tmppackage package.json
 yarn link @satellite-im/iridium


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
A lot of people are having problems with iridium getting cloned into core to be linked, test to do everything outside of core and seeing if the autodeploy works okay with that

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
