### PR TITLE
fix(toolbar): pull your own name in group lists

### DIFF
--- a/components/views/navigation/toolbar/Toolbar.vue
+++ b/components/views/navigation/toolbar/Toolbar.vue
@@ -54,7 +54,7 @@ export default Vue.extend({
       if (isGroup.value) {
         return (
           conversation?.value?.participants
-            ?.map((did) => iridium.users.state[did]?.name)
+            ?.map((did) => iridium.users.getUser(did)?.name)
             .join(', ') ?? ''
         )
       }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- couldn't find your own username via userManager direct state access. Jason and I added a guard clause (in another ticket) to the getUser method that will fetch your own info from profile state as needed

**Which issue(s) this PR fixes** 🔨

Resolve #4599 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
