### PR TITLE
fix(webrtc): media UI + hangup during second incoming call

### DIFF
--- a/components/views/media/Media.vue
+++ b/components/views/media/Media.vue
@@ -69,25 +69,28 @@ export default Vue.extend({
       if (!this.call) {
         return []
       }
+
       const muted = Object.entries(iridium.webRTC.state.streamMuted)
-      const participantStreams = muted.map(([did, mutedStreams]) => {
-        const participant = iridium.users.getUser(did)
-        let streams = Object.entries(mutedStreams)
-          .filter(([k, v]) => !v && k !== 'headphones')
-          .map(([k]) => k)
-        streams.unshift('audio')
-        streams = Array.from(new Set(streams))
-        if (streams.length > 1) {
-          streams = streams.filter((s) => s !== 'audio')
-        }
-        return streams.map((stream) => {
-          return {
-            participant,
-            stream,
-            hideTalkingIndicator: streams.length > 1 && stream !== 'video',
+      const participantStreams = muted
+        .filter(([did]) => did === iridium.id || Boolean(this.call?.peers[did]))
+        .map(([did, mutedStreams]) => {
+          const participant = iridium.users.getUser(did)
+          let streams = Object.entries(mutedStreams)
+            .filter(([k, v]) => !v && k !== 'headphones')
+            .map(([k]) => k)
+          streams.unshift('audio')
+          streams = Array.from(new Set(streams))
+          if (streams.length > 1) {
+            streams = streams.filter((s) => s !== 'audio')
           }
+          return streams.map((stream) => {
+            return {
+              participant,
+              stream,
+              hideTalkingIndicator: streams.length > 1 && stream !== 'video',
+            }
+          })
         })
-      })
       return participantStreams.flat()
     },
   },

--- a/libraries/Iridium/IridiumManager.ts
+++ b/libraries/Iridium/IridiumManager.ts
@@ -220,4 +220,14 @@ export class IridiumManager extends Emitter {
 }
 
 const instance = new IridiumManager()
+
+declare global {
+  interface Window {
+    iridium?: IridiumManager
+  }
+}
+
+if (process.env.NODE_ENV === 'development') {
+  window.iridium = instance
+}
 export default instance

--- a/libraries/WebRTC/Call.ts
+++ b/libraries/WebRTC/Call.ts
@@ -85,8 +85,6 @@ export class Call extends Emitter<CallEventListeners> {
     this.constraints = Config.webrtc.constraints
     this.peerDetails = peers || []
     this._bindBusListeners()
-
-    console.log('CALL', 'creating a new peer', callId)
   }
 
   /**
@@ -1188,8 +1186,11 @@ export class Call extends Emitter<CallEventListeners> {
    * @description Callback for the on hangup event. Used for the hang up
    * after the call started
    */
-  protected _onBusHangup({ payload }: { payload: any }) {
+  protected _onBusHangup({ payload }: IridiumMessage<IridiumDocument>) {
     const { did, callId } = payload.body
+
+    // It's related to another call
+    if (callId !== this.callId) return
 
     this.peerDialingDisabled[did] = true
     this.isCallee[did] = false


### PR DESCRIPTION
### What this PR does 📖
- when a second incoming call is happening, the UI doesn't show anymore any extra box in the Media component

### Which issue(s) this PR fixes 🔨
- Resolve #4646

### Special notes for reviewers 🗒️
- thanks for reviewing 🙏

### Additional comments 🎤
To test it you have to open 3 browsers with 3 different users (UserA, UserB, UserC). Make sure that one of them is friend with both the others (for example UserA is friend with both UserB and UserC). Create a call from UserA to UserB, then go to UserC and call UserA. If you look at the UserA UI you should not see any extra box in the Media component. Then if you go back to UserC and hang up, the call between UserA and UserB should keep going.
