### PR TITLE
chore(eslint): add cypress eslint 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "plugins": ["cypress"],
+  "extends": ["plugin:cypress/recommended"],
+  "rules": {
+      "jest/expect-expect": "off"
+  }
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -28,6 +28,7 @@ module.exports = {
   testPathIgnorePatterns: [
     '<rootDir>/node_modules',
     '<rootDir>/linked-iridium',
+    '<rootDir>/iridium',
     '<rootDir>/cypress',
   ],
   coveragePathIgnorePatterns: [

--- a/jest.config.js
+++ b/jest.config.js
@@ -28,6 +28,7 @@ module.exports = {
   testPathIgnorePatterns: [
     '<rootDir>/node_modules',
     '<rootDir>/linked-iridium',
+    '<rootDir>/cypress',
   ],
   coveragePathIgnorePatterns: [
     '<rootDir>/.nuxt',

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "cypress-real-events": "^1.7.0",
     "eslint": "^8.22.0",
     "eslint-config-prettier": "^8.4.0",
+    "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-jest": "^26.8.3",
     "eslint-plugin-nuxt": "^3.1.0",
     "eslint-plugin-prettier": "^4.0.0",


### PR DESCRIPTION
**What this PR does** 📖

- Adds eslint for Cypress
- Ignores Cypress tests on Jest config
- Adds iridium to be ignored on jest.config.js to avoid running tests from iridium repo
