### PR TITLE
fix(files): convert iridium files state to FilesManager state on fetch

### DIFF
--- a/components/views/files/grid/Grid.html
+++ b/components/views/files/grid/Grid.html
@@ -3,7 +3,7 @@
     <FilesGridItem
       v-for="item in directory"
       :item="item"
-      :key="item.id + item.modified.toString()"
+      :key="item.id + item.modified?.toString()"
       @like="(item) => $emit('like', item)"
       @share="(item) => $emit('share', item)"
       @rename="(item) => $emit('rename', item)"

--- a/libraries/Iridium/files/FilesManager.ts
+++ b/libraries/Iridium/files/FilesManager.ts
@@ -51,7 +51,9 @@ export default class FilesManager extends Emitter {
       '/files',
     )
     if (res && 'items' in res) {
-      this.state = res
+      // convert iridium files state to FilesManager state
+      const items = Object.values(res).map((v) => Object.values(v))[0]
+      this.state = { ...res, items }
     }
     this.lastUpdated = Date.now()
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- The file item array now gets converted to arrays when stored in iridium. This PR converts them back when the files in iridium are initiated in the FilesManager state

**Which issue(s) this PR fixes** 🔨
Relolve #4549 
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
