### PR TITLE
fix(seedPhrase): avoid cleartext seed phrase persistence in local storage

### DIFF
--- a/plugins/thirdparty/persist.ts
+++ b/plugins/thirdparty/persist.ts
@@ -44,11 +44,11 @@ const commonProperties = [
   'conversation.participants',
   'files',
   'ui.callHeight',
+  'accounts.phrase',
 ]
 
 const propertiesNoStorePin = [
   'accounts.pin',
-  'accounts.mnemonic',
   'accounts.locked',
   'accounts.error',
   'accounts.loading',

--- a/store/accounts/actions.ts
+++ b/store/accounts/actions.ts
@@ -108,7 +108,7 @@ export default {
       $BlockchainClient.account.publicKey.toBase58(),
       pinHash,
     )
-    commit('setEntropy', entropyMessage)
+    // commit('setEntropy', entropyMessage)
 
     const encryptedPhrase = await Crypto.encryptWithPassword(
       userWallet.mnemonic,
@@ -358,7 +358,7 @@ export default {
       $BlockchainClient.account.publicKey.toBase58(),
       pinHash,
     )
-    commit('setEntropy', entropyMessage)
+    // commit('setEntropy', entropyMessage)
 
     const fakeMnemonic = 'fake mnemonic to bypass checks'
     commit('setPhrase', 'fake mnemonic to bypass checks')


### PR DESCRIPTION
### What this PR does 📖
- avoid cleartext seed phrase persistence in local storage (only the encrypted version is persisted)
- avoid entropy message persistence in local storage (dynamically computed all the time) 

### Which issue(s) this PR fixes 🔨

### Special notes for reviewers 🗒️

### Additional comments 🎤

