### PR TITLE
fix(inputs): remove auto zoom on all ios inputs

### DIFF
--- a/components/interactables/Input/Input.html
+++ b/components/interactables/Input/Input.html
@@ -2,7 +2,7 @@
   <TypographyText v-if="label" as="label" uppercase>
     {{ label }}
   </TypographyText>
-  <div class="input-outer" :class="`font-size-${size}`">
+  <div class="input-outer" :class="`font-size-${derivedSize}`">
     <div
       class="input-inner"
       :class="[

--- a/components/interactables/Input/Input.vue
+++ b/components/interactables/Input/Input.vue
@@ -107,6 +107,10 @@ export default Vue.extend({
     derivedType(): string {
       return this.showPassword ? 'text' : this.type
     },
+    // mobile devices need at least 1rem font size on inputs or it zooms the user in on focus
+    derivedSize(): string {
+      return this.$device.isMobile ? 'md' : this.size
+    },
   },
   mounted() {
     if (this.autofocus) {

--- a/components/views/user/create/Create.html
+++ b/components/views/user/create/Create.html
@@ -38,7 +38,6 @@
         <InteractablesInput
           v-model="name"
           :placeholder="$t('user.registration.username_placeholder')"
-          size="small"
           input-kind="text"
           type="primary"
           :min-length="$Config.account.minLength"
@@ -52,7 +51,6 @@
         <InteractablesInput
           v-model="status"
           :placeholder="$t('user.registration.status_placeholder')"
-          size="small"
           input-kind="text"
           type="primary"
           :max-length="$Config.account.statusMaxLength"

--- a/pages/auth/unlock/Unlock.html
+++ b/pages/auth/unlock/Unlock.html
@@ -15,7 +15,6 @@
         :label="step === 'login' ? $t('pages.unlock.decrypt') : $t('pages.unlock.choose_pin')"
         :placeholder="$t('pages.unlock.placeholder')"
         :loading="status === 'loading'"
-        size="sm"
         autofocus
         @submit="action"
         data-cy="pin-label"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- switch unlock input to md since it's the only one on the page, no reason to make it small
- force mobile inputs to be 1 rem (16px default) so ios won't zoom on focus

### Which issue(s) this PR fixes 🔨
- Resolve #5014 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

