### PR TITLE
fix(call): mute screen stream after it has ended

### DIFF
--- a/libraries/WebRTC/Call.ts
+++ b/libraries/WebRTC/Call.ts
@@ -417,6 +417,10 @@ export class Call extends Emitter<CallEventListeners> {
     const screenTrack = screenStream.getVideoTracks()[0]
     screenTrack.enabled = true
 
+    screenTrack.addEventListener('ended', (event) => {
+      this.mute({ kind: 'screen', did: iridium.id })
+    })
+
     this.screenStreams[iridium.id] = screenStream.id
     this.streams[iridium.id].screen = screenStream
     this.tracks[iridium.id].add(screenTrack)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Mutes the screen stream after it has been ended by the browser

**Which issue(s) this PR fixes** 🔨

Resolve #4708
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
