### PR TITLE
fix(call): only show talking indicator for one stream

### DIFF
--- a/components/views/media/Media.html
+++ b/components/views/media/Media.html
@@ -31,6 +31,7 @@
         :size="mediaUserSize"
         :stream="stream.stream"
         :is-presenter-thumbnail="presenter === stream"
+        :hide-talking-indicator="stream.hideTalkingIndicator"
         @click="() => togglePresenter(stream)"
       />
     </template>

--- a/components/views/media/Media.html
+++ b/components/views/media/Media.html
@@ -13,6 +13,8 @@
       :stream="presenter.stream"
       @click="() => togglePresenter(null)"
       @mounted="calculateUserSizes"
+      is-presenter
+      hide-talking-indicator
     />
   </div>
 
@@ -28,20 +30,11 @@
         data-cy="remote-video"
         :size="mediaUserSize"
         :stream="stream.stream"
-        :class="{ 'is-presenter': presenter === stream }"
+        :is-presenter-thumbnail="presenter === stream"
         @click="() => togglePresenter(stream)"
       />
     </template>
-
-    <!-- <div
-      v-if="ui.fullscreen && users.length > fullscreenMaxViewableUsers || !ui.fullscreen && users.length > maxViewableUsers"
-      class="more-user"
-      :class="{full: ui.fullscreen, 'full-mobile': fullscreenMaxViewableUsers === 6}"
-    >
-      ...
-    </div> -->
   </div>
-  <!-- <MediaActionsSettings /> -->
 
   <MediaHeading />
   <MediaActions />

--- a/components/views/media/Media.less
+++ b/components/views/media/Media.less
@@ -34,23 +34,6 @@
       height: 120px;
       flex-grow: 0;
     }
-
-    #local {
-      order: -1;
-    }
-
-    .user {
-      &.full-video {
-        position: absolute;
-        width: 100% !important;
-        height: 100% !important;
-        &:extend(.third-layer);
-      }
-
-      &.is-presenter {
-        opacity: 0.66;
-      }
-    }
   }
 
   .controls {

--- a/components/views/media/Media.vue
+++ b/components/views/media/Media.vue
@@ -19,6 +19,7 @@ type OptimalBoxDomensionsParams = {
 type Stream = {
   participant: User | undefined
   stream: string
+  hideTalkingIndicator: boolean
 }
 
 export default Vue.extend({
@@ -80,7 +81,11 @@ export default Vue.extend({
           streams = streams.filter((s) => s !== 'audio')
         }
         return streams.map((stream) => {
-          return { participant, stream }
+          return {
+            participant,
+            stream,
+            hideTalkingIndicator: streams.length > 1 && stream !== 'video',
+          }
         })
       })
       return participantStreams.flat()

--- a/components/views/media/Media.vue
+++ b/components/views/media/Media.vue
@@ -27,16 +27,6 @@ export default Vue.extend({
       type: Array as PropType<Array<User>>,
       default: () => [],
     },
-    maxViewableUsers: {
-      type: Number,
-      default: 0,
-      required: true,
-    },
-    fullscreenMaxViewableUsers: {
-      type: Number,
-      default: 0,
-      required: true,
-    },
   },
   data() {
     return {

--- a/components/views/media/user/User.html
+++ b/components/views/media/user/User.html
@@ -1,7 +1,11 @@
 <div
   v-if="call"
   class="user"
-  :class="{'talking': isTalking}"
+  :class="{
+    'talking': isTalking,
+    'is-presenter': isPresenter,
+    'is-presenter-thumbnail': isPresenterThumbnail
+  }"
   :style="{ width: size[0] + 'px', height: size[1] + 'px' }"
   @click="$emit('click', $event)"
 >

--- a/components/views/media/user/User.html
+++ b/components/views/media/user/User.html
@@ -47,13 +47,15 @@
     />
   </div>
 
-  <TypographyTag :title="user.name" class="username" inverted>
-    {{user.name}}
-  </TypographyTag>
+  <div class="info-overlay">
+    <TypographyTag :title="user.name" class="username" inverted>
+      {{user.name}}
+    </TypographyTag>
 
-  <div class="indicators" v-if="!isPending || isLocal">
-    <div class="indicator" data-cy="muted-indicator" v-if="!audioStream">
-      <mic-off-icon />
+    <div class="indicators" v-if="!isPending || isLocal">
+      <div class="indicator" data-cy="muted-indicator" v-if="!audioStream">
+        <mic-off-icon />
+      </div>
     </div>
   </div>
 

--- a/components/views/media/user/User.html
+++ b/components/views/media/user/User.html
@@ -65,5 +65,5 @@
     autoplay
   />
 
-  <div class="talking-outline"></div>
+  <div v-if="!hideTalkingIndicator" class="talking-outline"></div>
 </div>

--- a/components/views/media/user/User.less
+++ b/components/views/media/user/User.less
@@ -7,6 +7,16 @@
   transition: box-shadow @animation-speed-long ease;
   cursor: pointer;
 
+  &.is-presenter-thumbnail .video-stream {
+    filter: brightness(70%);
+  }
+
+  &:not(.is-presenter-thumbnail):not(.is-presenter):hover {
+    .video-stream {
+      filter: brightness(85%);
+    }
+  }
+
   .talking-outline {
     position: absolute;
     inset: 0;
@@ -31,12 +41,6 @@
 
     &.flip {
       transform: scaleX(-1);
-    }
-  }
-
-  &:hover {
-    .video-stream {
-      filter: brightness(90%);
     }
   }
 

--- a/components/views/media/user/User.less
+++ b/components/views/media/user/User.less
@@ -72,18 +72,23 @@
     }
   }
 
+  .info-overlay {
+    display: flex;
+    width: 100%;
+    gap: 8px;
+    padding: 8px;
+    align-items: flex-start;
+    justify-content: space-between;
+  }
+
   .username {
-    position: absolute;
-    align-self: flex-start;
-    justify-self: flex-start;
     &:extend(.ellipsis);
-    margin: 8px;
     transition: opacity @animation-speed ease;
   }
 
   .username,
   .indicator {
-    background: fade(@foreground-alt, 20%);
+    background: fade(@foreground-alt, 40%);
     backdrop-filter: blur(8px);
     box-shadow: 0 1px 4px fade(@foreground, 10%);
   }
@@ -93,11 +98,7 @@
   display: flex;
   flex-flow: row nowrap;
   justify-content: flex-end;
-  position: absolute;
-  top: 0;
-  right: 0;
-  padding: @light-spacing;
-  gap: @light-spacing;
+  gap: 8px;
 
   .indicator {
     position: relative;

--- a/components/views/media/user/User.vue
+++ b/components/views/media/user/User.vue
@@ -149,9 +149,6 @@ export default Vue.extend({
   },
   methods: {
     initializeAudioStreamUtils(stream: MediaStream | undefined) {
-      if (this.hideTalkingIndicator) {
-        return
-      }
       this.audioStreamUtils?.destroy()
       if (!stream) {
         this.isTalking = false

--- a/components/views/media/user/User.vue
+++ b/components/views/media/user/User.vue
@@ -37,7 +37,7 @@ export default Vue.extend({
     },
     stream: {
       type: String,
-      default: null,
+      required: true,
     },
     size: {
       type: Array,
@@ -45,6 +45,18 @@ export default Vue.extend({
         MEDIA_USER_DIMENSIONS.width,
         MEDIA_USER_DIMENSIONS.height,
       ],
+    },
+    hideTalkingIndicator: {
+      type: Boolean,
+      default: false,
+    },
+    isPresenter: {
+      type: Boolean,
+      default: false,
+    },
+    isPresenterThumbnail: {
+      type: Boolean,
+      default: false,
     },
   },
   data() {
@@ -137,6 +149,9 @@ export default Vue.extend({
   },
   methods: {
     initializeAudioStreamUtils(stream: MediaStream | undefined) {
+      if (this.hideTalkingIndicator) {
+        return
+      }
       this.audioStreamUtils?.destroy()
       if (!stream) {
         this.isTalking = false

--- a/utilities/AudioStreamUtils.ts
+++ b/utilities/AudioStreamUtils.ts
@@ -1,6 +1,6 @@
 import { AudioState } from '~/store/audio/types'
 
-const IS_TALKING_THRESHOLD = 20 // %
+const IS_TALKING_THRESHOLD = 10 // %
 const TALK_OFF_TIMEOUT_MS = 500
 
 export class AudioStreamUtils {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Hide talking indicator for presenter
- Fix presenter thumbnail styling
- Fix username overflow in MediaUser
- Only show talking indicator for one participant stream (eg video only if sharing both video and screen)

**Which issue(s) this PR fixes** 🔨

Resolve #4656
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
