### PR TITLE
fix(desktop): stop switching between multiple Nuxt components

### DIFF
--- a/components/ui/DroppableWrapper/DroppableWrapper.vue
+++ b/components/ui/DroppableWrapper/DroppableWrapper.vue
@@ -5,6 +5,16 @@ import Vue from 'vue'
 
 export default Vue.extend({
   name: 'DroppableWrapper',
+  props: {
+    /**
+     * @prop {string} disabled - Whether or not the wrapper is disabled
+     * @description If the wrapper is disabled, it will not accept any drops
+     */
+    disabled: {
+      type: Boolean,
+      required: true,
+    },
+  },
   data() {
     return {
       target: null as EventTarget | null,
@@ -13,6 +23,7 @@ export default Vue.extend({
   },
   methods: {
     handleDrop(e: DragEvent) {
+      if (this.disabled) return
       this.$emit('handle-drop-prop', e)
       this.dragging = false
     },
@@ -21,6 +32,7 @@ export default Vue.extend({
      * @description Event handler that define target that was entered
      */
     handleDragenter(e: DragEvent) {
+      if (this.disabled) return
       this.target = e.target
       this.dragging = true
     },

--- a/components/ui/ResultsMessage/ResultsMessage.vue
+++ b/components/ui/ResultsMessage/ResultsMessage.vue
@@ -43,7 +43,7 @@ export default Vue.extend({
   justify-content: center;
   user-select: none;
   height: 100%;
-  gap: 16px;
+  gap: 8px;
   padding: 16px 0;
 
   .no-results-icon {

--- a/components/views/navigation/sidebar/Sidebar.html
+++ b/components/views/navigation/sidebar/Sidebar.html
@@ -19,6 +19,7 @@
       >
         <folder-icon size="1.2x" />
       </InteractablesButton>
+
       <InteractablesButton
         class="sidebar-full-btn"
         data-cy="sidebar-friends"
@@ -27,6 +28,7 @@
         :text="$t('friends.friends')"
       >
         <users-icon size="1.2x" />
+
         <span v-if="incomingRequestsLength" class="label-container">
           <TypographyText
             size="xs"

--- a/layouts/desktop.vue
+++ b/layouts/desktop.vue
@@ -10,10 +10,12 @@
   >
     <Slimbar :servers="$mock.servers" />
     <Sidebar />
-    <UiDroppableWrapper v-if="displayDroppable" @handle-drop-prop="handleDrop">
+    <UiDroppableWrapper
+      :disabled="!displayDroppable"
+      @handle-drop-prop="handleDrop"
+    >
       <Nuxt ref="page" />
     </UiDroppableWrapper>
-    <Nuxt v-else />
     <UiGlobal />
     <!-- Sets the global css variable for the theme flair color -->
     <v-style>
@@ -56,9 +58,8 @@ export default Vue.extend({
       return iridium.settings.state.privacy.consentToScan
     },
     displayDroppable(): boolean {
-      return (
-        this.$route.path.includes('files') || this.$route.path.includes('chat')
-      )
+      const droppablePages = ['/files', '/chat']
+      return droppablePages.includes(this.$route.path)
     },
     ready(): boolean {
       return iridium.ready && !!iridium.profile.state?.did
@@ -72,6 +73,8 @@ export default Vue.extend({
      * @example v-on:drop="handleDrop"
      */
     handleDrop(e: DragEvent) {
+      if (!this.displayDroppable) return
+
       e.preventDefault()
       if (!e?.dataTransfer) {
         return


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- Application was re-rendering between 2 Nuxt components in desktop layout, resulting in unintended side-effects, like the one found in #5047. This PR allows a single Nuxt component to be kept inside of the DroppableWrapper component by disabling the DroppableWrapper instead of conditionally rendering it.  

### Which issue(s) this PR fixes 🔨
- Resolve #5047 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

