### PR TITLE
refactor(notifications): construct notification body inside of global…

### DIFF
--- a/libraries/Iridium/friends/FriendsManager.ts
+++ b/libraries/Iridium/friends/FriendsManager.ts
@@ -3,11 +3,9 @@ import {
   IridiumPeerIdentifier,
   Emitter,
   didUtils,
-  encoding,
   IridiumPubsubMessage,
 } from '@satellite-im/iridium'
 import type {
-  IridiumMessage,
   IridiumGetOptions,
   IridiumSetOptions,
 } from '@satellite-im/iridium/src/types'
@@ -17,8 +15,7 @@ import { User } from '../users/types'
 import { FriendRequest, FriendRequestStatus, FriendsError } from './types'
 import logger from '~/plugins/local/logger'
 import {
-  Notification,
-  NotificationClickEvent,
+  NotificationBase,
   NotificationType,
 } from '~/libraries/Iridium/notifications/types'
 
@@ -352,32 +349,21 @@ export default class FriendsManager extends Emitter<IridiumFriendPubsub> {
 
       await this.send(payload)
     } else {
-      // Notify the recipient
-      const buildNotification: Exclude<Notification, 'id'> = {
-        fromName: user.name,
-        at: request.at,
-        title: 'New Request',
-        description: `New ${NotificationType.FRIEND_REQUEST} From ${user.name}`,
-        image: user.photoHash?.toString() || '',
-        type: NotificationType.FRIEND_REQUEST,
-        seen: false,
-        onNotificationClick: () => {
-          const clickEventData: NotificationClickEvent = {
-            from: user.name,
-            topic: user.did,
-            payload: {
-              type: NotificationType.FRIEND_REQUEST,
-            },
-          }
-
-          // Emit data to the app to handle the click event
-          iridium.notifications.emit('notification/clicked', {
-            ...clickEventData,
-          })
-        },
-      }
-      iridium.notifications.sendNotification(buildNotification)
+      this.sendNotification(user)
     }
+  }
+
+  private sendNotification(user: User) {
+    iridium.notifications.emit('notification/create', {
+      type: NotificationType.FRIEND_REQUEST,
+      title: 'notifications.friend_request.title',
+      description: 'notifications.friend_request.body',
+      descriptionValues: {
+        name: user.name,
+      },
+      fromName: user.name,
+      image: user.photoHash,
+    } as NotificationBase)
   }
 
   /**

--- a/libraries/Iridium/notifications/types.ts
+++ b/libraries/Iridium/notifications/types.ts
@@ -1,3 +1,6 @@
+import { type } from 'os'
+import { User } from '~/libraries/Iridium/users/types'
+
 export const NotificationsError = {
   NOTIFICATION_NOT_SENT: 'error.notifications.notifications_not_sent',
 }
@@ -30,6 +33,19 @@ export type Notification = {
   fromAddress?: string
   image?: string
   onNotificationClick?: () => void
+}
+
+export type NotificationBase = {
+  type: NotificationType
+  title: string
+  description: string
+  fromName: string
+  at?: number
+  image?: string
+  titleValues?: object
+  descriptionValues?: object
+  onNotificationClick?: void
+  notificationClickParams?: object
 }
 
 export type NotificationClickEvent = {

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -46,8 +46,6 @@ export default {
     more: 'More',
     live: 'Live {time}',
     edited: 'edited',
-    online: 'All users are offline | {name} is online | {name} are online',
-    offline: '{name} is not connected',
     background_call: 'Current call',
     no_results: 'No results found',
     early_access: 'Early Access',
@@ -906,5 +904,16 @@ export default {
     copy_img: 'Copy Image',
     save_img: 'Save Image',
     copy_link: 'Copy Link',
+  },
+  notifications: {
+    friend_request: {
+      title: 'Friend Request',
+      body: '{name} sent you a friend request!',
+    },
+    new_message: {
+      title: 'New Message',
+      group_title: '{name} ({server})',
+      body: 'You have a new message from {name}!',
+    },
   },
 }


### PR DESCRIPTION
… component

<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- Keeps notification logic centralized
- Previous structure didn't allow for notification data to include data stored in app, such as app state or locales

### Which issue(s) this PR fixes 🔨
- Resolve #5142 
- Resolve #5086
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

