### PR TITLE
fix(mobile): show mobile nav on consent push

### DIFF
--- a/pages/mobile/chat/_id.vue
+++ b/pages/mobile/chat/_id.vue
@@ -107,6 +107,9 @@ export default Vue.extend({
       this.swiper.slideNext()
     }
   },
+  beforeDestroy() {
+    this.isMobileNavVisible = true
+  },
 })
 </script>
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
If you got pushed to mobile consent settings from a chat page, nav would still be hidden. Fixes that

**Which issue(s) this PR fixes** 🔨

Resolve #
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
