### PR TITLE
feat(chat): add message loader in chat

### DIFF
--- a/components/views/chat/message/Message.html
+++ b/components/views/chat/message/Message.html
@@ -33,7 +33,7 @@
         v-if="message.body && !isEditing"
         :text="markdownToHtml"
         class="markdown"
-        :class="{ bigmoji: containsOnlyEmoji }"
+        :class="{ bigmoji: containsOnlyEmoji, pending: message.status === 'pending', failed: message.status === 'failed' }"
         data-cy="chat-message"
       />
       <MessageEdit
@@ -49,9 +49,14 @@
       >
         ({{$t('ui.edited')}})
       </span>
-      <MessageGlyph v-else-if="message.glyph" :glyph="message.glyph" />
+      <MessageGlyph
+        v-else-if="message.glyph"
+        :glyph="message.glyph"
+        :failed="message.status === 'failed'"
+        :class="{ pending: message.status === 'pending', failed: message.status === 'failed' }"
+      />
       <MessageActions
-        v-if="message.type !== 'call'"
+        v-if="actionsEnabled"
         :setReplyChatbarMessage="setReplyChatbarMessage"
         :emojiReaction="emojiReaction"
         :editMessage="editMessage"

--- a/components/views/chat/message/Message.less
+++ b/components/views/chat/message/Message.less
@@ -102,10 +102,14 @@
     .status {
       font-size: @font-size-xs;
       color: @gray;
-      &.editing {
-        vertical-align: bottom;
-        margin-top: 0;
-      }
+    }
+
+    .pending {
+      opacity: 0.5;
+    }
+
+    .failed {
+      color: @red;
     }
 
     .markdown {

--- a/components/views/chat/message/Message.vue
+++ b/components/views/chat/message/Message.vue
@@ -2,7 +2,6 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue'
 import { mapState, mapGetters } from 'vuex'
-import { ArchiveIcon } from 'satellite-lucide-icons'
 import { toHTML } from '~/libraries/ui/Markdown'
 import { ContextMenuItem, EmojiUsage } from '~/store/ui/types'
 import { RootState } from '~/types/store/store'
@@ -17,9 +16,6 @@ import { onlyHasEmoji } from '~/utilities/onlyHasEmoji'
 import { ChatItem } from '~/components/views/chat/conversation/Conversation.vue'
 
 export default Vue.extend({
-  components: {
-    ArchiveIcon,
-  },
   props: {
     item: {
       type: Object as PropType<ChatItem>,
@@ -124,6 +120,9 @@ export default Vue.extend({
         ]
       }
       return mainList
+    },
+    actionsEnabled(): boolean {
+      return this.message.type !== 'call' && !this.message.status
     },
   },
   methods: {

--- a/components/views/chat/message/glyph/Glyph.html
+++ b/components/views/chat/message/glyph/Glyph.html
@@ -1,7 +1,7 @@
 <div>
   <img
     class="glyph"
-    :src="src"
+    :src="!failed ? src : ''"
     data-cy="chat-glyph"
     alt=""
     @click="openModal"

--- a/components/views/chat/message/glyph/Glyph.vue
+++ b/components/views/chat/message/glyph/Glyph.vue
@@ -12,6 +12,11 @@ export default Vue.extend({
       type: Object as PropType<MessageGlyph>,
       required: true,
     },
+    failed: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
   computed: {
     ...mapState(['ui']),

--- a/libraries/Iridium/chat/ChatManager.ts
+++ b/libraries/Iridium/chat/ChatManager.ts
@@ -66,7 +66,7 @@ export default class ChatManager extends Emitter<ConversationMessage> {
   public ephemeral: {
     typing: { [key: Conversation['id']]: string[] | undefined }
     subscriptions: Conversation['id'][]
-    conversations: { [key: string]: ConversationMessage[] }
+    conversations: { [key: string]: ConversationMessage[] | undefined }
   } = {
     typing: {},
     subscriptions: [],

--- a/libraries/Iridium/chat/types.ts
+++ b/libraries/Iridium/chat/types.ts
@@ -45,6 +45,7 @@ export type ConversationMessage = {
   members?: string[]
   lastEditedAt?: number
   call?: MessageCall
+  status?: 'pending' | 'failed'
 }
 
 export type ConversationMessagePayload = Omit<


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- Add pending and failed status for messages in chat
- Message actions disabled while message are not confirmed
- Red color in case of text message failed, empty `src` for glyphs

### Which issue(s) this PR fixes 🔨
- Resolve #4999 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️
- Pending/failed msgs are kept in an ephemeral state, wont be there on refresh

### Additional comments 🎤
In the future we should add the `retry` action for failed msgs
