### PR TITLE
fix(friends): autofocus on desktop add friend

### DIFF
--- a/components/views/friends/search/Search.vue
+++ b/components/views/friends/search/Search.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <InteractablesInput
+      v-if="$route.query.route === 'add'"
       v-model.trim="query"
       :placeholder="$t('friends.search_placeholder')"
       :autofocus="$device.isDesktop"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
-  i broke this when i switched the tabs to v-show. It was getting mounted while the tab was not displayed, so it wouldn't autofocus. This will force the input to remount when you open the tab

**Which issue(s) this PR fixes** 🔨

Resolve #
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
