### PR TITLE
fix(files): only show border if not last child

### DIFF
--- a/components/views/files/mobileList/item/Item.less
+++ b/components/views/files/mobileList/item/Item.less
@@ -62,9 +62,12 @@
 
   &-list {
     padding: 0.75rem 0;
-    border-bottom: 1px solid @foreground;
     background: none;
     padding-right: unset;
+
+    &:not(:last-child) {
+      border-bottom: 1px solid @foreground;
+    }
 
     .body {
       padding: 0 @xlight-spacing;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖

look like this instead of additional border at bottom
![image](https://user-images.githubusercontent.com/33670767/187850643-e0916dc2-85c0-4cdc-a98d-f87789e55187.png)


**Which issue(s) this PR fixes** 🔨

Resolve #
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
