### PR TITLE
fix(errors): cleanup errors with wrong color

### DIFF
--- a/assets/styles/framework/typography.less
+++ b/assets/styles/framework/typography.less
@@ -70,7 +70,7 @@ h6 {
   &-color-flair {
     color: @flair-color;
   }
-  &-color-error {
+  &-color-danger {
     color: @red;
   }
   &-color-white {

--- a/components/interactables/ContextMenu/ContextMenu.less
+++ b/components/interactables/ContextMenu/ContextMenu.less
@@ -30,7 +30,7 @@
       }
     }
     &.disabled {
-      opacity: 0.7;
+      opacity: 0.5;
       &:hover {
         background: none;
       }

--- a/components/interactables/Input/Input.html
+++ b/components/interactables/Input/Input.html
@@ -51,5 +51,7 @@
   <span v-if="showLimit" class="char-limit">
     {{ text.length }}/{{ maxLength }}
   </span>
-  <TypographyError v-if="error" class="error" :text="error" small />
+  <TypographyText v-if="error" as="small" color="danger">
+    {{ error }}
+  </TypographyText>
 </div>

--- a/components/interactables/Input/Input.vue
+++ b/components/interactables/Input/Input.vue
@@ -113,7 +113,7 @@ export default Vue.extend({
   },
   methods: {
     handleSubmit(event: InputEvent) {
-      if (this.disabled || this.loading || this.error || this.invalid) {
+      if (this.disabled || this.loading || this.invalid) {
         return
       }
       this.$emit('submit', event)

--- a/components/interactables/Permissions/Permissions.vue
+++ b/components/interactables/Permissions/Permissions.vue
@@ -9,7 +9,7 @@
       :text="$t('pages.privacy.permissions.ask_permission')"
       @click="$emit('click', $event)"
     />
-    <TypographyText v-else-if="state === 'denied'" color="error">
+    <TypographyText v-else-if="state === 'denied'" color="danger">
       {{ $t('pages.privacy.permissions.denied') }}
     </TypographyText>
     <UiLoadersLoadingBar v-else-if="state === 'loading'" />

--- a/components/typography/Text.vue
+++ b/components/typography/Text.vue
@@ -72,6 +72,7 @@ export default Vue.extend({
         ['h5', 'sm'],
         ['h6', 'xs'],
         ['label', 'sm'],
+        ['small', 'sm'],
       ])
       return map.get(this.as) || 'md'
     },

--- a/components/ui/ContextMenu/ContextMenu.vue
+++ b/components/ui/ContextMenu/ContextMenu.vue
@@ -50,7 +50,7 @@
             :class="item?.type"
             @click="(e) => handleAction(e, item.func)"
           >
-            <TypographyText :color="item?.type === 'danger' ? 'error' : 'body'">
+            <TypographyText :color="item?.type">
               {{ item.text }}
             </TypographyText>
           </button>
@@ -146,7 +146,7 @@ export default Vue.extend({
       width: 100%;
 
       &.disabled {
-        opacity: 0.7;
+        opacity: 0.5;
       }
 
       &:not(:last-child) {

--- a/components/views/chat/chatbar/footer/Footer.html
+++ b/components/views/chat/chatbar/footer/Footer.html
@@ -4,7 +4,7 @@
   <TypographyText
     class="no-select"
     size="sm"
-    :color="charlimit ? 'error' : 'dark'"
+    :color="charlimit ? 'danger' : 'dark'"
   >
     {{ lengthCount }}
   </TypographyText>

--- a/components/views/chat/chatbar/upload/Error.vue
+++ b/components/views/chat/chatbar/upload/Error.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="file-error">
-    <TypographyText color="error">
+    <TypographyText color="danger">
       {{ $t('errors.chat.drop_file_count') }}
     </TypographyText>
     <x-icon

--- a/components/views/files/controls/Controls.html
+++ b/components/views/files/controls/Controls.html
@@ -61,7 +61,9 @@
   <div v-if="errors.length" class="error-container">
     <alert-triangle-icon size="1.3x" />
     <div>
-      <TypographyError v-for="error in errors" :key="error" :text="error" />
+      <TypographyText v-for="error in errors" :key="error" color="danger">
+        {{ $t(error) }}
+      </TypographyText>
     </div>
     <x-icon size="1.3x" class="close" @click="errors = []" />
   </div>

--- a/components/views/files/controls/Controls.vue
+++ b/components/views/files/controls/Controls.vue
@@ -27,6 +27,7 @@ const Controls = Vue.extend({
     return {
       searchValue: '' as string,
       newFolderName: '' as string,
+      // todo - switch to a set
       errors: [] as Array<string | TranslateResult>,
     }
   },
@@ -128,7 +129,7 @@ const Controls = Vue.extend({
             options: { progress: this.setProgress },
           })
           .catch((e) => {
-            // ensure there aren't any duplicate error messages
+            // todo - switch to a set - ensure there aren't any duplicate error messages
             if (!this.errors.includes(this.$t(e?.message)))
               this.errors.push(this.$t(e?.message ?? ''))
           })

--- a/components/views/files/rename/Rename.html
+++ b/components/views/files/rename/Rename.html
@@ -1,13 +1,13 @@
 <div class="rename" data-cy="files-rename">
   <InteractablesClose :action="closeModal" />
-  <TypographyTitle :size="3" :text="$t('modal.rename')" />
+  <TypographyText as="h3"> {{ $t('modal.rename') }} </TypographyText>
   <InteractablesInput
     v-model="text"
     ref="inputGroup"
     data-cy="files-rename-input"
     @submit="renameItem"
+    :error="error"
   >
     <save-icon size="1.3x" />
   </InteractablesInput>
-  <TypographyError v-if="error" :text="error" />
 </div>

--- a/components/views/friends/search/Search.vue
+++ b/components/views/friends/search/Search.vue
@@ -6,7 +6,9 @@
       :autofocus="$device.isDesktop"
       @change="_searchFriend"
     />
-    <TypographyError v-if="error" :text="$t(error)" />
+    <TypographyText v-if="error" color="danger">
+      {{ $t(error) }}
+    </TypographyText>
     <UiLoadersLoadingBar v-else-if="searching" />
     <div v-else-if="!query" class="id-container">
       <button class="id-button" @click="copyId">

--- a/components/views/settings/pages/privacy/Privacy.html
+++ b/components/views/settings/pages/privacy/Privacy.html
@@ -27,7 +27,7 @@
       :title="$t('pages.privacy.screenshare.title')"
       :text="$t('pages.privacy.screenshare.subtitle')"
     >
-      <TypographyText color="error">
+      <TypographyText color="danger">
         {{ $t('pages.privacy.screenshare.note') }}
       </TypographyText>
     </SettingsUnit>

--- a/components/views/settings/pages/realms/realm/Realm.html
+++ b/components/views/settings/pages/realms/realm/Realm.html
@@ -14,7 +14,7 @@
     </TypographyText>
     <div class="available">
       <TypographyText> Available </TypographyText>
-      <TypographyText :color="realm.disabled ? 'error' : 'success'">
+      <TypographyText :color="realm.disabled ? 'danger' : 'success'">
         {{ (!realm.disabled).toString() }}
       </TypographyText>
     </div>

--- a/components/views/user/create/Create.html
+++ b/components/views/user/create/Create.html
@@ -60,14 +60,14 @@
         />
       </div>
 
-      <template v-if="error.length">
-        <TypographyError
-          v-for="e in error"
-          :key="e"
-          :text="e"
-          data-cy="error-message"
-        />
-      </template>
+      <TypographyText
+        v-for="e in error"
+        :key="e"
+        color="danger"
+        data-cy="error-message"
+      >
+        {{ e }}
+      </TypographyText>
 
       <div class="submit-button-container">
         <InteractablesButton

--- a/pages/auth/unlock/Unlock.html
+++ b/pages/auth/unlock/Unlock.html
@@ -19,11 +19,11 @@
         autofocus
         @submit="action"
         data-cy="pin-label"
+        :error="$t(error)"
       >
         <unlock-icon size="1x" v-if="getIcon() === 'unlocked'" />
         <chevron-right-icon size="1x" v-else />
       </InteractablesInput>
-      <TypographyError v-if="error" :text="$t(error)" />
     </div>
     <InteractablesSwitch
       v-model="storePin"
@@ -31,10 +31,10 @@
     />
     <br />
     <a v-if="step === 'login'" class="delete-link" @click="clearAndReset">
-      {{$t('pages.unlock.delete_account_label')}}
+      {{ $t('pages.unlock.delete_account_label') }}
     </a>
     <!-- <InteractablesRealm /> -->
-    <TypographyText v-if="!isChrome" color="error" style="max-width: 600px">
+    <TypographyText v-if="!isChrome" color="danger" style="max-width: 600px">
       {{ $t('pages.unlock.browser_warning') }}
     </TypographyText>
     <div class="random-user-container" v-if="isDev">

--- a/types/typography.d.ts
+++ b/types/typography.d.ts
@@ -6,7 +6,7 @@ export type TextColor =
   | 'light'
   | 'dark'
   | 'flair'
-  | 'error'
+  | 'danger'
   | 'white'
   | 'success'
 export type Weight = 'regular' | 'bold'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- switch typography text to use 'danger' for red, rather than 'error'. this fits in better with the rest of the app
- switch a couple error messages using old component
- decrease opacity for disabled context menu items. It wasn't low enough

**Which issue(s) this PR fixes** 🔨

Resolve #
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
