### PR TITLE
fix(webrtc): handle iridium publish error which was stopping settings…

### DIFF
--- a/libraries/Iridium/webrtc/WebRTCManager.ts
+++ b/libraries/Iridium/webrtc/WebRTCManager.ts
@@ -108,7 +108,7 @@ export default class WebRTCManager extends Emitter {
       friends,
     })
 
-    if (!friends) return
+    if (!friends || !(profile.name && iridium.connector.p2p.ready)) return
 
     try {
       await iridium.connector?.publish(

--- a/libraries/Iridium/webrtc/WebRTCManager.ts
+++ b/libraries/Iridium/webrtc/WebRTCManager.ts
@@ -109,17 +109,23 @@ export default class WebRTCManager extends Emitter {
     })
 
     if (!friends) return
-    await iridium.connector?.publish(
-      'webrtc',
-      {
-        type: 'announce',
-      },
-      {
-        encrypt: {
-          recipients: friends,
+
+    try {
+      await iridium.connector?.publish(
+        'webrtc',
+        {
+          type: 'announce',
         },
-      },
-    )
+        {
+          encrypt: {
+            recipients: friends,
+          },
+        },
+      )
+    } catch (e) {
+      const error = e as Error
+      logger.error(this.loggerTag, 'announce failed to publish', error)
+    }
   }
 
   private async onMessage({


### PR DESCRIPTION
… manager init

<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Settings was not initiating as the WebRTC initiation before it was throwing an unhandled error. This PR handles the error so that the settings stored in iridium can be set on init

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
