### PR TITLE
fix(friends-manager): hang up before friend removal while on active c…

### DIFF
--- a/libraries/Iridium/friends/FriendsManager.ts
+++ b/libraries/Iridium/friends/FriendsManager.ts
@@ -477,6 +477,11 @@ export default class FriendsManager extends Emitter<IridiumFriendPubsub> {
    * @returns Promise<void>
    */
   async friendRemove(pid: IridiumPeerIdentifier): Promise<void> {
+    // TODO: update when group calls are implemented
+    if (iridium.webRTC.state.activeCall?.did === pid) {
+      await iridium.webRTC.hangUp()
+    }
+
     const did = didUtils.didString(pid)
     if (!iridium.connector) {
       logger.error(this.loggerTag, 'network error')


### PR DESCRIPTION
…all with that user

<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- Instead of disabling friend removal on calls this method simply hangs up the call with that friend before removing

### Which issue(s) this PR fixes 🔨
- Resolve #4853 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

