### PR TITLE
feat(chat): is_typing indicator

### DIFF
--- a/components/ui/Chat/TypingIndicator/TypingIndicator.less
+++ b/components/ui/Chat/TypingIndicator/TypingIndicator.less
@@ -17,7 +17,7 @@
     line-height: 1.6rem;
     font-size: 0.7em;
   }
-  margin-left: 1.4rem;
+  margin-left: 26px;
   display: flex;
 }
 

--- a/components/ui/Chat/TypingIndicator/TypingIndicator.vue
+++ b/components/ui/Chat/TypingIndicator/TypingIndicator.vue
@@ -2,16 +2,31 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import { mapGetters } from 'vuex'
-import { ConversationParticipant } from '~/store/conversation/types'
+import iridium from '~/libraries/Iridium/IridiumManager'
+import { User } from '~/libraries/Iridium/users/types'
+
 export default Vue.extend({
+  data() {
+    return {
+      chat: iridium.chat,
+    }
+  },
   computed: {
-    ...mapGetters('conversation', ['typingParticipants']),
+    typingParticipants(): User[] {
+      const conversationId = this.$route.params.id
+      const conversation = this.chat.getConversation(conversationId)
+      if (!conversation || !conversation.typing) {
+        return []
+      }
+
+      return Object.keys(conversation.typing)
+        .filter((k) => conversation.typing?.[k])
+        .map((did) => iridium.users.getUser(did))
+        .filter(Boolean)
+    },
     text(): string {
       return this.$tc('messaging.typing', this.typingParticipants.length, {
-        user: this.typingParticipants
-          .map((p: ConversationParticipant) => p.name)
-          .join(', '),
+        user: this.typingParticipants.map((u) => u.name).join(', '),
       })
     },
   },

--- a/components/ui/Global/Global.vue
+++ b/components/ui/Global/Global.vue
@@ -111,15 +111,6 @@ export default Vue.extend({
       this.$store.commit('ui/fullscreen', false)
       iridium.webRTC.denyCall()
     },
-    /**
-     * @method hangUp
-     * @description Hangs up active call
-     * @example
-     */
-    hangUp() {
-      this.$store.commit('ui/fullscreen', false)
-      iridium.webRTC.hangUp()
-    },
   },
 })
 </script>

--- a/components/views/chat/chatbar/Chatbar.vue
+++ b/components/views/chat/chatbar/Chatbar.vue
@@ -148,9 +148,13 @@ const Chatbar = Vue.extend({
      * @method throttleTyping
      * @description Throttles the typing event so that we only send the typing once every two seconds
      */
-    throttleTyping: throttle(function (ctx) {
-      ctx.$store.dispatch('webrtc/sendTyping')
-    }, Config.chat.typingInputThrottle),
+    throttleTyping: throttle(
+      function () {
+        iridium.webRTC.sendTyping(this.conversationId)
+      },
+      Config.chat.typingInputThrottle,
+      { trailing: false },
+    ),
     /**
      * @method smartTypingStart
      * @description Let's us send out events when a user starts typing without spam.

--- a/components/views/chat/chatbar/footer/Footer.vue
+++ b/components/views/chat/chatbar/footer/Footer.vue
@@ -2,9 +2,10 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import { mapState, mapGetters } from 'vuex'
+import { mapState } from 'vuex'
 import { CircleIcon } from 'satellite-lucide-icons'
 import { RootState } from '~/types/store/store'
+import iridium from '~/libraries/Iridium/IridiumManager'
 
 export default Vue.extend({
   components: {
@@ -20,7 +21,17 @@ export default Vue.extend({
     ...mapState({
       ui: (state) => (state as RootState).ui,
     }),
-    ...mapGetters('conversation', ['typingParticipants']),
+    typingParticipants(): string[] {
+      const conversationId = this.$route.params.id
+      const conversation = iridium.chat.getConversation(conversationId)
+      if (!conversation || !conversation.typing) {
+        return []
+      }
+
+      return Object.keys(conversation.typing).filter(
+        (k) => conversation.typing?.[k],
+      )
+    },
     lengthCount() {
       return `${this.ui.chatbarContent.length}/${this.$Config.chat.maxChars}`
     },

--- a/libraries/Iridium/chat/ChatManager.ts
+++ b/libraries/Iridium/chat/ChatManager.ts
@@ -259,6 +259,15 @@ export default class ChatManager extends Emitter<ConversationMessage> {
         `/conversations/${conversationId}/message/${message.id}`,
         message,
       )
+
+      // Remove is_typing indicator upon user message receive
+      clearTimeout(this.iridium.webRTC.timeoutMap[message.from])
+      Vue.set(
+        this.state.conversations[conversationId].typing,
+        message.from,
+        false,
+      )
+
       const friendName = this.iridium.users.getUser(message?.from)
       const buildNotification: Partial<Notification> = {
         fromName: friendName?.name,

--- a/libraries/Iridium/chat/types.ts
+++ b/libraries/Iridium/chat/types.ts
@@ -52,6 +52,9 @@ export type Conversation = {
   type: 'direct' | 'group'
   name?: string
   participants: string[]
+  typing?: {
+    [key: string]: boolean
+  }
   createdAt: number
   updatedAt: number
   message: {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Restore is_typing indicator in chat.
When the user sends the message, on the receiver the typing indicator is removed

**Which issue(s) this PR fixes** 🔨
AP-2017

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
If we will have hooks for the conversation some of the code can be refactored