### PR TITLE
fix(chatbar): placeholder visibility for ime langages

### DIFF
--- a/components/interactables/Editable/Editable.vue
+++ b/components/interactables/Editable/Editable.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="editable-container">
-    <div v-if="value.length === 0" class="placeholder">{{ placeholder }}</div>
+    <div v-if="value.length === 0 && !isComposing" class="placeholder">
+      {{ placeholder }}
+    </div>
     <div
       ref="editable"
       :contenteditable="enabled"
@@ -73,7 +75,7 @@ const Editable = Vue.extend({
     return {
       currentPosition: 0,
       currentRange: null as Range | null,
-      onComposition: false,
+      isComposing: false,
     }
   },
   watch: {
@@ -182,7 +184,7 @@ const Editable = Vue.extend({
      * @param {KeyboardEvent} e The keydown event
      */
     handleInputKeydown(e: KeyboardEvent) {
-      if (this.onComposition) return
+      if (this.isComposing) return
 
       switch (e.key) {
         case KeybindingEnum.BACKSPACE:
@@ -231,10 +233,10 @@ const Editable = Vue.extend({
      */
     handleCompositionChange(e: InputEvent) {
       if (e.type === 'compositionend') {
-        this.onComposition = false
+        this.isComposing = false
         this.onInput(e)
-      } else if (!this.onComposition) {
-        this.onComposition = true
+      } else if (!this.isComposing) {
+        this.isComposing = true
       }
     },
     /**
@@ -243,7 +245,7 @@ const Editable = Vue.extend({
      * @param {KeyboardEvent} e The input event
      */
     onInput(e: InputEvent) {
-      if (this.onComposition) return
+      if (this.isComposing) return
 
       if (e.inputType === 'historyUndo') {
         this.undo()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- Hides the placeholder when using an IME:

**Before:**
<img width="317" alt="Screen Shot 2022-10-04 at 2 42 37 pm" src="https://user-images.githubusercontent.com/5356544/193730352-9f56a07a-208a-43a9-b92d-badac5911de4.png">
**After:**
<img width="481" alt="Screen Shot 2022-10-04 at 2 43 04 pm" src="https://user-images.githubusercontent.com/5356544/193730363-e4b0ef0c-3142-4424-9e72-5e02b9b56e40.png">

### Which issue(s) this PR fixes 🔨
- Resolve #5136 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

