### PR TITLE
fix(chat): edit on keydown and no text in chatbar

### DIFF
--- a/components/views/chat/chatbar/Chatbar.html
+++ b/components/views/chat/chatbar/Chatbar.html
@@ -23,7 +23,6 @@
       :class="{'has-command' : hasCommand}"
       :focus="ui.chatbarFocus"
       @keydown="handleInputKeydown"
-      @keyup="handleInputKeyup"
       @paste="handlePaste"
     />
     <ChatbarControls

--- a/components/views/chat/chatbar/Chatbar.vue
+++ b/components/views/chat/chatbar/Chatbar.vue
@@ -226,21 +226,16 @@ const Chatbar = Vue.extend({
             event.preventDefault()
           }
           break
-        default:
-          break
-      }
-      this.smartTypingStart()
-    },
-    handleInputKeyup(event: KeyboardEvent) {
-      switch (event.key) {
         case KeybindingEnum.ARROW_UP:
-          if (!event.shiftKey) {
+          if (!event.shiftKey && !this.text.length) {
+            event.preventDefault()
             this.editMessage()
           }
           break
         default:
           break
       }
+      this.smartTypingStart()
     },
     async uploadAttachments(): Promise<MessageAttachment[]> {
       if (!this.files.length) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- Edit event on keydown
- Only edit if chatbar is empty

### Which issue(s) this PR fixes 🔨
- Resolve #5008 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

