### PR TITLE
fix(files): reset search state on controls component destroy

### DIFF
--- a/components/views/files/controls/Controls.vue
+++ b/components/views/files/controls/Controls.vue
@@ -48,6 +48,9 @@ const Controls = Vue.extend({
       this.$store.commit('files/setSearchValue', value)
     },
   },
+  beforeDestroy() {
+    this.$store.commit('files/setSearchValue', '')
+  },
   methods: {
     /**
      * @method addFile


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- Resets file search state after page change

### Which issue(s) this PR fixes 🔨
- Resolve #5048 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

