### PR TITLE
fix(sidebar): group icon flex bug

### DIFF
--- a/components/ui/GroupIcon/GroupIcon.less
+++ b/components/ui/GroupIcon/GroupIcon.less
@@ -1,5 +1,6 @@
 .group-icon {
   position: relative;
+  flex-shrink: 0;
 
   .label {
     position: absolute;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- group icon was getting shrunk because of recent sidebarListItem changes. This prevents the following visual bug
- I applied at the component level since it should be a universal rule. I think we already apply this independently in the two Toolbar components
![image](https://user-images.githubusercontent.com/33670767/190087080-653e6b78-bd8a-46aa-9511-94a079d2f26b.png)


### Which issue(s) this PR fixes 🔨
- Resolve #
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

