### PR TITLE
feat(webrtc): initialize webrtc streams with user selected devices

### DIFF
--- a/components/ui/Global/Global.vue
+++ b/components/ui/Global/Global.vue
@@ -6,6 +6,7 @@ import { TrackKind } from '~/libraries/WebRTC/types'
 import { ModalWindows } from '~/store/ui/types'
 import iridium from '~/libraries/Iridium/IridiumManager'
 import { useWebRTC } from '~/libraries/Iridium/webrtc/hooks'
+import { PropCommonEnum } from '~/libraries/Enums/enums'
 
 declare module 'vue/types/vue' {
   interface Vue {
@@ -26,13 +27,21 @@ export default Vue.extend({
     }
   },
   computed: {
-    ...mapState(['ui', 'media', 'conversation', 'files']),
+    ...mapState(['ui', 'media', 'conversation', 'files', 'settings']),
     ModalWindows: () => ModalWindows,
     showBackgroundCall(): boolean {
       if (!this.$device.isMobile) {
         return this.isBackgroundCall
       }
       return this.isBackgroundCall || (this.isActiveCall && this.ui.showSidebar)
+    },
+  },
+  watch: {
+    'settings.audioInput'(audioInput: string) {
+      this.updateWebRTCState({ audioInput })
+    },
+    'settings.videoInput'(videoInput: string) {
+      this.updateWebRTCState({ videoInput })
     },
   },
   mounted() {
@@ -65,6 +74,9 @@ export default Vue.extend({
       this.toggleModal('changelog')
       localStorage.setItem('local-version', this.$config.clientVersion)
     }
+
+    const { audioInput, videoInput } = this.settings
+    this.updateWebRTCState({ audioInput, videoInput })
   },
   methods: {
     /**
@@ -109,6 +121,29 @@ export default Vue.extend({
      */
     denyCall() {
       iridium.webRTC.denyCall()
+    },
+    /**
+     * @method updateWebRTCState
+     * @description Updates the WebRTC state with the given settings.
+     * @example this.updateWebRTCState({ audioInput: 'default', videoInput: 'default' })
+     */
+    updateWebRTCState({
+      audioInput,
+      videoInput,
+    }: {
+      audioInput?: string
+      videoInput?: string
+    }) {
+      const streamConstraints = {} as MediaStreamConstraints
+
+      if (audioInput && audioInput !== PropCommonEnum.DEFAULT) {
+        streamConstraints.audio = { deviceId: audioInput }
+      }
+      if (videoInput && videoInput !== PropCommonEnum.DEFAULT) {
+        streamConstraints.video = { deviceId: videoInput }
+      }
+
+      iridium.webRTC.streamConstraints = streamConstraints
     },
   },
 })

--- a/libraries/Iridium/webrtc/types.ts
+++ b/libraries/Iridium/webrtc/types.ts
@@ -21,6 +21,7 @@ export interface WebRTCState {
     data: SignalData
   } | null
   createdAt: number
+  streamConstraints: MediaStreamConstraints
 }
 
 export enum WebRTCError {

--- a/libraries/WebRTC/Call.ts
+++ b/libraries/WebRTC/Call.ts
@@ -281,11 +281,11 @@ export class Call extends Emitter<CallEventListeners> {
     }
 
     if (kinds.includes('audio')) {
-      await this.createAudioStream(constraints?.audio || true)
+      await this.createAudioStream(constraints?.audio)
     }
 
     if (kinds.includes('video')) {
-      await this.createVideoStream(constraints?.video || true)
+      await this.createVideoStream(constraints?.video)
     }
 
     return this.streams
@@ -299,9 +299,7 @@ export class Call extends Emitter<CallEventListeners> {
    * @example
    * await call.createAudioStream()
    */
-  async createAudioStream(
-    constraints: MediaTrackConstraints | boolean | undefined,
-  ) {
+  async createAudioStream(constraints?: MediaStreamConstraints['audio']) {
     if (!iridium.connector?.id) return
 
     const audioStream = await navigator.mediaDevices.getUserMedia({
@@ -342,9 +340,7 @@ export class Call extends Emitter<CallEventListeners> {
    * @example
    * await call.createVideoStream()
    */
-  async createVideoStream(
-    constraints: MediaTrackConstraints | boolean | undefined,
-  ) {
+  async createVideoStream(constraints?: MediaStreamConstraints['video']) {
     if (!iridium.connector?.id) return
     const videoStream = await navigator.mediaDevices.getUserMedia({
       video: constraints || true,
@@ -771,20 +767,22 @@ export class Call extends Emitter<CallEventListeners> {
   async unmute({
     kind,
     did = iridium.connector?.id,
+    constraints,
   }: {
     kind: string
     did?: string
+    constraints: MediaStreamConstraints
   }) {
     if (!did) return
 
     if (did === iridium.connector?.id) {
       if (kind === 'audio' && !this.streams[did]?.audio) {
-        await this.createAudioStream(true)
+        await this.createAudioStream(constraints?.audio)
       } else if (
         kind === 'video' &&
         !this.streams[did]?.video?.getVideoTracks()?.length
       ) {
-        await this.createVideoStream(true)
+        await this.createVideoStream(constraints?.video)
       } else if (kind === 'screen' && !this.streams[did]?.screen) {
         await this.createDisplayStream()
       }

--- a/store/audio/actions.ts
+++ b/store/audio/actions.ts
@@ -29,11 +29,11 @@ export default {
     }
 
     if (!state.muted) {
-      await call.mute({ kind: 'audio' })
+      await iridium.webRTC.mute({ kind: 'audio' })
       commit('setMute', true)
       return
     }
-    await call.unmute({ kind: 'audio' })
+    await iridium.webRTC.unmute({ kind: 'audio' })
     commit('setMute', false)
   },
   /**

--- a/store/video/actions.ts
+++ b/store/video/actions.ts
@@ -12,11 +12,11 @@ const videoActions = {
     }
 
     if (!state.disabled) {
-      await call.mute({ kind: 'video' })
+      await iridium.webRTC.mute({ kind: 'video' })
       commit('setDisabled', true)
       return
     }
-    await call.unmute({ kind: 'video' })
+    await iridium.webRTC.unmute({ kind: 'video' })
     commit('setDisabled', false)
   },
 }

--- a/store/webrtc/actions.ts
+++ b/store/webrtc/actions.ts
@@ -374,11 +374,11 @@ const webRTCActions = {
     }
     const isMuted = state.streamMuted[peerId]?.[kind]
     if (isMuted) {
-      await call.unmute({ peerId, kind })
+      await iridium.webRTC.unmute({ kind })
       dispatch('sounds/playSound', Sounds.UNMUTE, { root: true })
       return
     }
-    await call.mute({ peerId, kind })
+    await iridium.webRTC.mute({ kind })
     dispatch('sounds/playSound', Sounds.MUTE, { root: true })
   },
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Initiates WebRTCManager state with user selected audioIn and videoIn devices.
- Updates WebRTCManager state when user selected audioIn and videoIn devices change.
- Initiates calls with user selected audioIn and videoIn devices using WebRTCManager state.

**Which issue(s) this PR fixes** 🔨
AP-2231
<!--AP-X-->

**Special notes for reviewers** 🗒️
- This PR is outside the scope of switching audio/video stream devices while call is active. Switching devices during active calls will be implemented in a separate future PR.

**Additional comments** 🎤
