### PR TITLE
feat(calls): reposition call controls

### DIFF
--- a/components/views/media/Media.html
+++ b/components/views/media/Media.html
@@ -4,7 +4,7 @@
   data-cy="mediastream"
   :style="`height:${height}`"
 >
-  <MediaHeading :isFullscreen="isFullscreen" @toggle="toggleFullscreen" />
+  <MediaHeading />
   <div class="media">
     <MediaUser
       id="local"
@@ -25,13 +25,20 @@
       ...
     </div> -->
   </div>
-  <MediaActionsVolume
-    :volume="volume"
-    isPopup
-    @volumeControlValueChange="volumeControlValueChange"
-  />
-  <MediaActionsSettings />
+
+  <!-- <MediaActionsSettings /> -->
   <MediaActions />
+  <div class="controls">
+    <MediaActionsVolume
+      :volume="volume"
+      isPopup
+      @volumeControlValueChange="volumeControlValueChange"
+    />
+    <MediaActionsFullscreen
+      :isFullscreen="isFullscreen"
+      @toggle="toggleFullscreen"
+    />
+  </div>
   <InteractablesDragBar
     v-if="!isFullscreen"
     side="bottom"

--- a/components/views/media/Media.less
+++ b/components/views/media/Media.less
@@ -32,49 +32,13 @@
       }
     }
   }
-}
 
-.fullscreen-media {
-  .mediastream {
-    max-height: unset;
-    height: calc(@full - @toolbar-height - @light-spacing);
-    margin-bottom: 1rem;
-
-    .media {
-      justify-content: center;
-      flex-direction: row;
-    }
-  }
-}
-
-// .more-user {
-//   min-width: 16rem;
-//   height: 9rem;
-//   &:extend(.round-corners);
-//   display: flex;
-//   align-self: flex-end;
-//   justify-content: center;
-//   align-items: center;
-//   order: 11;
-//   font-size: 30px;
-//   line-height: 28px;
-//   margin: @xlight-spacing;
-//   padding: @light-spacing;
-//   position: relative;
-//   &.full {
-//     line-height: 13px;
-//     text-align: center;
-//   }
-//   &.full-mobile {
-//     min-width: 12rem !important;
-//   }
-// }
-
-@media only screen and (max-width: @mobile-breakpoint) {
-  .mediastream {
-    min-width: @viewport-width;
-    top: @toolbar-height - @normal-spacing;
-    margin: 0;
-    border-radius: 0;
+  .controls {
+    display: flex;
+    align-items: flex-end;
+    gap: 16px;
+    position: absolute;
+    bottom: 16px;
+    right: 16px;
   }
 }

--- a/components/views/media/actions/Fullscreen.vue
+++ b/components/views/media/actions/Fullscreen.vue
@@ -1,0 +1,29 @@
+<template>
+  <button
+    v-tooltip.top="
+      isFullscreen ? $t('ui.exit_fullscreen') : $t('ui.fullscreen')
+    "
+    @click="$emit('toggle')"
+  >
+    <component
+      :is="isFullscreen ? MinimizeIcon : MaximizeIcon"
+      size="1.2x"
+      :data-cy="isFullscreen ? 'exit-fullscreen' : 'go-fullscreen'"
+    />
+  </button>
+</template>
+
+<script setup lang="ts">
+import Vue from 'vue'
+import { MaximizeIcon, MinimizeIcon } from 'satellite-lucide-icons'
+
+const props = defineProps<{
+  isFullscreen: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'toggle'): void
+}>()
+</script>
+
+<style scoped lang="less"></style>

--- a/components/views/media/actions/Fullscreen.vue
+++ b/components/views/media/actions/Fullscreen.vue
@@ -17,11 +17,11 @@
 import Vue from 'vue'
 import { MaximizeIcon, MinimizeIcon } from 'satellite-lucide-icons'
 
-const props = defineProps<{
+defineProps<{
   isFullscreen: boolean
 }>()
 
-const emit = defineEmits<{
+defineEmits<{
   (e: 'toggle'): void
 }>()
 </script>

--- a/components/views/media/actions/volume/Volume.html
+++ b/components/views/media/actions/volume/Volume.html
@@ -1,5 +1,5 @@
 <div
-  :class="`volume-control ${isPopup? 'absolute': 'normal'} ${direction}`"
+  :class="`volume-control ${direction}`"
   ref="volumegroup"
   @mousedown="hideSlider"
   tabindex="0"
@@ -7,37 +7,26 @@
   <InteractablesVolume
     v-if="!isPopup || showSlider"
     :volume="volume"
-    v-bind:direction="direction"
+    :direction="direction"
     @returned-value="receivedValue"
   />
-  <div class="volume-icon" data-cy="volume-icon" v-if="!plain">
-    <volume-2-icon
-      v-if="volume >= 70"
-      data-cy="volume-at-max"
-      @click="toggleSlider"
-      size="1.2x"
-      class="fa-fw"
-    />
+  <button
+    v-if="!plain"
+    class="volume-icon"
+    data-cy="volume-icon"
+    @click="toggleSlider"
+  >
+    <volume-2-icon v-if="volume >= 70" data-cy="volume-at-max" size="1.2x" />
     <volume-1-icon
       v-if="volume > 30 && volume < 70"
       data-cy="volume-less-than-70"
-      @click="toggleSlider"
-      size="1.2x"
-      class="fa-fw"
+      size="1.4x"
     />
     <volume-icon
       v-if="volume > 0 && volume <= 30"
       data-cy="volume-less-than-30"
-      @click="toggleSlider"
-      size="1.2x"
-      class="fa-fw"
+      size="1.4x"
     />
-    <volume-x-icon
-      v-if="volume == 0"
-      data-cy="volume-at-min"
-      @click="toggleSlider"
-      size="1.2x"
-      class="fa-fw"
-    />
-  </div>
+    <volume-x-icon v-if="volume == 0" data-cy="volume-at-min" size="1.2x" />
+  </button>
 </div>

--- a/components/views/media/actions/volume/Volume.less
+++ b/components/views/media/actions/volume/Volume.less
@@ -1,11 +1,9 @@
 .volume-control {
-  &.absolute {
-    cursor: pointer;
-    position: absolute;
-    bottom: @light-spacing;
-    right: @normal-spacing;
-  }
   &.ltr {
+    display: flex;
+    justify-content: flex-end;
+    flex-direction: row-reverse;
+    align-items: center;
     .volume-slider {
       display: block;
       max-width: 10rem;
@@ -14,9 +12,5 @@
     .volume-icon {
       padding: 0 1rem 0 0;
     }
-    display: flex;
-    justify-content: flex-end;
-    flex-direction: row-reverse;
-    align-items: center;
   }
 }

--- a/components/views/media/actions/volume/Volume.vue
+++ b/components/views/media/actions/volume/Volume.vue
@@ -10,11 +10,6 @@ import {
   VolumeXIcon,
 } from 'satellite-lucide-icons'
 
-declare module 'vue/types/vue' {
-  interface Vue {
-    hideSlider: () => void
-  }
-}
 export default Vue.extend({
   components: {
     VolumeIcon,
@@ -58,7 +53,7 @@ export default Vue.extend({
      * @example
      */
     toggleSlider() {
-      this.$data.showSlider = !this.$data.showSlider
+      this.showSlider = !this.showSlider
     },
     /**
      * @method hideSlider DocsTODO
@@ -69,7 +64,7 @@ export default Vue.extend({
     hideSlider(event: Event) {
       const vgroup = this.$refs.volumegroup as Element
       if (vgroup && vgroup.contains(event.target as Node) === false) {
-        this.$data.showSlider = false
+        this.showSlider = false
       }
     },
     /**

--- a/components/views/media/heading/Heading.html
+++ b/components/views/media/heading/Heading.html
@@ -1,18 +1,4 @@
 <div class="heading">
-  <transition name="media-fullscreen" mode="out-in">
-    <button
-      :key="isFullscreen"
-      v-tooltip.left="isFullscreen ? $t('ui.exit_fullscreen') : $t('ui.fullscreen')"
-      @click="$emit('toggle')"
-    >
-      <minimize-icon
-        v-if="isFullscreen"
-        data-cy="exit-fullscreen"
-        size="1.2x"
-      />
-      <maximize-icon v-else data-cy="go-fullscreen" size="1.2x" />
-    </button>
-  </transition>
   <TypographyTag v-if="elapsedTime" data-cy="elapsed-time">
     {{$t('ui.live', { time: elapsedTime })}}
   </TypographyTag>

--- a/components/views/media/heading/Heading.less
+++ b/components/views/media/heading/Heading.less
@@ -1,16 +1,4 @@
 .heading {
   display: flex;
-  justify-content: space-between;
-  flex-direction: row-reverse;
-  min-height: 26px;
   padding: 0.75rem;
-
-  button {
-    height: fit-content;
-  }
-}
-
-.media-fullscreen-enter,
-.media-fullscreen-leave-to {
-  opacity: 0;
 }

--- a/components/views/media/heading/Heading.vue
+++ b/components/views/media/heading/Heading.vue
@@ -2,21 +2,10 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import { MaximizeIcon, MinimizeIcon } from 'satellite-lucide-icons'
 import iridium from '~/libraries/Iridium/IridiumManager'
 import { useCallElapsedTime } from '~/libraries/Iridium/webrtc/hooks'
 
 export default Vue.extend({
-  components: {
-    MaximizeIcon,
-    MinimizeIcon,
-  },
-  props: {
-    isFullscreen: {
-      type: Boolean,
-      required: true,
-    },
-  },
   setup() {
     const { elapsedTime, startInterval, clearTimer } = useCallElapsedTime()
     return { elapsedTime, startInterval, clearTimer }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- organize call controls so theyre better positioned. the modern convention for fullscreen toggle is the bottom right. may as well put the other buttons there too since most websites do. We want a familiar UI
- remove cog button because it doesnt do anything

**Which issue(s) this PR fixes** 🔨
AP-2240
<!--AP-X-->

**Special notes for reviewers** 🗒️
- the volume components are a bit tangled. settings uses the same volume component with a call, but greatly transforms it with props. kinda weird

**Additional comments** 🎤
