### PR TITLE
chore(chat): typing indicator only upon text change

### DIFF
--- a/components/views/chat/chatbar/Chatbar.vue
+++ b/components/views/chat/chatbar/Chatbar.vue
@@ -177,13 +177,20 @@ const Chatbar = Vue.extend({
         .sort((a, b) => a.at - b.at)
         .at(-1)
     },
+    draftMessage(): string {
+      return this.chat.draftMessages[this.conversationId] ?? ''
+    },
+  },
+  watch: {
+    draftMessage(val) {
+      if (val) this.smartTypingStart()
+    },
   },
   mounted() {
-    const message = this.chat.draftMessages[this.conversationId] ?? ''
     this.$store.commit('chat/clearReplyChatbarMessage', {
       conversationId: this.conversationId,
     })
-    this.$store.dispatch('ui/setChatbarContent', { content: message })
+    this.$store.dispatch('ui/setChatbarContent', { content: this.draftMessage })
     if (this.$device.isDesktop) {
       this.$store.dispatch('ui/setChatbarFocus')
     }
@@ -235,7 +242,6 @@ const Chatbar = Vue.extend({
         default:
           break
       }
-      this.smartTypingStart()
     },
     async uploadAttachments(): Promise<MessageAttachment[]> {
       if (!this.files.length) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- Send typing indicator only when the draft message in the chatbar changes and is not empty

### Which issue(s) this PR fixes 🔨
- Resolve #4970 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

