### PR TITLE
fix(settings): remove loading message while updating remote settings

### DIFF
--- a/components/views/settings/pages/audio/Audio.html
+++ b/components/views/settings/pages/audio/Audio.html
@@ -167,10 +167,7 @@
       :title="$t('pages.settings.video.flipVideo.title')"
       :text="$t('pages.settings.video.flipVideo.subtitle')"
     >
-      <InteractablesSwitch
-        v-model="flipVideo"
-        :isLocked="loading.includes('flipVideo')"
-      />
+      <InteractablesSwitch v-model="flipVideo" />
     </SettingsUnit>
   </SettingsSection>
 
@@ -201,7 +198,4 @@
     :value="$t('pages.settings.notifications.title')"
   />
   <SettingsPagesAudioSounds />
-  <TypographyText v-if="loading.length">
-    {{ $t('pages.privacy.updating') }}
-  </TypographyText>
 </SettingsPage>

--- a/components/views/settings/pages/audio/index.vue
+++ b/components/views/settings/pages/audio/index.vue
@@ -40,7 +40,6 @@ export default Vue.extend({
       stream: null,
       featureReadyToShow: false,
       updateInterval: null,
-      loading: [] as string[],
       captureMouses: [
         {
           value: CaptureMouseTypes.always,
@@ -61,7 +60,6 @@ export default Vue.extend({
   },
   computed: {
     ...mapState({
-      userThread: (state) => (state as RootState).textile.userThread,
       settings: (state) => (state as RootState).settings,
       audio: (state) => (state as RootState).audio,
     }),
@@ -138,10 +136,8 @@ export default Vue.extend({
       },
     },
     flipVideo: {
-      async set(value: boolean) {
-        this.loading.push('flipVideo')
-        await iridium.settings.set('/video/flipLocalStream', value)
-        this.loading.splice(this.loading.indexOf('flipVideo'), 1)
+      set(value: boolean) {
+        iridium.settings.set('/video/flipLocalStream', value)
       },
       get(): boolean {
         return this.iridiumSettings.video.flipLocalStream

--- a/components/views/settings/pages/privacy/Privacy.html
+++ b/components/views/settings/pages/privacy/Privacy.html
@@ -48,19 +48,13 @@
       :title="$t('pages.privacy.consentScan.title')"
       :text="$t('pages.privacy.consentScan.subtitle')"
     >
-      <InteractablesSwitch
-        v-model="consentScan"
-        :isLocked="loading.includes('consentScan')"
-      />
+      <InteractablesSwitch v-model="consentScan" />
     </SettingsUnit>
     <SettingsUnit
       :title="$t('pages.privacy.nsfw.title')"
       :text="$t('pages.privacy.nsfw.subtitle')"
     >
-      <InteractablesSwitch
-        v-model="blockNsfw"
-        :isLocked="loading.includes('blockNsfw')"
-      />
+      <InteractablesSwitch v-model="blockNsfw" />
     </SettingsUnit>
   </SettingsSection>
 
@@ -135,8 +129,4 @@
       </span>
     </SettingsUnit>
   </SettingsSection>
-
-  <TypographyText v-if="loading.length">
-    {{ $t('pages.privacy.updating') }}
-  </TypographyText>
 </SettingsPage>

--- a/components/views/settings/pages/privacy/index.vue
+++ b/components/views/settings/pages/privacy/index.vue
@@ -17,7 +17,6 @@ export default Vue.extend({
     return {
       formatError: false as boolean,
       lengthError: false as boolean,
-      loading: [] as string[],
       privacySettings: iridium.settings.state.privacy,
       permissions: [] as PermissionObject[],
     }
@@ -27,7 +26,6 @@ export default Vue.extend({
       ui: (state) => (state as RootState).ui,
       accounts: (state) => (state as RootState).accounts,
       settings: (state) => (state as RootState).settings,
-      userThread: (state) => (state as RootState).textile.userThread,
     }),
     ...mapGetters('textile', ['getInitialized']),
     embeddedLinks: {
@@ -39,20 +37,16 @@ export default Vue.extend({
       },
     },
     consentScan: {
-      async set(consentToScan: boolean) {
-        this.loading.push('consentScan')
-        await iridium.settings.set('/privacy/consentToScan', consentToScan)
-        this.loading.splice(this.loading.indexOf('consentScan'), 1)
+      set(consentToScan: boolean) {
+        iridium.settings.set('/privacy/consentToScan', consentToScan)
       },
       get(): boolean {
         return this.privacySettings.consentToScan
       },
     },
     blockNsfw: {
-      async set(blockNsfw: boolean) {
-        this.loading.push('blockNsfw')
-        await iridium.settings.set('/privacy/blockNsfw', blockNsfw)
-        this.loading.splice(this.loading.indexOf('blockNsfw'), 1)
+      set(blockNsfw: boolean) {
+        iridium.settings.set('/privacy/blockNsfw', blockNsfw)
       },
       get(): boolean {
         return this.privacySettings.blockNsfw


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- this was more relevant while we used textile because it was super slow. The remote update is relatively quick now, so this keeps things more predictable. When a switch was changed to Locked, it would lose keyboard focus

**Which issue(s) this PR fixes** 🔨

Resolve #
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
