### PR TITLE
refactor(calls): improve mediaUser markup

### DIFF
--- a/assets/styles/base.less
+++ b/assets/styles/base.less
@@ -1,5 +1,4 @@
 :root {
-  --app-height: 100vh;
   --flair-color: @satellite-color;
   --flair-color-secondary: @satellite-color-secondary;
   --flair-color-rgb: @satellite-color-rgb;
@@ -291,29 +290,6 @@ button {
   }
 }
 
-//Media
-#media-heading {
-  .tag {
-    &:extend(.background-flair);
-    &:extend(.glow-flair);
-    &:extend(.font-primary);
-  }
-}
-
-.user {
-  .tag {
-    &:extend(.background-flair);
-  }
-}
-
-.media-user {
-  &:extend(.background-flair);
-}
-
-.more-user {
-  &:extend(.background-flair);
-}
-
 //Video
 .plyr__control--overlaid {
   &:extend(.glow-flair);
@@ -322,32 +298,6 @@ button {
 
 .plyr--full-ui input[type='range'] {
   &:extend(.font-flair);
-}
-
-//Tag
-.tag {
-  font-family: @secondary-font;
-  &:extend(.background-flair-gradient);
-  &:extend(.glow-flair);
-  &:extend(.font-secondary);
-  .tag-number {
-    &:extend(.background-flair);
-  }
-
-  &:not(body).is-dark {
-    .tag-number {
-      &:extend(.background-flair);
-    }
-    background: @background;
-  }
-  &:not(body).is-primary {
-    &:extend(.background-flair);
-  }
-}
-
-.tag-inverted {
-  &:extend(.font-secondary);
-  background: @foreground;
 }
 
 .is-chatbar-reply {

--- a/assets/styles/framework/typography.less
+++ b/assets/styles/framework/typography.less
@@ -73,6 +73,9 @@ h6 {
   &-color-error {
     color: @red;
   }
+  &-color-white {
+    color: @white;
+  }
 }
 
 .font-weight {

--- a/components/typography/Tag/Tag.vue
+++ b/components/typography/Tag/Tag.vue
@@ -1,14 +1,18 @@
 <template>
-  <span :class="inverted ? 'tag tag-inverted' : 'tag'">
-    {{ text }}
-  </span>
+  <TypographyText
+    class="tag"
+    :class="{ inverted: inverted }"
+    color="white"
+    size="xs"
+  >
+    <slot>{{ text }}</slot>
+  </TypographyText>
 </template>
 <script lang="ts">
 import Vue from 'vue'
 
 export default Vue.extend({
   props: {
-    // eslint-disable-next-line vue/require-default-prop
     text: {
       type: String,
       default: '',
@@ -21,7 +25,17 @@ export default Vue.extend({
 })
 </script>
 <style lang="less">
-.tag-inverted {
-  box-shadow: none;
+.tag {
+  user-select: none;
+  background-color: @flair-color;
+  background: @flair-gradient;
+  box-shadow: @flair-glow;
+  padding: 4px 8px;
+  border-radius: @corner-rounding;
+
+  &.inverted {
+    background: @semitransparent-dark-gradient;
+    box-shadow: none;
+  }
 }
 </style>

--- a/components/typography/Text.vue
+++ b/components/typography/Text.vue
@@ -82,7 +82,7 @@ export default Vue.extend({
       if (this.as.match('h[1-3]')) {
         return 'bold'
       }
-      return ''
+      return 'normal'
     },
   },
 })

--- a/components/views/media/Media.html
+++ b/components/views/media/Media.html
@@ -1,27 +1,26 @@
-<div id="mediastream" data-cy="mediastream" ref="mediastream">
+<div class="mediastream" data-cy="mediastream" ref="mediastream">
   <MediaHeading />
-  <div id="media" ref="media">
+  <div class="media" ref="media">
     <MediaUser
       id="local_video"
+      :user="localParticipant"
+      isLocal
       data-cy="local-video"
       @dblclick="handleDoubleClick('local_video')"
-      :user="localParticipant"
-      :isLocal="true"
     />
 
     <MediaUser
       v-for="participant in remoteParticipants"
       :id="`remote_video_${ participant.did }`"
+      :user="participant"
       data-cy="remote-video"
       @dblclick="handleDoubleClick('remote_video')"
-      :user="participant"
-      :isLocal="false"
     />
 
     <div
-      v-if="fullscreen && users.length > fullscreenMaxViewableUsers || !fullscreen && users.length > maxViewableUsers"
+      v-if="ui.fullscreen && users.length > fullscreenMaxViewableUsers || !ui.fullscreen && users.length > maxViewableUsers"
       class="more-user"
-      v-bind:class="{full: fullscreen, 'full-mobile': fullscreenMaxViewableUsers === 6}"
+      :class="{full: ui.fullscreen, 'full-mobile': fullscreenMaxViewableUsers === 6}"
     >
       ...
     </div>

--- a/components/views/media/Media.less
+++ b/components/views/media/Media.less
@@ -1,28 +1,29 @@
-#mediastream {
-  &:extend(.second-layer);
-  height: auto;
-  max-height: 25.5rem;
-  &:extend(.full-width);
-  &:extend(.background-semitransparent-dark);
-  &:extend(.blur);
-  padding: 0.75rem;
+.mediastream {
   display: flex;
+  max-height: 25.5rem;
+  background-color: @midground;
+  padding: 0.75rem;
   flex-direction: column;
-  &:extend(.round-corners);
+  position: relative;
+  border-radius: @corner-rounding;
 
-  #media {
+  .media {
     position: relative;
     display: flex;
     flex: 1;
-    &:extend(.full-width);
-    overflow: hidden;
     justify-content: center;
     align-items: center;
     flex-wrap: wrap;
+    overflow-y: auto;
+    gap: 8px;
+
+    #local_video {
+      order: -1;
+    }
+
     .user {
       width: 16rem;
       height: 9rem;
-      margin: @xlight-spacing;
       &.full-video {
         position: absolute;
         width: 100% !important;
@@ -50,55 +51,22 @@
           right: 0;
           bottom: 0;
           padding: 1rem;
-
-          &:extend(.first-layer);
           .indicator {
             margin-left: @light-spacing;
           }
         }
-      }
-
-      &:nth-child(1) {
-        order: 1;
-      }
-      &:nth-child(2) {
-        order: 2;
-      }
-      &:nth-child(3) {
-        order: 3;
-      }
-      &:nth-child(4) {
-        order: 4;
-      }
-      &:nth-child(5) {
-        order: 5;
-      }
-      &:nth-child(6) {
-        order: 6;
-      }
-      &:nth-child(7) {
-        order: 7;
-      }
-      &:nth-child(8) {
-        order: 8;
-      }
-      &:nth-child(9) {
-        order: 9;
-      }
-      &:nth-child(10) {
-        order: 10;
       }
     }
   }
 }
 
 .fullscreen-media {
-  #mediastream {
+  .mediastream {
     max-height: unset;
     height: calc(@full - @toolbar-height - @light-spacing);
     margin-bottom: 1rem;
 
-    #media {
+    .media {
       justify-content: center;
       flex-direction: row;
       .user {
@@ -135,34 +103,10 @@
 }
 
 @media only screen and (max-width: @mobile-breakpoint) {
-  #mediastream {
+  .mediastream {
     min-width: @viewport-width;
     top: @toolbar-height - @normal-spacing;
     margin: 0;
     border-radius: 0;
-  }
-}
-
-@media only screen and (max-width: 1917px) {
-  .more-user:not(.full) {
-    order: 9;
-  }
-}
-
-@media only screen and (max-width: 1653px) {
-  .more-user:not(.full) {
-    order: 7;
-  }
-}
-
-@media only screen and (max-width: 1389px) {
-  .more-user:not(.full) {
-    order: 5;
-  }
-}
-
-@media only screen and (max-width: 1125px) {
-  .more-user:not(.full) {
-    order: 3;
   }
 }

--- a/components/views/media/Media.vue
+++ b/components/views/media/Media.vue
@@ -13,11 +13,6 @@ export default Vue.extend({
       type: Array as PropType<Array<User>>,
       default: () => [],
     },
-    fullscreen: {
-      type: Boolean,
-      default: false,
-      required: true,
-    },
     maxViewableUsers: {
       type: Number,
       default: 0,
@@ -36,7 +31,6 @@ export default Vue.extend({
   },
   data() {
     return {
-      componentKey: this.fullscreen,
       webrtc: iridium.webRTC.state,
     }
   },
@@ -44,7 +38,7 @@ export default Vue.extend({
     ...mapState(['ui', 'accounts', 'groups', 'audio']),
   },
   watch: {
-    fullscreen(value) {
+    'ui.fullscreen'(value) {
       const media: HTMLElement = this.$refs.media as HTMLElement
       if (!value) {
         const blocks = media.querySelectorAll('.user, .more-user')

--- a/components/views/media/heading/Heading.html
+++ b/components/views/media/heading/Heading.html
@@ -1,14 +1,6 @@
-<div id="media-heading">
-  <TypographyTag
-    v-if="elapsedTime"
-    data-cy="elapsed-time"
-    :text="$t('ui.live', {
-    time: elapsedTime
-  })"
-  />
-  <div class="spacer"></div>
+<div class="heading">
   <transition name="media-fullscreen" mode="out-in">
-    <div
+    <button
       :key="ui.fullscreen"
       v-tooltip.left="ui.fullscreen ? $t('ui.exit_fullscreen') : $t('ui.fullscreen')"
       @click="toggleFullscreen"
@@ -19,6 +11,9 @@
         size="1.2x"
       />
       <maximize-icon v-else data-cy="go-fullscreen" size="1.2x" />
-    </div>
+    </button>
   </transition>
+  <TypographyTag v-if="elapsedTime" data-cy="elapsed-time">
+    {{$t('ui.live', { time: elapsedTime })}}
+  </TypographyTag>
 </div>

--- a/components/views/media/heading/Heading.less
+++ b/components/views/media/heading/Heading.less
@@ -1,14 +1,12 @@
-#media-heading {
-  .spacer {
-    flex: 1;
-  }
-  .expand-icon {
-    align-self: center;
-    justify-self: flex-end;
-    cursor: pointer;
-  }
-  height: 2rem;
+.heading {
   display: flex;
+  justify-content: space-between;
+  flex-direction: row-reverse;
+  min-height: 26px;
+
+  button {
+    height: fit-content;
+  }
 }
 
 .media-fullscreen-enter,

--- a/components/views/media/incomingCall/IncomingCall.html
+++ b/components/views/media/incomingCall/IncomingCall.html
@@ -16,18 +16,18 @@
   <UiLoadersScaleLoader />
   <div class="buttons">
     <InteractablesButton
-      color="success"
-      @click="acceptCall(['audio'])"
-      data-cy="incoming-call-accept"
-    >
-      <phone-icon size="1x" class="button-icon" />
-    </InteractablesButton>
-    <InteractablesButton
       color="danger"
       @click="denyCall"
       data-cy="incoming-call-deny"
     >
       <phone-off-icon size="1x" class="button-icon" />
+    </InteractablesButton>
+    <InteractablesButton
+      color="success"
+      @click="acceptCall(['audio'])"
+      data-cy="incoming-call-accept"
+    >
+      <phone-icon size="1x" class="button-icon" />
     </InteractablesButton>
   </div>
 </div>

--- a/components/views/media/user/User.html
+++ b/components/views/media/user/User.html
@@ -1,54 +1,41 @@
 <div v-if="call" class="user">
-  <div v-if="screenStream" class="video-stream-container">
-    <video
-      :id="`${isLocal ? 'local' : 'remote'}-screen-${user.did}`"
-      class="video-stream screen-stream"
-      data-cy="screen-stream"
-      :src-object.prop="screenStream"
-      playsinline
-      autoplay
-    ></video>
-  </div>
+  <video
+    v-if="videoStream"
+    :id="`${isLocal ? 'local' : 'remote'}-video-${user.did}`"
+    class="video-stream"
+    data-cy="video-stream"
+    :src-object.prop="videoStream"
+    playsinline
+    autoplay
+  />
 
-  <div v-else-if="videoStream" class="video-stream-container">
-    <video
-      :id="`${isLocal ? 'local' : 'remote'}-video-${user.did}`"
-      class="video-stream"
-      data-cy="video-stream"
-      :src-object.prop="videoStream"
-      playsinline
-      autoplay
-    ></video>
-  </div>
+  <video
+    v-if="screenStream"
+    :id="`${isLocal ? 'local' : 'remote'}-screen-${user.did}`"
+    class="video-stream"
+    data-cy="screen-stream"
+    :src-object.prop="screenStream"
+    playsinline
+    autoplay
+  />
 
   <div
-    class="media-user"
+    v-else-if="!screenStream || !videoStream"
+    class="voice-user"
     :class="{calling: audioStream, loading: isPending && !isLocal}"
-    v-else-if="user"
   >
+    <TypographyTag :title="user.name" class="ellipsis tag" inverted>
+      {{user.name}}
+    </TypographyTag>
+    <UiLoadersScaleLoader v-if="isPending && !isLocal" class="loader" />
     <UiCircle
+      v-else
       :type="src ? 'image' : 'random'"
       :seed="user.did"
       :size="$device.isMobile ? 36 : 65"
       data-cy="media-user-circle"
       :source="src"
       color="transparent"
-    />
-    <TypographyTag :text="user.name" :title="user.name" inverted />
-    <div class="loader" v-if="isPending && !isLocal">
-      <UiLoadersScaleLoader />
-    </div>
-  </div>
-
-  <div
-    v-if="!isLocal && !audio.deafened && audioStream"
-    class="audio-stream-container"
-  >
-    <audio
-      :id="`audio-stream-${audioStream.id}`"
-      :class="`${isLocal ? 'local' : 'remote'}-audio-stream`"
-      :src-object.prop="audioStream"
-      autoplay
     />
   </div>
 
@@ -57,4 +44,12 @@
       <mic-off-icon />
     </div>
   </div>
+
+  <audio
+    v-if="!isLocal && !audio.deafened && audioStream"
+    :id="`audio-stream-${audioStream.id}`"
+    :class="`${isLocal ? 'local' : 'remote'}-audio-stream`"
+    :src-object.prop="audioStream"
+    autoplay
+  />
 </div>

--- a/components/views/media/user/User.html
+++ b/components/views/media/user/User.html
@@ -9,18 +9,8 @@
     autoplay
   />
 
-  <video
-    v-if="screenStream"
-    :id="`${isLocal ? 'local' : 'remote'}-screen-${user.did}`"
-    class="video-stream"
-    data-cy="screen-stream"
-    :src-object.prop="screenStream"
-    playsinline
-    autoplay
-  />
-
   <div
-    v-else-if="!screenStream || !videoStream"
+    v-else
     class="voice-user"
     :class="{calling: audioStream, loading: isPending && !isLocal}"
   >
@@ -38,6 +28,16 @@
       color="transparent"
     />
   </div>
+
+  <video
+    v-if="screenStream"
+    :id="`${isLocal ? 'local' : 'remote'}-screen-${user.did}`"
+    class="video-stream"
+    data-cy="screen-stream"
+    :src-object.prop="screenStream"
+    playsinline
+    autoplay
+  />
 
   <div class="indicators" v-if="!isPending || isLocal">
     <div class="indicator" data-cy="muted-indicator" v-if="!audioStream">

--- a/components/views/media/user/User.less
+++ b/components/views/media/user/User.less
@@ -1,13 +1,12 @@
 .user {
   position: relative;
-}
+  background: linear-gradient(
+      180deg,
+      rgba(48, 52, 71, 0.7) 0%,
+      rgba(42, 54, 75, 0) 100%
+    ),
+    @foreground-alt;
 
-.video-stream-container {
-  height: 100%;
-  width: 100%;
-  background: @semitransparent-light-gradient;
-  border: 1px solid @foreground;
-  border-radius: @corner-rounding;
   .video-stream {
     width: 100%;
     height: 100%;
@@ -16,6 +15,39 @@
     box-shadow: none;
     &.flip {
       transform: scaleX(-1);
+    }
+  }
+
+  .voice-user {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    padding: 8px;
+    overflow: hidden;
+    height: 100%;
+
+    &.loading {
+      background: @foreground-gradient;
+    }
+    &.calling {
+      .circle {
+        box-shadow: 0 0 0 0 rgba(0, 0, 0, 1);
+        transform: scale(1);
+        animation: pulse 2s infinite;
+      }
+    }
+    .loader {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      position: absolute;
+      inset: 0;
+    }
+
+    .tag {
+      align-self: flex-start;
+      max-width: 100%;
     }
   }
 }
@@ -47,67 +79,6 @@
       color: @white;
       width: 16px;
       height: 16px;
-    }
-  }
-}
-
-.media-user {
-  .circle {
-    position: absolute;
-    top: calc(@half - 38.5px);
-    left: calc(@half - 32.5px);
-  }
-  &.loading {
-    background: @foreground-gradient;
-    .circle {
-      filter: @xlight-blur;
-      -webkit-filter: @xlight-blur;
-    }
-  }
-
-  .loader {
-    position: absolute;
-    inset: 0;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  }
-
-  &.calling {
-    .circle {
-      box-shadow: 0 0 0 0 rgba(0, 0, 0, 1);
-      transform: scale(1);
-      animation: pulse 2s infinite;
-    }
-  }
-
-  .tag {
-    &:extend(.ellipsis);
-    &:extend(.background-semitransparent-dark);
-    &:extend(.font-primary);
-    font-family: @primary-font;
-
-    display: inline-block;
-    line-height: 2em;
-    max-width: calc(100% - @indicator-size - @light-spacing);
-  }
-  width: 100%;
-  height: 100%;
-  &:extend(.round-corners);
-  display: inline-block;
-  padding: @light-spacing;
-  position: relative;
-}
-
-@media only screen and (max-width: @mobile-breakpoint) {
-  .user {
-    min-width: 160px;
-    min-height: 90px;
-    .circle,
-    .tag,
-    .talking {
-      top: calc(@half - 5px);
-      left: calc(@half - 17.5px);
     }
   }
 }

--- a/pages/chat/Chat.html
+++ b/pages/chat/Chat.html
@@ -2,12 +2,10 @@
   <Toolbar />
   <Media
     v-if="isActiveCall"
-    :fullscreen="ui.fullscreen"
-    :users="$mock.callUsers"
     :max-viewable-users="10"
     :fullscreen-max-viewable-users="20"
   />
   <Conversation />
   <Chatbar ref="chatbar" />
-  <WalletMini v-if="ui.modals.walletMini" />
+  <!-- <WalletMini v-if="ui.modals.walletMini" /> -->
 </div>

--- a/pages/chat/_id.vue
+++ b/pages/chat/_id.vue
@@ -2,8 +2,6 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import { mapState } from 'vuex'
-import { RootState } from '~/types/store/store'
 import { useWebRTC } from '~/libraries/Iridium/webrtc/hooks'
 
 export default Vue.extend({
@@ -13,11 +11,6 @@ export default Vue.extend({
     const { isActiveCall } = useWebRTC()
 
     return { isActiveCall }
-  },
-  computed: {
-    ...mapState({
-      ui: (state) => (state as RootState).ui,
-    }),
   },
 })
 </script>

--- a/types/typography.d.ts
+++ b/types/typography.d.ts
@@ -1,4 +1,4 @@
 export type Font = 'heading' | 'body'
 export type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl'
-export type TextColor = 'body' | 'light' | 'dark' | 'flair' | 'error'
+export type TextColor = 'body' | 'light' | 'dark' | 'flair' | 'error' | 'white'
 export type Weight = 'regular' | 'bold'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- refactor tag component to use slots and new Text component
- remove extra container elements from mediaUser. display both video and screenshare at the same time if possible. Still needs some additional styling if 2 windows are shown for 1 user. I wanted to break this out separately since it may be fairly involved
- adjust call loader to not display user image, only loader
- switch position of incoming call buttons so accept is on the right. I believe this is the convention in most user interfaces
- add overflow scroll to media window

**Which issue(s) this PR fixes** 🔨
AP-2213
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
