### PR TITLE
chore(groups): remove coming soon

### DIFF
--- a/components/views/chat/message/actions/Actions.html
+++ b/components/views/chat/message/actions/Actions.html
@@ -1,8 +1,7 @@
 <div class="message-actions">
   <div
     class="reply-command"
-    :class="{'coming-soon': isGroup}"
-    v-tooltip.top="$t(isGroup ? 'ui.coming_soon' : 'ui.emoji')"
+    v-tooltip.top="$t('ui.emotes')"
     @click="emojiReaction"
   >
     <smile-icon
@@ -13,8 +12,7 @@
   <div
     v-if="!hideReply"
     class="reply-command"
-    :class="{'coming-soon': isGroup}"
-    v-tooltip.top="$t(isGroup ? 'ui.coming_soon' : 'messaging.reply')"
+    v-tooltip.top="$t('messaging.reply')"
     @click="setReplyChatbarMessage"
   >
     <corner-down-right-icon size="1x" :class="'control-icon'" />

--- a/components/views/chat/message/actions/Actions.html
+++ b/components/views/chat/message/actions/Actions.html
@@ -1,7 +1,7 @@
 <div class="message-actions">
   <div
     class="reply-command"
-    v-tooltip.top="$t('ui.emotes')"
+    v-tooltip.top="$t('ui.emoji')"
     @click="emojiReaction"
   >
     <smile-icon


### PR DESCRIPTION
### What this PR does 📖
- Removes coming soon UI on groups reply to message/reactions, this is working but it had the coming soon UI that wasn't removed previously

before

https://user-images.githubusercontent.com/29093946/190521119-cdd09377-a587-4918-bf9a-d0fb992d8744.mov




after

https://user-images.githubusercontent.com/29093946/190522179-502c2299-4410-4853-89fd-5a16d432f9e1.mov

