### PR TITLE
fix(chat): user headers fix

### DIFF
--- a/components/views/chat/conversation/Conversation.vue
+++ b/components/views/chat/conversation/Conversation.vue
@@ -78,6 +78,8 @@ export default Vue.extend({
         const showHeader =
           !isSameAuthor ||
           (prevMessage && conversationMessageIsNotice(prevMessage)) ||
+          this.$dayjs.duration(timeDiff).minutes() >= 5 ||
+          isNextDay ||
           false
 
         return {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- Insert user header in chat when lastMessage is more than 5 minutes ago or if it's the next day

### Which issue(s) this PR fixes 🔨
- Resolve #
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

