### PR TITLE
fix(account): proper reactivity on profile update

### DIFF
--- a/components/views/settings/pages/profile/index.vue
+++ b/components/views/settings/pages/profile/index.vue
@@ -100,8 +100,6 @@ export default Vue.extend({
       const img = new Image()
       img.src = this.croppedImage
       // TODO: Save image with iridium
-      // Note: This was used for Solana implementation
-      // this.$store.dispatch('accounts/updateProfilePhoto', image)
     },
     /**
      * @method selectProfileImage DocsTODO

--- a/libraries/Iridium/profile/ProfileManager.ts
+++ b/libraries/Iridium/profile/ProfileManager.ts
@@ -64,7 +64,6 @@ export default class IridiumProfile extends Emitter {
       payload,
       options,
     )
-    this.state = await this.get<User>()
   }
 
   async setUser() {
@@ -76,6 +75,10 @@ export default class IridiumProfile extends Emitter {
 
   async updateUser(details: Partial<User>) {
     logger.info('iridium/profile', 'updating user', { details })
+    for (const [key, value] of Object.entries(details)) {
+      this.state[key] = value
+    }
+
     await this.set('/', { ...this.state, ...(details as User) })
     if (!this.state || !iridium.id) return
     // tell our peers via user announce

--- a/store/accounts/actions.ts
+++ b/store/accounts/actions.ts
@@ -311,26 +311,6 @@ export default {
   },
 
   /**
-   * @method updateProfilePhoto
-   * @description update profile photo of the user on the Solana blockchain
-   * @param image
-   * @example
-   * ```typescript
-   * this.$store.dispatch(
-   *  'accounts/updateProfilePhoto', image
-   * );
-   * ```
-   */
-  async updateProfilePhoto(
-    { commit, state, dispatch }: ActionsArguments<AccountsState>,
-    image: string,
-  ) {
-    const imagePath = await uploadPicture(image)
-    await iridium.profile?.updateUser({ photoHash: imagePath })
-    commit('setPhotoHash', imagePath)
-  },
-
-  /**
    * @method initializeEncryptionEngine
    * @description Initializes the Crypto class with the current user keypair
    * @param userAccount keypair of the current user


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- observer was getting blasted away because profile state was reassigned after a remote set
- remove unused profile action

### Which issue(s) this PR fixes 🔨
- Resolve #
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

