### PR TITLE
test(cypress): fixes for chat images tests

### DIFF
--- a/components/views/chat/chatbar/upload/Upload.html
+++ b/components/views/chat/chatbar/upload/Upload.html
@@ -1,5 +1,6 @@
 <button
   @click="clickFileInput"
+  data-cy="chat-file-upload-btn-container"
   v-tooltip.top="$t('global.upload')"
   :disabled="disabled"
 >
@@ -7,6 +8,7 @@
   <input
     type="file"
     ref="upload"
+    data-cy="chat-file-upload"
     style="display: none"
     @click="resetFileInput"
     @change="handleFile"

--- a/components/views/chat/conversation/Conversation.html
+++ b/components/views/chat/conversation/Conversation.html
@@ -29,6 +29,7 @@
       </template>
       <div
         v-if="activeUploadChats.includes(conversation?.id)"
+        data-cy="file-loader-container"
         class="loader-container"
       >
         <file-icon size="24" class="icon" />

--- a/components/views/confirmation/Confirmation.vue
+++ b/components/views/confirmation/Confirmation.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="confirmation">
+  <div class="confirmation" data-cy="confirmation-modal">
     <div class="confirmation-main">
       <TypographyText color="flair" class="icon-container">
         <info-icon size="2x" />
@@ -10,7 +10,12 @@
             <info-icon size="1.5x" />
           </TypographyText>
 
-          <TypographyText as="h2" color="light" font="heading">
+          <TypographyText
+            data-cy="confirmation-modal-header"
+            as="h2"
+            color="light"
+            font="heading"
+          >
             <slot name="title" />
           </TypographyText>
         </div>
@@ -24,6 +29,7 @@
     <div class="buttons">
       <InteractablesButton
         :color="showConfirmButton ? 'light' : 'primary'"
+        data-cy="close-button"
         class="close-button"
         @click="close"
       >
@@ -33,6 +39,7 @@
       <InteractablesButton
         v-if="showConfirmButton"
         color="primary"
+        data-cy="confirm-button"
         class="confirm-button"
         @click="confirm"
       >

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -440,13 +440,15 @@ Cypress.Commands.add('goToLastGlyphOnChat', () => {
 // Chat - Images Commands
 
 Cypress.Commands.add('chatFeaturesSendImage', (imagePath, filename) => {
-  cy.get('#quick-upload').selectFile(imagePath, {
+  cy.get('[data-cy=chat-file-upload]').selectFile(imagePath, {
     force: true,
   })
   cy.get('[data-cy=file-item]', { timeout: 60000 }).should('exist')
   cy.get('[data-cy=file-item-filename]').should('contain', filename)
   cy.get('[data-cy=send-message]').click() //sending image message
-  cy.get('[data-cy=file-item]', { timeout: 120000 }).should('not.exist')
+  cy.get('[data-cy=file-loader-container]', { timeout: 60000 }).should(
+    'not.exist',
+  )
 })
 
 Cypress.Commands.add('goToLastImageOnChat', (waitTime = 30000) => {
@@ -486,7 +488,10 @@ Cypress.Commands.add(
 
 Cypress.Commands.add('selectContextMenuOption', (locator, optionText) => {
   cy.get(locator).scrollIntoView().rightclick()
-  cy.contains(optionText).click()
+  cy.get('[data-cy=context-menu]')
+    .find('[data-cy=context-menu-option]')
+    .contains(optionText)
+    .click()
 })
 
 Cypress.Commands.add(
@@ -559,7 +564,7 @@ Cypress.Commands.add('goToNewChat', () => {
   cy.get('[data-cy=friend-confirm-button]').click()
 
   //Wait until chat page is loaded
-  cy.get('#conversation-container', { timeout: 30000 }).should('be.visible')
+  cy.get('#conversation-container', { timeout: 30000 }).should('exist')
 })
 
 Cypress.Commands.add('workaroundChatLoad', (user) => {


### PR DESCRIPTION
### What this PR does 📖
- Fixes for chat images cypress tests
- Added new data-cy attributes used in this spec
- Small improvements to cypress commands used on chat images tests, mostly adding the new data-cy locators

### Which issue(s) this PR fixes 🔨
- Resolve #AP-2846

### Special notes for reviewers 🗒️
- Sending a gif with more than 5mb makes the fail test since apparently the functionality just works with smaller images. I am having this test skipped for now, to do more research on this

### Additional comments 🎤
Cypress Video:
https://user-images.githubusercontent.com/35935591/193694227-2bacdec9-bea4-4a17-8bef-e00e48f0792d.mp4

All specs passed:
![image](https://user-images.githubusercontent.com/35935591/193694199-98a58a9d-ef87-4103-82e9-6310033ac3f7.png)
