### PR TITLE
fix(files): mobile wrap for directory name

### DIFF
--- a/components/views/files/controls/switch/Switch.less
+++ b/components/views/files/controls/switch/Switch.less
@@ -2,6 +2,7 @@
   display: flex;
   align-items: center;
   gap: 9.5px;
+  align-self: flex-start;
 
   .control-icon {
     &:extend(.font-muted);

--- a/components/views/files/filepath/Filepath.less
+++ b/components/views/files/filepath/Filepath.less
@@ -5,6 +5,7 @@
     display: flex;
     align-items: center;
     gap: 0.375rem;
+    flex-wrap: wrap;
 
     li {
       display: flex;

--- a/components/views/navigation/mobile/nav/Nav.less
+++ b/components/views/navigation/mobile/nav/Nav.less
@@ -36,8 +36,10 @@
     flex: 1;
     font-size: @small-icon-size;
     color: @text-muted;
+    opacity: 0.7;
     &.active {
       color: @secondary-text;
+      opacity: 1;
     }
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- wrap directory names
- add better contrast to mobile nav

**Which issue(s) this PR fixes** 🔨
AP-2227
<!--AP-X-->

**Special notes for reviewers** 🗒️
- maybe we need to break the view switcher into a separate container. looks kinda weird once it starts wrapping. this at least fixes the overflow

**Additional comments** 🎤
