### PR TITLE
fix(slimbar): vertical padding

### DIFF
--- a/components/views/navigation/sidebar/list/item/Item.html
+++ b/components/views/navigation/sidebar/list/item/Item.html
@@ -21,11 +21,9 @@
     <div class="row">
       <TypographyText
         class="ellipsis"
-        color="light"
-        font="heading"
-        weight="bold"
+        as="h4"
+        :color="unreadCount ? 'light' : 'dark'"
         data-cy="sidebar-user-name"
-        :color="!!unreadCount ? 'light' : 'dark'"
       >
         {{ conversation.name }}
       </TypographyText>

--- a/components/views/navigation/slimbar/Slimbar.less
+++ b/components/views/navigation/slimbar/Slimbar.less
@@ -2,8 +2,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: @light-spacing;
-  overflow-y: scroll;
+  padding: 16px 0;
+  overflow-y: auto;
   transition: @transition-all;
   width: @slimbar-width;
   flex-shrink: 0;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- switch from 8 on top to 16 so it's inline with the rest of the app
- also simplify props for sidebarListItem name, I've been using h4 for username everywhere and overriding color as needed

### Which issue(s) this PR fixes 🔨
- Resolve #
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

