### PR TITLE
fix(notifications): take user to chat on chat notification click

### DIFF
--- a/libraries/Iridium/chat/ChatManager.ts
+++ b/libraries/Iridium/chat/ChatManager.ts
@@ -345,7 +345,9 @@ export default class ChatManager extends Emitter<ConversationMessage> {
     const isGroup = conversation.type === 'group'
 
     iridium.notifications.emit('notification/create', {
-      type: NotificationType.FRIEND_REQUEST,
+      type: isGroup
+        ? NotificationType.GROUP_MESSAGE
+        : NotificationType.DIRECT_MESSAGE,
       title: isGroup
         ? 'notifications.new_message.group_title'
         : sender?.name || 'notifications.new_message.title',
@@ -355,6 +357,9 @@ export default class ChatManager extends Emitter<ConversationMessage> {
       description,
       fromName: sender?.name || '',
       image: fromDID,
+      notificationClickParams: {
+        conversationId: conversation.id,
+      },
     } as NotificationBase)
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- Was previously taking users to friend request page on chat notification clicks. This change takes them to the appropriate chat instead.

### Which issue(s) this PR fixes 🔨
- Resolve #5146 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

