### PR TITLE
refactor(settings): v show instead of v if for settings modal

### DIFF
--- a/components/views/settings/modal/Modal.html
+++ b/components/views/settings/modal/Modal.html
@@ -6,36 +6,38 @@
       :class="{profile: ui.settingsRoute === SettingsRoutes.PROFILE}"
     >
       <SettingsPagesPersonalize
-        v-if="ui.settingsRoute === SettingsRoutes.PERSONALIZE"
+        v-show="ui.settingsRoute === SettingsRoutes.PERSONALIZE"
       />
       <SettingsPagesAccounts
-        v-if="ui.settingsRoute === SettingsRoutes.ACCOUNTS_AND_DEVICES"
+        v-show="ui.settingsRoute === SettingsRoutes.ACCOUNTS_AND_DEVICES"
       />
       <SettingsPagesAudio
-        v-if="ui.settingsRoute === SettingsRoutes.AUDIO_AND_VIDEO"
+        v-show="ui.settingsRoute === SettingsRoutes.AUDIO_AND_VIDEO"
       />
       <SettingsPagesDeveloper
-        v-if="ui.settingsRoute === SettingsRoutes.DEVELOPER"
+        v-show="ui.settingsRoute === SettingsRoutes.DEVELOPER"
       />
-      <SettingsPagesInfo v-if="ui.settingsRoute === SettingsRoutes.INFO" />
+      <SettingsPagesInfo v-show="ui.settingsRoute === SettingsRoutes.INFO" />
       <SettingsPagesKeybinds
-        v-if="ui.settingsRoute === SettingsRoutes.KEY_BINDS"
+        v-show="ui.settingsRoute === SettingsRoutes.KEY_BINDS"
       />
       <SettingsPagesNotifications
-        v-if="ui.settingsRoute === SettingsRoutes.NOTIFICATIONS"
+        v-show="ui.settingsRoute === SettingsRoutes.NOTIFICATIONS"
       />
       <SettingsPagesProfile
-        v-if="ui.settingsRoute === SettingsRoutes.PROFILE"
+        v-show="ui.settingsRoute === SettingsRoutes.PROFILE"
       />
       <SettingsPagesStorage
-        v-if="ui.settingsRoute === SettingsRoutes.STORAGE"
+        v-show="ui.settingsRoute === SettingsRoutes.STORAGE"
       />
       <SettingsPagesNetwork
-        v-if="ui.settingsRoute === SettingsRoutes.NETWORK"
+        v-show="ui.settingsRoute === SettingsRoutes.NETWORK"
       />
-      <SettingsPagesRealms v-if="ui.settingsRoute === SettingsRoutes.REALMS" />
+      <SettingsPagesRealms
+        v-show="ui.settingsRoute === SettingsRoutes.REALMS"
+      />
       <SettingsPagesPrivacy
-        v-if="ui.settingsRoute === SettingsRoutes.PRIVACY_AND_PERMISSIONS"
+        v-show="ui.settingsRoute === SettingsRoutes.PRIVACY_AND_PERMISSIONS"
       />
     </div>
     <InteractablesClose data-cy="settings-close-button" :action="close" />


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- title
- did this because v-if is lazy, while v-show has a higher initial load cost. For something that will be toggled several times, v-show will have better performance

**Which issue(s) this PR fixes** 🔨

Resolve #
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
