### PR TITLE
refactor(sidebar): apply padding to individual sidebar elements

### DIFF
--- a/components/views/navigation/sidebar/Sidebar.html
+++ b/components/views/navigation/sidebar/Sidebar.html
@@ -48,7 +48,7 @@
         @toggle="toggleModal"
       />
     </div>
-    <SidebarList :filter="filter" />
+    <SidebarList class="conversation-list" :filter="filter" />
   </div>
   <div class="controls">
     <SidebarLive />

--- a/components/views/navigation/sidebar/Sidebar.less
+++ b/components/views/navigation/sidebar/Sidebar.less
@@ -11,7 +11,6 @@
     display: flex;
     flex-direction: column;
     gap: @normal-spacing;
-    padding: @normal-spacing;
     box-shadow: @ui-shadow;
     max-height: calc(100% - @sidebar-controls-height);
     &:extend(.round-corners);
@@ -20,6 +19,7 @@
     .sidebar-search {
       display: flex;
       gap: @normal-spacing;
+      padding: 16px 16px 0;
       .toggle-sidebar {
         cursor: pointer;
         &:extend(.filter-glow);
@@ -31,11 +31,13 @@
       flex-direction: column;
       gap: @light-spacing;
       position: relative;
+      padding: 0 16px;
     }
 
     .quick-toggle {
       align-self: flex-end;
       position: relative;
+      margin-right: 16px;
       button {
         align-items: center;
         justify-content: center;
@@ -44,6 +46,10 @@
         border-radius: 50%;
         background-color: @foreground-alt;
       }
+    }
+
+    .conversation-list {
+      padding: 0 16px;
     }
 
     .users {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- push scrollbar to the edge of the sidebar, rather than being snug against the list items. See ticket for screenshot of old display
- list items are visible at the very bottom of the list, rather than 16px of background-color

### Which issue(s) this PR fixes 🔨
- Resolve #
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

