### PR TITLE
fix(media-user): ensure AudioStreamUtils is re-enabled on page changes

### DIFF
--- a/components/ui/Pip/Pip.vue
+++ b/components/ui/Pip/Pip.vue
@@ -214,6 +214,7 @@ export default Vue.extend({
   overflow: hidden;
   box-shadow: @ui-shadow-large;
   &:extend(.no-select);
+  padding: 8px;
 }
 
 .dragging {

--- a/components/ui/Pip/Pip.vue
+++ b/components/ui/Pip/Pip.vue
@@ -6,6 +6,7 @@
       transform: transform,
       width: `${elWidth}px`,
       height: `${elHeight}px`,
+      padding: `${padding}px`,
     }"
     :class="{ dragging: isDragging }"
     @mousedown.stop="mouseDown"
@@ -20,6 +21,9 @@ import Vue from 'vue'
 import { throttle } from 'lodash'
 import { Config } from '~/config'
 import { animate, easeOutBack, lerp } from '~/utilities/animation'
+import { MEDIA_USER_DIMENSIONS } from '~/components/views/media/user/User.vue'
+
+const PIP_PADDING = 8
 
 type ColumnType = typeof Config.pip.columns[number]
 type RowType = typeof Config.pip.rows[number]
@@ -47,14 +51,15 @@ export default Vue.extend({
       y: Config.pip.windowMargin,
       offsetX: 0,
       offsetY: 0,
-      elWidth: 320,
-      elHeight: 180,
+      elWidth: MEDIA_USER_DIMENSIONS.width + PIP_PADDING * 2,
+      elHeight: MEDIA_USER_DIMENSIONS.height + PIP_PADDING * 2,
       quarter: { x: Config.pip.columns.length - 1, y: 0 } as QuarterType,
       isDragging: false,
       isEnlarged: false,
       dragInterval: null as NodeJS.Timer | null,
       mouseX: 0,
       mouseY: 0,
+      padding: PIP_PADDING,
     }
   },
   computed: {
@@ -214,7 +219,6 @@ export default Vue.extend({
   overflow: hidden;
   box-shadow: @ui-shadow-large;
   &:extend(.no-select);
-  padding: 8px;
 }
 
 .dragging {

--- a/components/views/media/user/User.vue
+++ b/components/views/media/user/User.vue
@@ -16,7 +16,10 @@ import iridium from '~/libraries/Iridium/IridiumManager'
 import { WebRTCEnum } from '~/libraries/Enums/enums'
 import { Call } from '~/libraries/WebRTC/Call'
 
+export const MEDIA_USER_DIMENSIONS = { width: 320, height: 180 }
+
 export default Vue.extend({
+  name: 'MediaUser',
   components: {
     VideoIcon,
     VideoOffIcon,
@@ -32,10 +35,16 @@ export default Vue.extend({
       type: Boolean,
       default: false,
     },
-    stream: String,
+    stream: {
+      type: String,
+      default: null,
+    },
     size: {
       type: Array,
-      default: () => [320, 180],
+      default: () => [
+        MEDIA_USER_DIMENSIONS.width,
+        MEDIA_USER_DIMENSIONS.height,
+      ],
     },
   },
   data() {
@@ -121,12 +130,10 @@ export default Vue.extend({
   },
   mounted() {
     this.initializeAudioStreamUtils(this.audioStream)
+    this.$emit('mounted')
   },
   beforeDestroy() {
     this.audioStreamUtils?.destroy()
-  },
-  mounted() {
-    this.$emit('mounted')
   },
   methods: {
     initializeAudioStreamUtils(stream: MediaStream | undefined) {
@@ -142,7 +149,6 @@ export default Vue.extend({
       const muted =
         !this.user.did ||
         Boolean(iridium.webRTC.state.streamMuted[this.user.did]?.[kind])
-      console.info('isMuted', kind, this.user, muted)
       return muted
     },
   },

--- a/components/views/media/user/User.vue
+++ b/components/views/media/user/User.vue
@@ -100,16 +100,8 @@ export default Vue.extend({
     },
   },
   watch: {
-    audioStream(stream) {
-      this.audioStreamUtils?.destroy()
-
-      if (!stream) {
-        this.isTalking = false
-        return
-      }
-
-      this.audioStreamUtils = new AudioStreamUtils(stream, this.audio)
-      this.audioStreamUtils.start()
+    audioStream(stream: MediaStream | undefined) {
+      this.initializeAudioStreamUtils(stream)
     },
     'audioStreamUtils.isTalking'(isTalking) {
       this.isTalking = isTalking
@@ -127,6 +119,9 @@ export default Vue.extend({
       }
     }
   },
+  mounted() {
+    this.initializeAudioStreamUtils(this.audioStream)
+  },
   beforeDestroy() {
     this.audioStreamUtils?.destroy()
   },
@@ -134,6 +129,15 @@ export default Vue.extend({
     this.$emit('mounted')
   },
   methods: {
+    initializeAudioStreamUtils(stream: MediaStream | undefined) {
+      this.audioStreamUtils?.destroy()
+      if (!stream) {
+        this.isTalking = false
+        return
+      }
+      this.audioStreamUtils = new AudioStreamUtils(stream, this.audio)
+      this.audioStreamUtils.start()
+    },
     isMuted(kind: WebRTCEnum) {
       const muted =
         !this.user.did ||


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Stops green border around MediaUser component from disappearing after page change

**Which issue(s) this PR fixes** 🔨

Resolve #4458 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
