### PR TITLE
fix(reactivity): flip local video setting in calls

### DIFF
--- a/components/views/media/user/User.html
+++ b/components/views/media/user/User.html
@@ -9,7 +9,7 @@
     v-if="stream === 'video'"
     :id="`${isLocal ? 'local' : 'remote'}-video-${user.did}`"
     class="video-stream"
-    :class="{flip: isLocal && isLocalVideoFlipped}"
+    :class="{ flip: flipVideo }"
     data-cy="video-stream"
     :src-object.prop="videoStream"
     playsinline
@@ -19,7 +19,7 @@
   <video
     v-else-if="stream === 'screen'"
     :id="`${isLocal ? 'local' : 'remote'}-screen-${user.did}`"
-    :class="['video-stream', { flip: flipVideo }]"
+    class="video-stream"
     data-cy="screen-stream"
     :src-object.prop="screenStream"
     playsinline

--- a/components/views/media/user/User.vue
+++ b/components/views/media/user/User.vue
@@ -43,6 +43,7 @@ export default Vue.extend({
     return {
       isTalking: false,
       audioStreamUtils: null as AudioStreamUtils | null,
+      settings: iridium.settings.state,
     }
   },
   computed: {
@@ -69,7 +70,7 @@ export default Vue.extend({
       return (
         this.isLocal &&
         this.stream === 'video' &&
-        this.videoSettings.flipLocalStream
+        this.settings.video.flipLocalStream
       )
     },
     isPending(): boolean {
@@ -91,11 +92,8 @@ export default Vue.extend({
       if (this.isMuted(WebRTCEnum.SCREEN) || !this.call) return undefined
       return this.streams?.screen
     },
-    hasVideoOrScreen() {
-      return !this.isMuted('video') || !this.isMuted('screen')
-    },
-    isLocalVideoFlipped(): boolean {
-      return iridium.settings.state.video.flipLocalStream
+    hasVideoOrScreen(): boolean {
+      return !this.isMuted(WebRTCEnum.VIDEO) || !this.isMuted(WebRTCEnum.SCREEN)
     },
     circleSize(): number {
       const height = this.size[1] as number


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Setting "Mirror VIideo" in Settings > Audio & Video would not update the local video stream in the active call
 
**Which issue(s) this PR fixes** 🔨
Resolve #4653 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
