### PR TITLE
chore(unlock): notice on unlock page to recommend chrome

### DIFF
--- a/components/ui/InlineNotification/InlineNotification.html
+++ b/components/ui/InlineNotification/InlineNotification.html
@@ -1,5 +1,4 @@
 <div class="inline-notification">
   {{ text }}
   <div class="fill"></div>
-  <x-icon size="1x" />
 </div>

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -239,7 +239,7 @@ export default {
       delete_account_label: 'Not you? Create or import an account',
       generate_random_user: 'Generate a Random User (DEV)',
       browser_warning:
-        'Hey there, welcome to our early access! While one of our goals is to make Satellite work across all browsers, we have focused the early access on Chromium-based browsers. You are welcome to try Satellite on any browser you like, and we will focus on more broad support soon, but you may run into more UI and functionality issues.',
+        'Satellite is optimized for Chromium browsers. You may experience UI and functional issues. We will optimize for more browsers in the future.',
     },
     loading: {
       loading: 'Linking Satellites...',

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -238,6 +238,8 @@ export default {
       store_pin: 'Store Pin? (Less Secure)',
       delete_account_label: 'Not you? Create or import an account',
       generate_random_user: 'Generate a Random User (DEV)',
+      browser_warning:
+        'Hey there, welcome to our early access! While one of our goals is to make Satellite work across all browsers, we have focused the early access on Chromium based browsers. You are welcome to try Satellite on any browser you like, and we will focus on more broad support soon, but you may run in to more UI and functionality issues.',
     },
     loading: {
       loading: 'Linking Satellites...',

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -239,7 +239,7 @@ export default {
       delete_account_label: 'Not you? Create or import an account',
       generate_random_user: 'Generate a Random User (DEV)',
       browser_warning:
-        'Hey there, welcome to our early access! While one of our goals is to make Satellite work across all browsers, we have focused the early access on Chromium based browsers. You are welcome to try Satellite on any browser you like, and we will focus on more broad support soon, but you may run in to more UI and functionality issues.',
+        'Hey there, welcome to our early access! While one of our goals is to make Satellite work across all browsers, we have focused the early access on Chromium-based browsers. You are welcome to try Satellite on any browser you like, and we will focus on more broad support soon, but you may run into more UI and functionality issues.',
     },
     loading: {
       loading: 'Linking Satellites...',

--- a/pages/auth/unlock/Unlock.html
+++ b/pages/auth/unlock/Unlock.html
@@ -33,8 +33,12 @@
     <a v-if="step === 'login'" class="delete-link" @click="clearAndReset">
       {{$t('pages.unlock.delete_account_label')}}
     </a>
-    <div class="realm-container">
-      <InteractablesRealm />
+    <div class="realm-container" v-if="!$device.isMobile">
+      <!-- <InteractablesRealm /> -->
+      <UiInlineNotification
+        v-if="!isChrome"
+        :text="$t('pages.unlock.browser_warning')"
+      />
     </div>
     <div class="random-user-container" v-if="isDev">
       <InteractablesButton

--- a/pages/auth/unlock/Unlock.less
+++ b/pages/auth/unlock/Unlock.less
@@ -16,7 +16,7 @@
     &:extend(.full-width);
     display: inline-flex;
     justify-content: center;
-    margin-top: 24px;
+    margin: 24px 0 70px 0;
   }
 
   .decryption-body {

--- a/pages/auth/unlock/index.vue
+++ b/pages/auth/unlock/index.vue
@@ -23,6 +23,7 @@ export default Vue.extend({
       status: 'idle' as 'idle' | 'loading',
       error: '',
       step: 'signup' as 'signup' | 'login',
+      isChrome: false,
     }
   },
   computed: {
@@ -69,7 +70,8 @@ ${this.$t('pages.unlock.choose_pin_description_2')}`
   mounted() {
     // This information can be useful for users to help us find and report bugs.
     ConsoleWarning(this.$config.clientVersion, this.$store.state)
-
+    // @ts-ignore
+    this.isChrome = !!window.chrome
     this.$store.commit('accounts/lock')
   },
   methods: {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Adds a warning message on unlock page to recommend Chrome, but still allow user to log in/create account

![Screen Shot 2022-08-25 at 1 41 45 PM](https://user-images.githubusercontent.com/2993032/186754233-8749c633-212c-4c4b-b1df-ed650ce05363.png)


**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️
this is hidden on mobile, and removes the realms since we dont have realms rightnow. Firefox on desktop does not trigger the mobile flag when resized like chromium browsers do

**Additional comments** 🎤
