### PR TITLE
fix(chat): only scroll to bottom when adding children

### DIFF
--- a/components/views/chat/conversation/Conversation.vue
+++ b/components/views/chat/conversation/Conversation.vue
@@ -166,6 +166,4 @@ export default Vue.extend({
   },
 })
 </script>
-<style scoped lang="less" src="./Conversation.less">
-
-</style>
+<style scoped lang="less" src="./Conversation.less"></style>

--- a/components/views/chat/conversation/Conversation.vue
+++ b/components/views/chat/conversation/Conversation.vue
@@ -126,15 +126,20 @@ export default Vue.extend({
       container.scrollTo(0, y)
     }
     scrollToBottom()
-    this.mutationObserver = new MutationObserver(() => {
-      if (this.isLockedToBottom || this.isLastChatItemAuthor) {
-        scrollToBottom()
-      }
+    this.mutationObserver = new MutationObserver((records) => {
+      records.forEach((record) => {
+        const target = record.target as HTMLElement
+        if (
+          target.classList.contains('messages') &&
+          (this.isLockedToBottom || this.isLastChatItemAuthor)
+        ) {
+          scrollToBottom()
+        }
+      })
     })
     this.mutationObserver.observe(container, {
       childList: true,
       subtree: true,
-      attributes: true,
     })
   },
   beforeDestroy() {
@@ -161,4 +166,6 @@ export default Vue.extend({
   },
 })
 </script>
-<style scoped lang="less" src="./Conversation.less"></style>
+<style scoped lang="less" src="./Conversation.less">
+
+</style>

--- a/components/views/chat/message/replies/Replies.less
+++ b/components/views/chat/message/replies/Replies.less
@@ -22,7 +22,7 @@
   }
 
   .message-replies {
-    padding: @normal-spacing;
+    padding: 0 1rem 1rem;
 
     .chat-message-container:first-child .chat-message {
       margin-top: 0;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- Checks that only children message elements are add to the messages container in the MutationObserver callback
- Fix padding in message replies container

### Which issue(s) this PR fixes 🔨
- Resolve #4795 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

