### PR TITLE
fix(input): improve a11y around input component

### DIFF
--- a/components/interactables/Input/Input.html
+++ b/components/interactables/Input/Input.html
@@ -2,7 +2,10 @@
   <TypographyText v-if="label" as="label" uppercase>
     {{ label }}
   </TypographyText>
-  <div class="input-outer" :class="`font-size-${derivedSize}`">
+  <div
+    class="input-outer"
+    :class="[`font-size-${derivedSize}`, {'outline': isFocused}]"
+  >
     <div
       class="input-inner"
       :class="[
@@ -27,6 +30,9 @@
         data-cy="input-group"
         @keydown.enter="handleSubmit"
         @input="handleInput"
+        @mousedown="setMousedown"
+        @focus="handleFocus"
+        @blur="isFocused = false"
       />
 
       <div v-if="enabledAppends.length" class="append input-options">

--- a/components/interactables/Input/Input.html
+++ b/components/interactables/Input/Input.html
@@ -30,7 +30,6 @@
         data-cy="input-group"
         @keydown.enter="handleSubmit"
         @input="handleInput"
-        @mousedown="setMousedown"
         @focus="handleFocus"
         @blur="isFocused = false"
       />

--- a/components/interactables/Input/Input.less
+++ b/components/interactables/Input/Input.less
@@ -52,6 +52,7 @@
         min-width: 0;
         background: none;
         border: 0;
+        outline: none;
         .ellipsis();
 
         &.is-danger {

--- a/components/interactables/Input/Input.vue
+++ b/components/interactables/Input/Input.vue
@@ -137,9 +137,8 @@ export default Vue.extend({
   mounted() {
     if (this.autofocus) {
       const input = this.$refs.input as HTMLInputElement
-      // set to avoid a11y outline which is set via keyboard focus only
+      // if mobile, delay focus to avoid clash with swiper animation
       if (this.$device.isMobile) {
-        // delay focus to avoid clash with swiper animation
         setTimeout(() => {
           input.focus()
         }, MOBILE_FOCUS_DELAY)

--- a/components/interactables/Input/Input.vue
+++ b/components/interactables/Input/Input.vue
@@ -100,11 +100,13 @@ export default Vue.extend({
   },
   data() {
     return {
-      Appends,
       showPassword: false,
+      isMousedown: false,
+      isFocused: false,
     }
   },
   computed: {
+    Appends: () => Appends,
     isEmpty(): boolean {
       return !this.text.length
     },
@@ -133,17 +135,23 @@ export default Vue.extend({
     },
   },
   mounted() {
+    window.addEventListener('blur', this.setMousedown)
     if (this.autofocus) {
-      const inputRef = this.$refs.input as HTMLInputElement
+      const input = this.$refs.input as HTMLInputElement
+      // set to avoid a11y outline which is set via keyboard focus only
+      this.setMousedown()
       if (this.$device.isMobile) {
         // delay focus to avoid clash with swiper animation
         setTimeout(() => {
-          inputRef.focus()
+          input.focus()
         }, MOBILE_FOCUS_DELAY)
       } else {
-        this.$nextTick(() => inputRef.focus())
+        this.$nextTick(() => input.focus())
       }
     }
+  },
+  beforeDestroy() {
+    window.removeEventListener('blur', this.setMousedown)
   },
   methods: {
     handleSubmit(event: InputEvent) {
@@ -164,6 +172,15 @@ export default Vue.extend({
     },
     toggleShowPassword() {
       this.showPassword = !this.showPassword
+    },
+    handleFocus() {
+      if (!this.isMousedown) {
+        this.isFocused = true
+      }
+      this.isMousedown = false
+    },
+    setMousedown() {
+      this.isMousedown = true
     },
   },
 })

--- a/components/interactables/Input/Input.vue
+++ b/components/interactables/Input/Input.vue
@@ -3,6 +3,7 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue'
 import { DeleteIcon, EyeIcon, EyeOffIcon } from 'satellite-lucide-icons'
+import whatInput from 'what-input'
 import { InputType, InputColor } from './types'
 import { Size } from '~/types/typography'
 
@@ -101,7 +102,6 @@ export default Vue.extend({
   data() {
     return {
       showPassword: false,
-      isMousedown: false,
       isFocused: false,
     }
   },
@@ -135,11 +135,9 @@ export default Vue.extend({
     },
   },
   mounted() {
-    window.addEventListener('blur', this.setMousedown)
     if (this.autofocus) {
       const input = this.$refs.input as HTMLInputElement
       // set to avoid a11y outline which is set via keyboard focus only
-      this.setMousedown()
       if (this.$device.isMobile) {
         // delay focus to avoid clash with swiper animation
         setTimeout(() => {
@@ -150,9 +148,7 @@ export default Vue.extend({
       }
     }
   },
-  beforeDestroy() {
-    window.removeEventListener('blur', this.setMousedown)
-  },
+
   methods: {
     handleSubmit(event: InputEvent) {
       if (this.disabled || this.loading || this.invalid) {
@@ -174,13 +170,9 @@ export default Vue.extend({
       this.showPassword = !this.showPassword
     },
     handleFocus() {
-      if (!this.isMousedown) {
+      if (whatInput.ask() === 'keyboard') {
         this.isFocused = true
       }
-      this.isMousedown = false
-    },
-    setMousedown() {
-      this.isMousedown = true
     },
   },
 })

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "vue-slider-component": "^3.2.15",
     "vue-virtual-scroll-list": "^2.3.3",
     "vuejs-paginate": "^2.1.0",
-    "vuex-persist": "^3.1.3"
+    "vuex-persist": "^3.1.3",
+    "what-input": "^5.2.12"
   },
   "devDependencies": {
     "@babel/core": "^7.17.5",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- move accessibility outline to outer input border (wraps button and appends too, similar to chatbar)
- prevent outline on autofocus inputs

### Which issue(s) this PR fixes 🔨
- Resolve #5102 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

