### PR TITLE
fix(profile): remove whitespace from title passed to InfoButton

### DIFF
--- a/components/views/settings/pages/profile/Profile.html
+++ b/components/views/settings/pages/profile/Profile.html
@@ -200,17 +200,16 @@
                     :text="$t('pages.settings.profile.accounts.subtitle_url')"
                     class="accounts-subtitle-text"
                   />
-                  <!--
                   <UiInfoButton class="info-button">
-                    <template #title>
-                      {{ $t('pages.settings.profile.accounts.title') }}
-                    </template>
+                    <template #title
+                      >{{ $t('pages.settings.profile.accounts.title')
+                      }}</template
+                    >
                     <template #body
                       >{{ $t('pages.settings.profile.accounts.subtitle_url')
                       }}</template
                     >
                   </UiInfoButton>
-                  -->
                 </div>
 
                 <UiComingSoon


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- Whitespace in title slot was affecting layout. This PR removes that whitespace.

### Which issue(s) this PR fixes 🔨
- Resolve #5042 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

