### PR TITLE
fix(messages): display attachments in single row

### DIFF
--- a/components/views/chat/message/attachments/Attachments.less
+++ b/components/views/chat/message/attachments/Attachments.less
@@ -1,6 +1,6 @@
 .message-attachments {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 8px;
   margin: 8px 0;
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
Before:
<img width="789" alt="スクリーンショット 2022-09-27 16 30 50" src="https://user-images.githubusercontent.com/40599535/192449912-ef577792-b507-472c-b8b6-458c52cdfa92.png">

After:
<img width="799" alt="スクリーンショット 2022-09-27 16 29 32" src="https://user-images.githubusercontent.com/40599535/192449707-1b1125c3-67c1-4b2f-88bd-d3b3d1ac6da8.png">


### Which issue(s) this PR fixes 🔨
- Resolve #4801 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

