### PR TITLE
fix(sidebar-list-item): show subtitle text as single line

### DIFF
--- a/assets/styles/framework/typography.less
+++ b/assets/styles/framework/typography.less
@@ -99,10 +99,3 @@ h6 {
   white-space: nowrap;
   display: block;
 }
-
-.multiline-ellipsis(@lines: 2) {
-  display: -webkit-box;
-  text-overflow: ellipsis;
-  -webkit-line-clamp: @lines;
-  -webkit-box-orient: vertical;
-}

--- a/components/views/navigation/sidebar/list/item/Item.html
+++ b/components/views/navigation/sidebar/list/item/Item.html
@@ -37,7 +37,7 @@
         ref="subtitle"
         class="ellipsis"
         :class="{ bigmoji: containsOnlyEmoji(lastMessageDisplay) }"
-        v-html="wrapEmoji(markdownToHtml(lastMessageDisplay))"
+        v-html="subtitle"
       />
     </TypographyText>
   </div>

--- a/components/views/navigation/sidebar/list/item/Item.vue
+++ b/components/views/navigation/sidebar/list/item/Item.vue
@@ -37,6 +37,11 @@ export default Vue.extend({
   },
   computed: {
     ...mapGetters('settings', ['getTimestamp', 'getDate']),
+    subtitle(): string {
+      const html = this.markdownToHtml(this.lastMessageDisplay)
+      const firstLine = html.split('<br>')[0]
+      return this.wrapEmoji(firstLine)
+    },
     conversation(): Conversation {
       return iridium.chat.state.conversations[this.conversationId]
     },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- Trims the subtitle text to a single line

### Which issue(s) this PR fixes 🔨
- Resolve #4732 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

