### PR TITLE
fix(friends): stop input autofocus from breaking swiper animation

### DIFF
--- a/components/interactables/Input/Input.vue
+++ b/components/interactables/Input/Input.vue
@@ -6,6 +6,8 @@ import { DeleteIcon } from 'satellite-lucide-icons'
 import { InputType, InputColor } from './types'
 import { Size } from '~/types/typography'
 
+const MOBILE_FOCUS_DELAY = 300 // ms
+
 export default Vue.extend({
   components: {
     DeleteIcon,
@@ -90,7 +92,15 @@ export default Vue.extend({
   },
   mounted() {
     if (this.autofocus) {
-      this.$nextTick(() => (this.$refs?.input as HTMLElement).focus())
+      const inputRef = this.$refs.input as HTMLInputElement
+      if (this.$device.isMobile) {
+        // delay focus to avoid clash with swiper animation
+        setTimeout(() => {
+          inputRef.focus()
+        }, MOBILE_FOCUS_DELAY)
+      } else {
+        this.$nextTick(() => inputRef.focus())
+      }
     }
   },
   methods: {

--- a/components/views/friends/search/Search.vue
+++ b/components/views/friends/search/Search.vue
@@ -3,7 +3,7 @@
     <InteractablesInput
       v-model="friendId"
       :placeholder="$t('friends.search_placeholder')"
-      autofocus
+      :autofocus="$device.isDesktop"
       @change="_searchFriend"
     />
     <TypographyError v-if="error" :text="$t(error)" />


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Disables autofocus on mobile devices.
- Adds delay to autofocus for InteractablesInput component to prevent swiper animation from breaking.

**Which issue(s) this PR fixes** 🔨
AP-2239
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
