### PR TITLE
fix(sidebar-list-item): time section constraining last message width

### DIFF
--- a/components/views/navigation/sidebar/Sidebar.less
+++ b/components/views/navigation/sidebar/Sidebar.less
@@ -11,6 +11,7 @@
     display: flex;
     flex-direction: column;
     gap: @normal-spacing;
+    padding: 16px 16px 0;
     box-shadow: @ui-shadow;
     max-height: calc(100% - @sidebar-controls-height);
     &:extend(.round-corners);

--- a/components/views/navigation/sidebar/Sidebar.less
+++ b/components/views/navigation/sidebar/Sidebar.less
@@ -11,7 +11,6 @@
     display: flex;
     flex-direction: column;
     gap: @normal-spacing;
-    padding: 16px 16px 0;
     box-shadow: @ui-shadow;
     max-height: calc(100% - @sidebar-controls-height);
     &:extend(.round-corners);
@@ -32,7 +31,7 @@
       flex-direction: column;
       gap: @light-spacing;
       position: relative;
-      padding: 0 16px;
+      padding: 0 16px 8px;
     }
 
     .quick-toggle {

--- a/components/views/navigation/sidebar/list/List.less
+++ b/components/views/navigation/sidebar/list/List.less
@@ -1,5 +1,6 @@
 .list {
   overflow-y: auto;
+  padding-bottom: 16px;
 
   .empty-friends-wrapper {
     display: flex;

--- a/components/views/navigation/sidebar/list/List.less
+++ b/components/views/navigation/sidebar/list/List.less
@@ -7,7 +7,7 @@
     justify-content: center;
     align-items: center;
     height: 100%;
-    padding: 16px 0;
+    padding-bottom: 32px;
 
     .no-result {
       text-align: center;

--- a/components/views/navigation/sidebar/list/item/Item.html
+++ b/components/views/navigation/sidebar/list/item/Item.html
@@ -30,32 +30,32 @@
         {{ conversation.name }}
       </TypographyText>
 
-      <div class="user-chat-details">
-        <TypographyText v-if="messages.length" color="dark" size="xs">
-          {{ timestamp }}
-        </TypographyText>
-        <TypographyTag
-          v-if="unreadCount"
-          class="tag"
-          :text="unreadCount"
-          small
-        />
-      </div>
+      <TypographyText
+        class="user-chat-details"
+        v-if="messages.length"
+        color="dark"
+        size="xs"
+      >
+        {{ timestamp }}
+      </TypographyText>
     </div>
 
-    <TypographyText
-      size="sm"
-      :color="unreadCount ? 'light' : 'dark'"
-      :weight="unreadCount ? 'bold' : ''"
-      data-cy="sidebar-user-name"
-    >
-      <div
-        ref="subtitle"
-        class="ellipsis"
-        :class="{ bigmoji: containsOnlyEmoji(lastMessageDisplay) }"
-        v-html="subtitle"
-      />
-    </TypographyText>
+    <div class="bottom">
+      <TypographyText
+        size="sm"
+        class="sidebar-subtitle"
+        :color="unreadCount ? 'light' : 'dark'"
+        :weight="unreadCount ? 'bold' : ''"
+      >
+        <div
+          ref="subtitle"
+          class="subtitle"
+          :class="{ bigmoji: containsOnlyEmoji(lastMessageDisplay) }"
+          v-html="subtitle"
+        />
+      </TypographyText>
+      <TypographyTag v-if="unreadCount" class="tag" :text="unreadCount" small />
+    </div>
   </div>
 
   <div class="user-loader">

--- a/components/views/navigation/sidebar/list/item/Item.html
+++ b/components/views/navigation/sidebar/list/item/Item.html
@@ -11,22 +11,38 @@
       :user="user"
       :conversationId="conversationId"
     />
+
     <UiGroupIcon
       v-else-if="conversation.participants"
       :members="conversation.participants"
     />
   </template>
   <div class="user-info">
-    <TypographyText
-      class="ellipsis"
-      color="light"
-      font="heading"
-      weight="bold"
-      data-cy="sidebar-user-name"
-      :color="!!unreadCount ? 'light' : 'dark'"
-    >
-      {{ conversation.name }}
-    </TypographyText>
+    <div class="top">
+      <TypographyText
+        class="user-name"
+        color="light"
+        font="heading"
+        weight="bold"
+        data-cy="sidebar-user-name"
+        :color="!!unreadCount ? 'light' : 'dark'"
+      >
+        {{ conversation.name }}
+      </TypographyText>
+
+      <div class="user-chat-details">
+        <TypographyText v-if="messages.length" color="dark" size="xs">
+          {{ timestamp }}
+        </TypographyText>
+        <TypographyTag
+          v-if="unreadCount"
+          class="tag"
+          :text="unreadCount"
+          small
+        />
+      </div>
+    </div>
+
     <TypographyText
       size="sm"
       :color="unreadCount ? 'light' : 'dark'"
@@ -41,12 +57,7 @@
       />
     </TypographyText>
   </div>
-  <div class="user-chat-details">
-    <TypographyText v-if="messages.length" color="dark" size="xs">
-      {{ timestamp }}
-    </TypographyText>
-    <TypographyTag v-if="unreadCount" class="tag" :text="unreadCount" small />
-  </div>
+
   <div class="user-loader">
     <UiLoadersSpinner :spinning="isLoading" />
   </div>

--- a/components/views/navigation/sidebar/list/item/Item.less
+++ b/components/views/navigation/sidebar/list/item/Item.less
@@ -2,6 +2,7 @@
   height: 64px;
   display: flex;
   align-items: center;
+  gap: 8px;
   cursor: pointer;
   position: relative;
   padding: @light-spacing;
@@ -27,20 +28,23 @@
   }
 
   .user-info {
-    flex: 1;
-    padding-left: @light-spacing;
-    overflow: hidden;
-  }
+    flex-grow: 1;
+    min-width: 0;
 
-  .user-chat-details {
-    display: flex;
-    flex-direction: column;
-    align-self: flex-start;
-    gap: 4px;
+    .top {
+      display: flex;
 
-    .tag {
-      align-self: flex-end;
-      min-width: 16px;
+      .user-name {
+        flex-grow: 1;
+        &:extend(.ellipsis);
+      }
+
+      .user-chat-details {
+        .tag {
+          align-self: flex-end;
+          min-width: 16px;
+        }
+      }
     }
   }
 

--- a/components/views/navigation/sidebar/list/item/Item.less
+++ b/components/views/navigation/sidebar/list/item/Item.less
@@ -48,6 +48,7 @@
 
     .bottom {
       display: flex;
+      justify-content: space-between;
       gap: 4px;
 
       .sidebar-subtitle {
@@ -59,7 +60,6 @@
       }
 
       .tag {
-        align-self: flex-end;
         min-width: 16px;
       }
     }

--- a/components/views/navigation/sidebar/list/item/Item.less
+++ b/components/views/navigation/sidebar/list/item/Item.less
@@ -33,17 +33,34 @@
 
     .top {
       display: flex;
+      gap: 4px;
 
       .user-name {
         flex-grow: 1;
+        min-width: 0;
         &:extend(.ellipsis);
       }
 
       .user-chat-details {
-        .tag {
-          align-self: flex-end;
-          min-width: 16px;
+        flex-shrink: 0;
+      }
+    }
+
+    .bottom {
+      display: flex;
+      gap: 4px;
+
+      .sidebar-subtitle {
+        &:extend(.ellipsis);
+
+        .subtitle {
+          &:extend(.ellipsis);
         }
+      }
+
+      .tag {
+        align-self: flex-end;
+        min-width: 16px;
       }
     }
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
Before:
<img width="300" alt="スクリーンショット 2022-09-13 午後6 40 51" src="https://user-images.githubusercontent.com/40599535/189854625-dfd7c77d-dd26-4270-ade4-9819d23119a4.png">

After:
<img width="295" alt="スクリーンショット 2022-09-13 午後7 07 21" src="https://user-images.githubusercontent.com/40599535/189860785-5870eeb2-3ddc-45f4-b5a6-f495c2769758.png">


### Which issue(s) this PR fixes 🔨
- Resolve #4753 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

