### PR TITLE
test(cypress): fixes for glyphs tests locators and commands

### DIFF
--- a/components/interactables/Close/Close.html
+++ b/components/interactables/Close/Close.html
@@ -1,3 +1,7 @@
-<div class="close-button" @click="$emit('click', $event)">
+<div
+  class="close-button"
+  data-cy="close-button"
+  @click="$emit('click', $event)"
+>
   <x-icon size="1.6x" />
 </div>

--- a/components/views/glyphs/Glyphs.html
+++ b/components/views/glyphs/Glyphs.html
@@ -6,6 +6,7 @@
   <GlyphsSample :glyphUrls="samplePackUrls" />
   <InteractablesButton
     class="button"
+    data-cy="glyphs-modal-view-btn"
     :text="$t('glyphs.view_pack')"
     @click="openMarketplace"
   >

--- a/components/views/glyphs/sample/Sample.html
+++ b/components/views/glyphs/sample/Sample.html
@@ -1,5 +1,5 @@
 <div class="sample">
-  <div class="img-container">
+  <div class="img-container" data-cy="glyphs-modal-container">
     <img
       v-for="src in glyphUrls"
       :src="getSrc(src)"

--- a/cypress/e2e/chat-features.js
+++ b/cypress/e2e/chat-features.js
@@ -6,8 +6,8 @@ let imageURL, expecedEditedMessage
 
 describe('Chat Features Tests', () => {
   before(() => {
-    // Save Localstorage Snapshots for next specs
-    cy.restoreLocalStorage('Chat User A', 'Chat User B')
+    // Restore Localstorage Snapshots for next specs
+    cy.restoreLocalStorage('Chat User A')
   })
   it('Chat - Send message on chat', { retries: 2 }, () => {
     // Import account
@@ -163,10 +163,5 @@ describe('Chat Features Tests', () => {
   //Test is skipped because Profile Screen cannot be accessed now from Main Chat Page
   it.skip('Chat - Assert note from user profile', () => {
     cy.addOrAssertProfileNote('This is a test note' + randomNumber, 'assert')
-  })
-
-  after(() => {
-    // Save Localstorage Snapshots for next specs
-    cy.saveLocalStorage('Chat User A', 'Chat User B')
   })
 })

--- a/cypress/e2e/chat-glyphs-validations.js
+++ b/cypress/e2e/chat-glyphs-validations.js
@@ -1,45 +1,35 @@
-import { dataRecovery } from '../fixtures/test-data-accounts.json'
-
-const faker = require('faker')
-const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
-const recoverySeed =
-  dataRecovery.accounts
-    .filter((item) => item.description === 'cypress')
-    .map((item) => item.recoverySeed) + '{enter}'
-
-describe.skip('Chat - Sending Glyphs Tests', () => {
-  // Skipping since import account is not working
+describe('Chat - Sending Glyphs Tests', () => {
+  before(() => {
+    // Restore Localstorage Snapshots for next specs
+    cy.restoreLocalStorage('Chat User A')
+  })
   it('Send a glyph on chat', { retries: 2 }, () => {
-    //Import account
-    cy.importAccount(randomPIN, recoverySeed)
+    // Import account from localstorage
+    cy.loginWithLocalStorage('Chat User A', '12345')
 
-    //Validate profile name displayed
-    cy.validateChatPageIsLoaded()
-
-    //Validate message is sent
-    cy.goToConversation('cypress friend')
+    // Go to a Conversation
+    cy.goToNewChat()
 
     //Send first glyph from Astrobunny pack
-    //cy.chatFeaturesSendGlyph()
+    cy.chatFeaturesSendGlyph()
 
-    //Assert glyph received
-    //cy.goToLastGlyphOnChat()
+    //Assert glyph sent
+    cy.goToLastGlyphOnChat()
   })
 
   it('Send a glyph after scrolling in the selection screen', () => {
     //Send fourth glyph from Genshin Impact 2 pack
     cy.chatFeaturesSendGlyph(6, 3)
 
-    //Assert glyph received
+    //Assert glyph sent
     cy.goToLastGlyphOnChat()
   })
 
   it('Send a glyph from the recents section', () => {
     //Send a glyph from recents section
-    cy.get('#glyph-toggle').click()
-    cy.get('#glyphs').should('be.visible')
+    cy.get('[data-cy=send-glyph]').click()
+    cy.get('[data-cy=glyphs-picker]').should('be.visible')
     cy.get('[data-cy=recent-glyph-item]').first().click()
-    cy.get('[data-cy=send-message]').click() //sending glyph message
 
     //Assert glyph received
     cy.goToLastGlyphOnChat()
@@ -51,8 +41,17 @@ describe.skip('Chat - Sending Glyphs Tests', () => {
   })
 
   it('Validate coming soon modal is displayed on glyph pack screen', () => {
-    cy.contains('View Glyph Pack').click()
+    cy.get('[data-cy=glyphs-modal-view-btn]').click()
     cy.get('[data-cy=modal-cta]').should('be.visible')
     cy.closeModal('[data-cy=modal-cta]')
+  })
+
+  //Skipped until bug #5069 - Modals extra close icon is fixed
+  it.skip('Validate glyph pack modal can be closed', () => {
+    cy.goToLastGlyphOnChat().should('be.visible').click()
+    cy.get('[data-cy=glyphs-modal]').should('be.visible')
+    cy.closeModal('[data-cy=glyphs-modal]').then(() => {
+      cy.get('[data-cy=glyphs-modal]').should('not.exist')
+    })
   })
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -421,8 +421,8 @@ Cypress.Commands.add('getReply', (messageReplied) => {
 Cypress.Commands.add(
   'chatFeaturesSendGlyph',
   (packIndex = 0, itemIndex = 0) => {
-    cy.get('#glyph-toggle').click()
-    cy.get('#glyphs').should('be.visible')
+    cy.get('[data-cy=send-glyph]').click()
+    cy.get('[data-cy=glyphs-picker]').should('be.visible')
     cy.get('[data-cy=glyph-pack]').eq(packIndex).as('glyph-pack')
     cy.get('@glyph-pack')
       .scrollIntoView()
@@ -430,7 +430,6 @@ Cypress.Commands.add(
       .eq(itemIndex)
       .scrollIntoView()
       .click()
-    cy.get('[data-cy=send-message]').click() //sending glyph message
   },
 )
 
@@ -652,14 +651,16 @@ Cypress.Commands.add('validateGlyphsModal', () => {
     .should('be.visible')
     .invoke('text')
     .then(($text) => {
-      expect($text).to.be.oneOf(['Astrobunny', 'Genshin Impact 2'])
+      expect($text).to.be.oneOf(['Genshin Impact 2', 'Astrobunny'])
     })
-  cy.get('.img-container').children().should('have.length', 3)
-  cy.contains('View Glyph Pack').should('be.visible')
+  cy.get('[data-cy=glyphs-modal-container]').children().should('have.length', 3)
+  cy.get('[data-cy=glyphs-modal-view-btn]')
+    .should('be.visible')
+    .and('contain', 'View Glyph Pack')
 })
 
 Cypress.Commands.add('closeModal', (locator) => {
-  cy.get(locator).find('.close-button').click()
+  cy.get(locator).siblings('[data-cy=close-button]').click()
   cy.get(locator).should('not.exist')
 })
 


### PR DESCRIPTION
### What this PR does 📖
- Added new data-cy attributes for glyphs and close button on modals
- Fixed glyphs cypress tests
- Small update to chat-features cypress test for localstorage snapshots used

### Which issue(s) this PR fixes 🔨
- Resolve #AP-2846

### Special notes for reviewers 🗒️
- One test is skipped due to the open bug "#5069 - Modals extra close icon is fixed". It will be unskipped once that this issue is fixed

### Additional comments 🎤
Cypress Tests Passed:
![image](https://user-images.githubusercontent.com/35935591/193354979-98f45d51-e8bc-4ec8-9a30-856db2ced5ae.png)

Chat Glyphs Tests Cypress Video:
https://user-images.githubusercontent.com/35935591/193355008-2255d814-e2bf-46b4-89ee-3eb3668a8d90.mp4
