### PR TITLE
fix(update-modal): wrap unlock screen UpdateModal in modal component

### DIFF
--- a/components/ui/Global/Global.html
+++ b/components/ui/Global/Global.html
@@ -81,7 +81,7 @@
       <FilesRename :close-modal="() => toggleModal(ModalWindows.RENAME_FILE)" />
     </UiModal>
     <UiModal v-if="ui.modals.changelog">
-      <UiUpdateModal @close="() => toggleModal(ModalWindows.CHANGELOG)" />
+      <UiUpdateModal />
     </UiModal>
     <UiChatImageOverlay v-if="ui.chatImageOverlay" />
     <FilesView v-if="files.preview" />

--- a/pages/auth/unlock/Unlock.html
+++ b/pages/auth/unlock/Unlock.html
@@ -60,7 +60,7 @@
   <UiVersion name version @click="toggleChangelogVisibility" />
 
   <UiModal v-if="ui.modals.changelog">
-    <UiUpdateModal @close="() => toggleModal(ModalWindows.CHANGELOG)" />
+    <UiUpdateModal />
   </UiModal>
 
   <UiConfirmationModal

--- a/pages/auth/unlock/Unlock.html
+++ b/pages/auth/unlock/Unlock.html
@@ -59,7 +59,9 @@
 
   <UiVersion name version @click="toggleChangelogVisibility" />
 
-  <UiUpdateModal v-if="ui.modals.changelog" />
+  <UiModal v-if="ui.modals.changelog">
+    <UiUpdateModal @close="() => toggleModal(ModalWindows.CHANGELOG)" />
+  </UiModal>
 
   <UiConfirmationModal
     :show-modal="confirmClearAccountModalVisible"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- There was an iteration of the UpdateModal in the unlock screen that was missing a modal wrapper, resulting in it getting added to the actual layout of the unlock screen. This PR adds a modal wrapper.

### Which issue(s) this PR fixes 🔨
- Resolve #4950 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

