### PR TITLE
fix(typing): typing indicator bug

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -111,6 +111,7 @@ export const Config = {
     timestampUpdateInterval: 60 * 1000, // 60 seconds
     maxChars: 2048,
     typingInputThrottle: 5000,
+    typingInputDebounce: 1000,
     maxUndoStack: 100,
     batchUndoSeconds: 5,
     searchCharLimit: 256,

--- a/libraries/Iridium/chat/ChatManager.ts
+++ b/libraries/Iridium/chat/ChatManager.ts
@@ -325,7 +325,7 @@ export default class ChatManager extends Emitter<ConversationMessage> {
 
       // Remove is_typing indicator upon user message receive
       clearTimeout(this.iridium.webRTC.timeoutMap[message.from])
-      this.toggleTypingStatus(conversationId, message.from)
+      this.setTypingStatus(conversationId, message.from, false)
 
       const friendName = this.iridium.users.getUser(message?.from)
       const buildNotification: Partial<Notification> = {
@@ -752,10 +752,10 @@ export default class ChatManager extends Emitter<ConversationMessage> {
     )
   }
 
-  toggleTypingStatus(conversationId: string, did: string) {
+  setTypingStatus(conversationId: string, did: string, value: boolean) {
     Vue.set(this.typingStatus, conversationId, {
       ...this.typingStatus[conversationId],
-      [did]: !this.typingStatus[conversationId]?.[did],
+      [did]: value,
     })
   }
 }

--- a/libraries/Iridium/webrtc/WebRTCManager.ts
+++ b/libraries/Iridium/webrtc/WebRTCManager.ts
@@ -400,12 +400,12 @@ export default class WebRTCManager extends Emitter {
     if (!did || !conversation) return
 
     if (!this.iridium.chat.typingStatus[conversationId]?.[did]) {
-      this.iridium.chat.toggleTypingStatus(conversationId, did)
+      this.iridium.chat.setTypingStatus(conversationId, did, true)
     }
     clearTimeout(this.timeoutMap[did])
 
     this.timeoutMap[did] = setTimeout(() => {
-      this.iridium.chat.toggleTypingStatus(conversationId, did)
+      this.iridium.chat.setTypingStatus(conversationId, did, false)
     }, Config.chat.typingInputThrottle * 2)
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Fix some typing indicator bugs:
* Switch toggle in favour of set, more resilient;
* Added a debounce function inside the throttling so to not spam with the typing event if i send quickly a lot of messages;
* Moved function outside the methods because Vue was hiding the `.cancel` lodash method on throttle and debounce.

**Which issue(s) this PR fixes** 🔨
AP-2252

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
