### PR TITLE
feat(calls): remove background call banner

### DIFF
--- a/assets/styles/base.less
+++ b/assets/styles/base.less
@@ -40,8 +40,7 @@ body {
   color: @body;
 }
 
-body,
-#app {
+body {
   background: @background;
 }
 

--- a/components/ui/DroppableWrapper/DroppableWrapper.vue
+++ b/components/ui/DroppableWrapper/DroppableWrapper.vue
@@ -2,7 +2,6 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import { MessagingTypesEnum } from '~/libraries/Enums/enums'
 
 export default Vue.extend({
   name: 'DroppableWrapper',
@@ -22,14 +21,6 @@ export default Vue.extend({
      * @description Event handler that define target that was entered
      */
     handleDragenter(e: DragEvent) {
-      // do not show hovered effect if draggable item type include text
-      if (
-        Array.prototype.some.call(e.dataTransfer?.items, (item) =>
-          item.type.includes(MessagingTypesEnum.TEXT),
-        )
-      ) {
-        return null
-      }
       this.target = e.target
       this.dragging = true
     },

--- a/components/ui/Global/Global.html
+++ b/components/ui/Global/Global.html
@@ -81,7 +81,6 @@
   <transition :name="$device.isMobile ? 'slide' : ''">
     <InteractablesQuickProfile v-if="ui.quickProfile" :user="ui.quickProfile" />
   </transition>
-  <UiBackgroundCall v-if="showBackgroundCall" />
   <UiPip v-if="showBackgroundCall" v-slot="{ dragging }">
     <MediaPreviewCall :dragging="dragging" />
   </UiPip>

--- a/components/views/friends/requests/Requests.vue
+++ b/components/views/friends/requests/Requests.vue
@@ -57,10 +57,7 @@
 import Vue from 'vue'
 import iridium from '~/libraries/Iridium/IridiumManager'
 import type { FriendRequest } from '~/libraries/Iridium/friends/types'
-
-function notNull<TValue>(value: TValue | null): value is TValue {
-  return value !== null
-}
+import notNull from '~/utilities/notNull'
 
 export default Vue.extend({
   name: 'FriendRequests',

--- a/layouts/desktop.vue
+++ b/layouts/desktop.vue
@@ -31,17 +31,14 @@ import { ChatbarRef } from '~/components/views/chat/chatbar/Chatbar.vue'
 import { FilesControlsRef } from '~/components/views/files/controls/Controls.vue'
 import iridium from '~/libraries/Iridium/IridiumManager'
 import { flairs, Flair } from '~/libraries/Iridium/settings/types'
-import { useWebRTC } from '~/libraries/Iridium/webrtc/hooks'
 import { RootState } from '~/types/store/store'
+import notNull from '~/utilities/notNull'
 
 export default Vue.extend({
   name: 'Desktop',
   middleware: 'authenticated',
   setup() {
     useMeta()
-    const { isBackgroundCall } = useWebRTC()
-
-    return { isBackgroundCall }
   },
   data() {
     return {
@@ -87,7 +84,9 @@ export default Vue.extend({
           ...e.dataTransfer.items,
         ])
       } else if (childRefs.controls) {
-        const files = [...e.dataTransfer.items].map((f) => f.getAsFile())
+        const files = [...e.dataTransfer.items]
+          .map((f) => f.getAsFile())
+          .filter(notNull)
         ;(childRefs.controls as FilesControlsRef).handleFile(files)
       }
     },

--- a/layouts/desktop.vue
+++ b/layouts/desktop.vue
@@ -4,7 +4,6 @@
     :class="[
       `theme-${settings.theme}`,
       {
-        'has-background-call': isBackgroundCall,
         'hide-sidebars': !showSidebar,
       },
     ]"
@@ -106,11 +105,6 @@ export default Vue.extend({
 
   &.hide-sidebars {
     left: calc(calc(@sidebar-width + @slimbar-width) * -1);
-  }
-
-  &.has-background-call {
-    position: relative;
-    padding-top: @background-call-height;
   }
 }
 </style>

--- a/layouts/mobile.vue
+++ b/layouts/mobile.vue
@@ -54,10 +54,5 @@ export default Vue.extend({
   &.hidden-nav {
     padding-bottom: 0;
   }
-
-  &.has-background-call {
-    position: relative;
-    padding-top: @background-call-height;
-  }
 }
 </style>

--- a/utilities/notNull.ts
+++ b/utilities/notNull.ts
@@ -1,0 +1,3 @@
+export default function notNull<TValue>(value: TValue | null): value is TValue {
+  return value !== null
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- remove bg call banner since PIP serves the same purpose(but does it better)
- remove background gradient from `#app` since it was stacking with the `body` gradient behind it
- break out non null filter to utility function. fix eslint error in desktop.vue related to null files
- remove guard clause from droppable wrapper. It was preventing the glow effect from showing when you drag and drop text files

**Which issue(s) this PR fixes** 🔨
AP-2204
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
