### PR TITLE
fix(mobile): repair mobile functionality

### DIFF
--- a/components/compositions/conversations.ts
+++ b/components/compositions/conversations.ts
@@ -75,3 +75,10 @@ export async function call({
     })
     .catch((e) => $nuxt.$toast.error($nuxt.i18n.t(e.message)))
 }
+
+export default function useConversation() {
+  return {
+    ...conversationHooks(),
+    call,
+  }
+}

--- a/components/ui/Popups/ErrorNetwork/ErrorNetwork.less
+++ b/components/ui/Popups/ErrorNetwork/ErrorNetwork.less
@@ -1,14 +1,15 @@
 .error-network-container {
   &:extend(.modal-gradient);
-  padding: 1rem;
+  padding: 32px;
+  max-width: 550px;
 
   .modal-body {
     .custom-modal-content {
-      padding: 0 1rem;
       display: flex;
       flex-direction: column;
       justify-content: center;
       align-items: center;
+      gap: 24px;
 
       .mascot {
         width: 15rem;
@@ -19,17 +20,11 @@
       .title {
         font-size: 1.9rem;
         color: @secondary-text;
-        margin-top: 2rem;
         text-align: center;
-      }
-
-      .subtitle {
-        margin-top: 2rem;
       }
 
       .action {
         width: 100%;
-        margin-top: 1rem;
 
         .text {
           margin: 0 0.5rem;
@@ -39,8 +34,28 @@
   }
 }
 
-@media only screen and (min-width: @mobile-breakpoint) {
+@media (max-width: @mobile-breakpoint) {
   .error-network-container {
-    max-width: 550px;
+    padding: 16px;
+    height: 100%;
+    max-width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    .modal-body {
+      max-width: 550px;
+
+      .custom-modal-content {
+        .mascot {
+          width: 10rem;
+          height: 10rem;
+        }
+
+        .title {
+          font-size: 1.5rem;
+        }
+      }
+    }
   }
 }

--- a/components/views/media/incomingCall/IncomingCall.html
+++ b/components/views/media/incomingCall/IncomingCall.html
@@ -1,5 +1,6 @@
 <div class="incoming" data-cy="incoming-call">
   <UiCircle
+    class="avatar"
     :type="callerAvatar ? 'image' : 'random'"
     :seed="caller.did"
     :source="callerAvatar"

--- a/components/views/media/incomingCall/IncomingCall.less
+++ b/components/views/media/incomingCall/IncomingCall.less
@@ -11,6 +11,10 @@
   background: @foreground-gradient;
   border-radius: @corner-rounding;
 
+  .avatar {
+    margin-top: auto;
+  }
+
   .user-info {
     max-width: @width;
     overflow: hidden;

--- a/components/views/navigation/mobile/nav/Nav.html
+++ b/components/views/navigation/mobile/nav/Nav.html
@@ -23,9 +23,10 @@
   >
     <users-icon size="1.5x" />
   </button>
+  <!-- NOTE: Returns to the main settings screen if the user is already in settings -->
   <button
     :class="{active: isActiveRoute('settings')}"
-    @click="$router.push('/mobile/settings')"
+    @click="isActiveRoute('settings') ? emptySettingsRoute() : $router.push('/mobile/settings')"
     data-cy="mobile-nav-settings"
   >
     <UiUserState :user="accounts.details" />

--- a/components/views/navigation/mobile/nav/Nav.vue
+++ b/components/views/navigation/mobile/nav/Nav.vue
@@ -11,7 +11,7 @@ import {
   SettingsIcon,
   ShoppingBagIcon,
 } from 'satellite-lucide-icons'
-import { ModalWindows } from '~/store/ui/types'
+import { ModalWindows, SettingsRoutes } from '~/store/ui/types'
 import { RootState } from '~/types/store/store'
 import iridium from '~/libraries/Iridium/IridiumManager'
 import { UserStatus } from '~/libraries/Iridium/users/types'
@@ -55,6 +55,9 @@ export default Vue.extend({
     },
     isActiveRoute(route: string): boolean {
       return this.$route.path.includes(route)
+    },
+    emptySettingsRoute() {
+      this.$store.commit('ui/setSettingsRoute', SettingsRoutes.EMPTY)
     },
   },
 })

--- a/components/views/settings/Sidebar.vue
+++ b/components/views/settings/Sidebar.vue
@@ -28,6 +28,7 @@ export default Vue.extend({
       settingsRoute: (state) => (state as RootState).ui.settingsRoute,
     }),
     menuOptions(): SidebarGrouping[] {
+      // TODO: Replace all text entries with i18n
       return [
         {
           title: 'User Settings',

--- a/components/views/settings/pages/notifications/Notifications.html
+++ b/components/views/settings/pages/notifications/Notifications.html
@@ -69,6 +69,4 @@
       </span>
     </SettingsUnit>
   </SettingsSection>
-
-  <SettingsPagesNotificationsSounds />
 </SettingsPage>

--- a/components/views/settings/pages/profile/Profile.html
+++ b/components/views/settings/pages/profile/Profile.html
@@ -82,9 +82,7 @@
                 </button>
                 <form
                   class="editable-wrapper username"
-                  @submit="
-                    (e) => submitEdit(e, 'name')
-                  "
+                  @submit="(e) => submitEdit(e, 'name')"
                 >
                   <typography-text
                     v-if="!editing.has('name')"
@@ -97,14 +95,16 @@
                     v-else
                     v-model="inputs.name"
                     class="username-input"
-                    :placeholder="$t('user.registration.username_placeholder')"
+                    :placeholder="
+                      $t('user.registration.username_placeholder')
+                    "
                     autofocus
                     transparent
                   />
 
                   <button
                     class="edit-button"
-                    :class="{active: editing.has('name')}"
+                    :class="[{ active: editing.has('name') }, { mobile: $device.isMobile }]"
                     type="submit"
                   >
                     {{ getEditButtonText('name') }}
@@ -114,17 +114,16 @@
                   class="status-input"
                   @click="editing.add('status')"
                   @submit="
-                        (e) =>
-                          updateUserDetail(e, 'status', inputs.status ?? '')
-                      "
+                    (e) => updateUserDetail(e, 'status', inputs.status ?? '')
+                  "
                 >
                   <InteractablesInput
                     v-model="inputs.status"
                     size="xs"
                     type="text"
                     :placeholder="
-                        $t('pages.settings.profile.status_placeholder')
-                      "
+                      $t('pages.settings.profile.status_placeholder')
+                    "
                     :loading="loading.has('status')"
                     button-type="submit"
                   >
@@ -167,12 +166,13 @@
                 />
               </div>
               <div
+                v-show="inputs.about || editing.has('about')"
                 class="editable-wrapper"
-                :class="{'readonly': !editing.has('about')}"
+                :class="{ readonly: !editing.has('about') }"
               >
                 <InteractablesEditable
                   v-model="inputs.about"
-                  :placeholder="$t('ui.talk')"
+                  :placeholder="$t('pages.settings.profile.about.placeholder')"
                   :enabled="editing.has('about')"
                 />
               </div>

--- a/components/views/settings/pages/profile/Profile.less
+++ b/components/views/settings/pages/profile/Profile.less
@@ -259,6 +259,7 @@
       padding: 8px;
       opacity: 0;
 
+      &.mobile,
       &.active,
       &:focus {
         opacity: 1;

--- a/libraries/Iridium/friends/FriendsManager.ts
+++ b/libraries/Iridium/friends/FriendsManager.ts
@@ -321,9 +321,8 @@ export default class FriendsManager extends Emitter<IridiumFriendPubsub> {
         payload,
       })
 
-      const user = iridium.users.getUser(did)
+      iridium.users.setUser(did, user)
 
-      if (!user) return
       const buildNotification: Exclude<Notification, 'id'> = {
         fromName: user.name,
         at: request.at,

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -586,6 +586,7 @@ export default {
           title: 'About Me',
           subtitle:
             'Let your friends know who you are! Your about me will display on your profile.',
+          placeholder: 'Enter a short introduction about yourself...',
         },
         accounts: {
           title: 'Your Accounts',

--- a/pages/mobile/friends/index.vue
+++ b/pages/mobile/friends/index.vue
@@ -11,9 +11,6 @@
             <button @click="next('request')">
               <user-check-icon />
             </button>
-            <button>
-              <more-vertical-icon />
-            </button>
           </div>
         </div>
         <FriendsMobileList v-if="friendsList.length" :list="friendsList" />
@@ -65,7 +62,6 @@
 import Vue from 'vue'
 import {
   ArrowLeftIcon,
-  MoreVerticalIcon,
   UserPlusIcon,
   UserCheckIcon,
 } from 'satellite-lucide-icons'
@@ -79,7 +75,6 @@ export default Vue.extend({
   name: 'MobileFriends',
   components: {
     ArrowLeftIcon,
-    MoreVerticalIcon,
     UserPlusIcon,
     UserCheckIcon,
   },
@@ -139,6 +134,14 @@ export default Vue.extend({
             sensitivity: 'base',
           }),
         )
+    },
+  },
+  watch: {
+    route() {
+      // return to main tab if route is not valid
+      if (!this.route && this.swiper?.activeIndex === 1) {
+        this.swiper.slideTo(0)
+      }
     },
   },
   mounted() {

--- a/pages/mobile/settings/index.vue
+++ b/pages/mobile/settings/index.vue
@@ -72,6 +72,7 @@ export default Vue.extend({
               return
             }
             if (activeIndex === 0) {
+              this.$store.commit('ui/setSettingsRoute', SettingsRoutes.EMPTY)
               this.swiper.allowSlidePrev = false
               this.swiper.allowSlideNext = true
             }
@@ -88,6 +89,8 @@ export default Vue.extend({
     settingsRoute(val) {
       if (val) {
         this.swiper?.slideNext()
+      } else {
+        this.swiper?.slidePrev()
       }
     },
   },

--- a/pages/setup/phrase/Phrase.less
+++ b/pages/setup/phrase/Phrase.less
@@ -37,12 +37,11 @@
     &:extend(.full-width);
 
     .phrase-body {
-      margin-top: @normal-spacing;
+      padding: 16px 0;
       align-self: flex-start;
       height: @full;
       display: flex;
       flex-direction: column;
-      padding-bottom: @normal-spacing;
 
       .is-button {
         margin-top: auto;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- FriendsManager.requestAccept() not working on mobile unless app refreshed after request received
- Always display edit name button on mobile in settings profile
- Improve "about me" conditional display for input and input placeholder
- Return to main friends page on friends tab press
- Return to main settings page on settings tab press
- Can’t re-press settings sections on mobile after swiping back to main settings page
- Fix setup/phrase component's spacing from pushing contents outside of container (which enables scroll)
- Username not set for outgoing friend requests
- Remove unused references in AudioVolume
- Remove unused references to missing component SettingsPagesNotificationsSounds
- Vertically center incoming call content
- Resolve “no default found in compositions/conversations.ts” warning that appears on initial app load
- Fix ErrorNetwork modal styling

**Which issue(s) this PR fixes** 🔨

Resolve #4677
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
