### PR TITLE
fix(incoming-call): get conversation id from incoming call data and n…

### DIFF
--- a/components/views/media/incomingCall/IncomingCall.vue
+++ b/components/views/media/incomingCall/IncomingCall.vue
@@ -41,7 +41,7 @@ export default Vue.extend({
   },
   computed: {
     conversationId(): Conversation['id'] | undefined {
-      return this.$route.params.id
+      return this.incomingCall?.did
     },
     conversation(): Conversation | undefined {
       if (!this.conversationId) {
@@ -56,14 +56,14 @@ export default Vue.extend({
       return this.webrtc.incomingCall
     },
     caller(): User | undefined {
-      if (!this.incomingCall?.did) {
+      if (!this.conversationId) {
         return
       }
       // TODO : fix this later
       if (this.isGroup) {
         return
       }
-      return iridium.users.getUser(this.incomingCall.did)
+      return iridium.users.getUser(this.conversationId)
     },
     callerAvatar(): string {
       if (!this.caller) {


### PR DESCRIPTION
…ot url params

<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Bug was first noticed when user received calls while in a group chat. In which case undefined errors would appear, or in the case of the online version the IncomingCall modal would not show.
- The conversationId of the incoming call was being acquired from the current chat the user was in via url params.
- If the user was in the wrong chat the incorrect conversationId would be acquired. If they weren't in a chat at all no conversationId would be received.

**Which issue(s) this PR fixes** 🔨
AP-2248
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
