### PR TITLE
fix(mobile): fix swiper issues around mobile chat

### DIFF
--- a/components/ui/Global/Global.html
+++ b/components/ui/Global/Global.html
@@ -1,5 +1,5 @@
 <div>
-  <UiSvgDefs />
+  <UiSvgDefs class="hidden" />
   <InteractablesContextMenu v-if="ui.contextMenuStatus" />
   <transition name="modal">
     <SettingsModal v-if="ui.settingsRoute && !$device.isMobile" />

--- a/components/views/navigation/sidebar/list/List.html
+++ b/components/views/navigation/sidebar/list/List.html
@@ -3,6 +3,7 @@
     v-for="c in sortedConversations"
     :key="c.id"
     :conversation="c"
+    @slideNext="$emit('slideNext')"
   />
   <FriendsEmptyMessage v-if="!sortedConversations.length" displayImage />
 </div>

--- a/components/views/navigation/sidebar/list/item/Item.vue
+++ b/components/views/navigation/sidebar/list/item/Item.vue
@@ -160,6 +160,10 @@ export default Vue.extend({
      */
     async openConversation() {
       if (this.$device.isMobile) {
+        if (this.conversation.id === this.$route.params.id) {
+          this.$emit('slideNext')
+          return
+        }
         this.$router.push({ params: { id: this.conversation.id } })
         return
       }

--- a/pages/mobile/chat/_id.vue
+++ b/pages/mobile/chat/_id.vue
@@ -15,7 +15,7 @@
             <menu-icon class="font-color-flair" size="1.5x" />
           </button>
         </div>
-        <SidebarList class="mobile-list" />
+        <SidebarList class="mobile-list" @slideNext="swiper.slideNext()" />
       </div>
       <div class="swiper-slide">
         <MobileToolbar @slidePrev="swiper.slidePrev()" />
@@ -91,6 +91,13 @@ export default Vue.extend({
     },
   },
 
+  watch: {
+    isActiveCall(val) {
+      if (val) {
+        this.swiper?.slideNext()
+      }
+    },
+  },
   // component is remounted anytime the route param changes
   mounted() {
     this.swiper = new Swiper(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- enter into already selected chat on touch if user swiped back. previously, swiping was the only way to get back
- hide svg definitions, they were taking up noticeable space on mobile
- automatically go to slide 2 when you answer a call on mobile

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
