### PR TITLE
refactor(sidebar): simplify sidebar button styles

### DIFF
--- a/components/interactables/Tabs/Tabs.html
+++ b/components/interactables/Tabs/Tabs.html
@@ -5,9 +5,9 @@
     v-for="tab in tabs"
     @click="setRoute(tab.route)"
     :class="{active: route === tab.route}"
-    :data-badge="tab.badge || null"
   >
     {{tab.text}}
+    <TypographyTag v-if="tab.badge" small> {{tab.badge}} </TypographyTag>
   </button>
   <slot />
 </div>

--- a/components/interactables/Tabs/Tabs.less
+++ b/components/interactables/Tabs/Tabs.less
@@ -3,52 +3,30 @@
   gap: 32px;
   margin-right: auto;
   justify-content: flex-start;
-  width: 100%;
+  flex-grow: 1;
+  user-select: none;
 
   .tab {
-    cursor: pointer;
-    color: @text;
-    background: transparent;
-    padding-bottom: @normal-spacing;
-    margin-bottom: -1px;
-    user-select: none;
+    display: flex;
+    gap: 8px;
+    padding-bottom: 16px;
 
     &.active {
       color: @secondary-text;
       border-bottom: 2px solid @flair-color;
       padding-bottom: calc(@normal-spacing - 2px;);
     }
-
-    &[data-badge] {
-      position: relative;
-      display: flex;
-      align-items: center;
-      gap: 8px;
-
-      &::after {
-        content: attr(data-badge);
-        text-align: center;
-        font-size: 9pt;
-        background-color: @flair-color;
-        border-radius: 2px;
-        line-height: 0.5;
-        padding: 0.25rem 0.15rem;
-        min-width: 12px;
-        font-family: 'SpaceMono', monospace;
-        pointer-events: none;
-      }
-    }
   }
 }
 
 @media only screen and (max-width: @mobile-breakpoint) {
-  #tabs {
+  .tabs {
     gap: @normal-spacing;
   }
 }
 
 @media only screen and (max-width: @mobile-small-breakpoint) {
-  #tabs {
+  .tabs {
     gap: initial;
     justify-content: space-between;
   }

--- a/components/typography/Tag.vue
+++ b/components/typography/Tag.vue
@@ -28,7 +28,7 @@ export default Vue.extend({
   },
 })
 </script>
-<style lang="less">
+<style lang="less" scoped>
 .tag {
   user-select: none;
   background-color: @flair-color;
@@ -36,6 +36,7 @@ export default Vue.extend({
   box-shadow: @flair-glow;
   padding: 4px 8px;
   border-radius: @corner-rounding;
+  min-width: 18px;
 
   &.inverted {
     background: @semitransparent-dark-gradient;

--- a/components/typography/Text.vue
+++ b/components/typography/Text.vue
@@ -58,7 +58,8 @@ export default Vue.extend({
       if (this.as.match('h[1-6]|label')) {
         return 'light'
       }
-      return 'body'
+      // dont need to return 'body' due to global styles
+      return ''
     },
     getSize(): string {
       if (this.size) {

--- a/components/views/navigation/sidebar/Sidebar.html
+++ b/components/views/navigation/sidebar/Sidebar.html
@@ -10,56 +10,54 @@
       <InteractablesSidebarToggle />
     </div>
     <div class="sidebar-nav">
-      <InteractablesButton
-        class="sidebar-full-btn"
+      <button
+        class="sidebar-button"
+        :class="{selected: $route.path.includes('/files')}"
         data-cy="sidebar-files"
-        :color="$route.path.includes('/files') ? 'primary' : 'dark'"
-        @click="() => $router.push('/files')"
-        :text="$t('files.files')"
+        @click="$router.push('/files')"
       >
-        <folder-icon size="1.2x" />
-      </InteractablesButton>
+        <folder-icon size="20" />
+        <TypographyText size="sm"> {{$t('files.files')}} </TypographyText>
+      </button>
 
-      <InteractablesButton
-        class="sidebar-full-btn"
+      <button
+        class="sidebar-button"
+        :class="{selected: $route.path.includes('/friends')}"
         data-cy="sidebar-friends"
-        :color="$route.path.includes('/friends') ? 'primary' : 'dark'"
-        @click="() => $router.push('/friends')"
-        :text="$t('friends.friends')"
+        @click="$router.push('/friends')"
       >
-        <users-icon size="1.2x" />
+        <users-icon size="20" />
+        <TypographyText size="sm"> {{$t('friends.friends')}} </TypographyText>
 
-        <span v-if="incomingRequestsLength" class="label-container">
-          <TypographyText
-            size="xs"
-            class="label"
-            :class="{inverted : $route.path.includes('/friends')}"
-          >
-            {{incomingRequestsLength}}
-          </TypographyText>
-        </span>
-      </InteractablesButton>
+        <TypographyTag v-if="incomingRequestsLength" class="tag" small>
+          {{incomingRequestsLength}}
+        </TypographyTag>
+      </button>
     </div>
 
     <div v-show="$config.feedbackUrl" class="banner-wrapper">
       <UiEarlyAccessBanner />
     </div>
-
-    <div class="quick-toggle">
-      <button
-        title="$t('pages.chat.new_chat')"
-        @click="toggleModal"
-        v-tooltip.top="$t('pages.chat.new_chat')"
-      >
-        <plus-icon size="1.4x" />
-      </button>
+    <div class="toggle-container">
+      <TypographyText as="label" color="dark">
+        {{$t('messaging.messages')}}
+      </TypographyText>
+      <div class="quick-toggle">
+        <button
+          title="$t('pages.chat.new_chat')"
+          v-tooltip.top="$t('pages.chat.new_chat')"
+          @click="toggleModal"
+        >
+          <plus-icon size="20" />
+        </button>
+      </div>
       <SidebarQuick
         v-if="isQuickchatVisible"
         v-click-outside="toggleModal"
         @toggle="toggleModal"
       />
     </div>
-    <SidebarList class="conversation-list" :filter="filter" />
+    <SidebarList :filter="filter" />
   </div>
   <div class="controls">
     <SidebarControls />

--- a/components/views/navigation/sidebar/Sidebar.html
+++ b/components/views/navigation/sidebar/Sidebar.html
@@ -45,7 +45,7 @@
       <div class="quick-toggle">
         <button
           title="$t('pages.chat.new_chat')"
-          v-tooltip.top="$t('pages.chat.new_chat')"
+          v-tooltip.left="$t('pages.chat.new_chat')"
           @click="toggleModal"
         >
           <plus-icon size="20" />

--- a/components/views/navigation/sidebar/Sidebar.less
+++ b/components/views/navigation/sidebar/Sidebar.less
@@ -29,9 +29,29 @@
     .sidebar-nav {
       display: flex;
       flex-direction: column;
-      gap: @light-spacing;
-      position: relative;
-      padding: 0 16px 8px;
+      gap: 2px;
+
+      .sidebar-button {
+        display: flex;
+        align-items: center;
+        padding: 0 16px 0 22px;
+        gap: 12px;
+        height: 44px;
+        color: @dark;
+
+        &.selected {
+          color: @light;
+          .background-semitransparent-lighter();
+        }
+        &:hover:not(.selected) {
+          color: @body;
+          .background-semitransparent-lighter();
+        }
+
+        .tag {
+          margin-left: auto;
+        }
+      }
     }
 
     .banner-wrapper {
@@ -40,26 +60,16 @@
       &:extend(.round-corners);
     }
 
-    .quick-toggle {
-      align-self: flex-end;
+    .toggle-container {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin: 0 16px 0 20px;
+      user-select: none;
       position: relative;
-      margin-right: 16px;
-      button {
-        align-items: center;
-        justify-content: center;
-        height: 32px;
-        width: 32px;
-        border-radius: 50%;
-        background-color: @foreground-alt;
-      }
-    }
 
-    .users {
-      flex: 1;
-      position: relative;
-      overflow: hidden;
-      .inline-notification {
-        width: @sidebar-width - (@normal-spacing * 2);
+      .quick-toggle {
+        align-self: flex-end;
       }
     }
   }
@@ -74,33 +84,5 @@
     flex-shrink: 0;
     &:extend(.round-corners);
     background: @foreground-gradient;
-  }
-
-  .label-container {
-    display: flex;
-    align-items: center;
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    right: 0;
-    padding: 8px;
-
-    .label {
-      text-align: center;
-      font-size: @mini-text-size;
-      background-color: @flair-color;
-      border-radius: 2px;
-      line-height: 1;
-      padding: 0.25rem;
-      min-width: 18px;
-      font-family: @primary-font;
-      &:extend(.font-primary);
-      &:extend(.background-flair);
-      pointer-events: none;
-
-      &.inverted {
-        background: @foreground;
-      }
-    }
   }
 }

--- a/components/views/navigation/sidebar/list/item/Item.less
+++ b/components/views/navigation/sidebar/list/item/Item.less
@@ -16,11 +16,11 @@
   }
 
   &.selected {
-    &:extend(.background-semitransparent-lighter);
+    .background-semitransparent-lighter();
   }
 
   &:hover:not(.selected) {
-    &:extend(.background-semitransparent-light);
+    .background-semitransparent-light();
   }
 
   .user-info {

--- a/components/views/navigation/sidebar/quick/Quick.less
+++ b/components/views/navigation/sidebar/quick/Quick.less
@@ -1,7 +1,7 @@
 .quick-chat {
   position: absolute;
   width: 288px;
-  top: 0;
+  top: -12px;
   left: calc(100% + 12px);
   padding: 12px;
   display: flex;

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -88,7 +88,6 @@ export default {
   },
   messaging: {
     messages: 'Messages',
-    groups: 'Groups',
     pin: 'Password',
     reply: 'Reply',
     typing: '{user} is typing | {user} are typing',


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- switch sidebar top buttons to be more inline with figma
- switch tabs indicator to use Tag component for the friend request count indicator so everything is standardized

### Which issue(s) this PR fixes 🔨
- Resolve #5083 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️
- if everybody likes this, we could make a sidebarButton component to cut back copy/paste here


### Additional comments 🎤

