### PR TITLE
refactor(files): use UiModal with files fullscreen preview

### DIFF
--- a/components/ui/Global/Global.html
+++ b/components/ui/Global/Global.html
@@ -2,6 +2,9 @@
   <UiSvgDefs class="hidden" />
   <InteractablesContextMenu v-if="ui.contextMenuStatus" />
   <transition name="modal">
+    <UiModal v-if="incomingCall" :showCloseButton="false">
+      <MediaIncomingCall />
+    </UiModal>
     <UiModal
       v-if="ui.modals.consentScanConfirmation"
       @close="() => toggleModal(ModalWindows.CONSENT_SCAN_CONFIRMATION)"
@@ -41,9 +44,6 @@
         :set-close-timeout="5000"
       />
     </UiModal> -->
-    <UiModal v-if="incomingCall" :showCloseButton="false">
-      <MediaIncomingCall />
-    </UiModal>
     <UiModal
       v-if="ui.modals.marketplace"
       @close="toggleModal(ModalWindows.MARKETPLACE)"

--- a/components/ui/Global/Global.html
+++ b/components/ui/Global/Global.html
@@ -73,7 +73,7 @@
       v-if="ui.modals.renameFile"
       @close="toggleModal(ModalWindows.RENAME_FILE)"
     >
-      <FilesRename @close="toggleModal(ModalWindows.RENAME_FILE)" />
+      <FilesRename />
     </UiModal>
     <UiModal
       v-if="ui.modals.changelog"
@@ -82,7 +82,14 @@
       <UiUpdateModal />
     </UiModal>
     <UiChatImageOverlay v-if="ui.chatImageOverlay" />
-    <FilesView v-if="files.preview" />
+    <UiModal
+      v-if="files.preview"
+      :showCloseButton="false"
+      fullscreen
+      @close="$store.commit('files/setPreview', undefined)"
+    >
+      <FilesView @close="$store.commit('files/setPreview', undefined)" />
+    </UiModal>
     <UiModal
       v-if="isNewAccount"
       @close="$store.commit('accounts/setNewAccount', false)"

--- a/components/ui/Modal/Modal.html
+++ b/components/ui/Modal/Modal.html
@@ -1,4 +1,4 @@
-<div class="modal-container">
+<div class="modal-container" :class="{fullscreen}">
   <div
     class="modal"
     ref="modal"

--- a/components/ui/Modal/Modal.less
+++ b/components/ui/Modal/Modal.less
@@ -1,18 +1,29 @@
 .modal-container {
   display: flex;
-  align-items: center;
-  justify-content: center;
   position: fixed;
   inset: 0;
   backdrop-filter: @light-blur brightness(75%);
-  &:extend(.sixth-layer);
+
+  &.fullscreen {
+    height: 100%;
+    width: 100%;
+
+    .modal {
+      flex-grow: 1;
+    }
+  }
+
+  &:not(.fullscreen) {
+    align-items: center;
+    justify-content: center;
+  }
 
   .modal {
     transform-origin: 50% 200%;
     position: relative;
     box-shadow: @ui-shadow-large;
     border-radius: @corner-rounding;
-    &:extend(.background-semitransparent-dark);
+    .background-semitransparent-dark();
   }
 }
 
@@ -37,28 +48,12 @@
 
 @media only screen and (max-width: @mobile-breakpoint) {
   .modal {
-    height: @full;
-    width: @full;
+    height: 100%;
+    width: 100%;
 
     &.small {
       height: auto;
       top: inherit;
     }
-  }
-  .modal-card {
-    height: @full;
-    &:extend(.full-width);
-    margin: 0px;
-    max-height: @full;
-  }
-
-  .mobile-modal-background {
-    width: 100%;
-    height: 100%;
-    position: absolute;
-
-    &:extend(.first-layer);
-    background: transparent;
-    backdrop-filter: @light-blur;
   }
 }

--- a/components/ui/Modal/Modal.vue
+++ b/components/ui/Modal/Modal.vue
@@ -19,6 +19,10 @@ export default Vue.extend({
       type: Boolean,
       default: true,
     },
+    fullscreen: {
+      type: Boolean,
+      default: false,
+    },
   },
   data: () => ({
     trap: null as FocusTrap | null,

--- a/components/views/files/view/View.html
+++ b/components/views/files/view/View.html
@@ -1,41 +1,27 @@
-<div id="view-file" @keydown.esc="close" tabindex="1" ref="modal">
+<div class="fullscreen-file">
   <div class="file-nav">
-    <div class="file-info ellipsis">
-      <TypographyText as="h2" class="ellipsis">
+    <div class="file-info">
+      <TypographyText class="ellipsis" as="h2">
         {{ file.name }}
       </TypographyText>
-      <TypographyText> {{ file.type }} </TypographyText>
-      <TypographyText> {{ $filesize(file.size) }} </TypographyText>
-      <TypographyText> {{ $dayjs(file.modified).fromNow() }} </TypographyText>
+      <TypographyText class="ellipsis" color="dark" size="sm">
+        {{ file.type }}
+      </TypographyText>
+      <TypographyText color="dark" size="sm">
+        {{ $filesize(file.size) }}
+      </TypographyText>
     </div>
     <div class="controls">
-      <UiLoadersSpinner
-        v-if="isDownloading"
-        class="control disabled"
-        spinning
-      />
+      <UiLoadersSpinner v-if="isDownloading" class="disabled" spinning />
       <button
         v-else
-        @click="download"
         v-tooltip.bottom="$t('controls.download')"
-        class="control"
+        @click="download"
       >
-        <download-icon size="1x" />
+        <download-icon />
       </button>
-      <!-- 
-      <a
-        v-tooltip.bottom="$t('controls.share_link')"
-        class="control"
-        @click="share"
-      >
-        <link-icon size="1x" />
-      </a> -->
-      <button
-        class="control control--close"
-        v-tooltip.bottom="$t('ui.close')"
-        @click="close"
-      >
-        <x-icon size="1x" />
+      <button v-tooltip.bottom="$t('ui.close')" @click="$emit('close')">
+        <x-icon />
       </button>
     </div>
   </div>
@@ -46,16 +32,7 @@
   >
     <img :src="thumbnail" />
   </ui-image-container>
-  <div v-else class="no-preview">
-    <UiLoadersSpinner v-if="isDownloading" class="file-icon" spinning />
-    <button v-else @click="download" v-tooltip.top="$t('controls.download')">
-      <download-icon size="1x" class="file-icon" />
-    </button>
-    <TypographyText as="h1"> {{ file.name }} </TypographyText>
-    <TypographyText>{{ file.type }}</TypographyText>
-    <TypographyText>{{ $filesize(file.size) }}</TypographyText>
-    <TypographyText>{{ $dayjs(file.modified).fromNow() }}</TypographyText>
-  </div>
+  <file-icon v-else class="no-preview" size="68" />
   <a
     v-show="false"
     ref="download"

--- a/components/views/files/view/View.less
+++ b/components/views/files/view/View.less
@@ -1,52 +1,34 @@
-#view-file {
+.fullscreen-file {
   display: flex;
-  position: absolute;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.75);
-  &:extend(.first-layer);
-  padding: 16px;
+  justify-content: center;
+  height: 100%;
+  --padding: 16px;
+  padding: var(--padding);
 
   .file-nav {
-    width: calc(100% - 32px); //to account for padding
     display: flex;
-    position: absolute;
     gap: 16px;
+    position: absolute;
+    width: calc(100% - var(--padding) * 2);
 
     .file-info {
-      flex: 1;
+      flex-grow: 1;
+      overflow: hidden;
     }
 
     .controls {
       display: flex;
       height: fit-content;
-      margin-left: auto;
-      gap: @normal-spacing;
+      gap: 16px;
       flex-shrink: 0;
-
-      .control {
-        display: flex;
-        font-size: @icon-size;
-        &:extend(.font-secondary);
-        &.disabled {
-          cursor: not-allowed;
-        }
-        &--close {
-          &:before {
-            left: auto;
-            right: 0;
-            transform: translate(0, 100%);
-          }
-        }
-      }
     }
   }
 
   .image-container {
-    display: flex;
-    margin: auto;
     max-width: 80vw;
     max-height: 60vh;
-    &:extend(.round-corners);
+    align-self: center;
+    .round-corners();
 
     img {
       height: 100%;
@@ -55,19 +37,7 @@
   }
 
   .no-preview {
-    display: flex;
-    flex-direction: column;
-    text-align: center;
-    margin: auto;
-    .subtitle {
-      display: block;
-      text-align: center;
-      margin-bottom: 0;
-    }
-    .file-icon {
-      font-size: 50pt;
-      margin: auto;
-      margin-bottom: @normal-spacing;
-    }
+    align-self: center;
+    color: @flair-color;
   }
 }

--- a/components/views/files/view/View.vue
+++ b/components/views/files/view/View.vue
@@ -50,8 +50,6 @@ export default Vue.extend({
     },
   },
   async mounted() {
-    if (this.$refs.modal) (this.$refs.modal as HTMLElement).focus()
-
     if (this.file?.thumbnail) {
       this.thumbnail = URL.createObjectURL(
         await iridium.files.fetchThumbnail(this.file.thumbnail, this.file.type),
@@ -85,9 +83,6 @@ export default Vue.extend({
     },
     share() {
       this.$toast.show(this.$t('todo - share') as string)
-    },
-    close() {
-      this.$store.commit('files/setPreview', undefined)
     },
   },
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- wrap FilesView with UiModal to use better background styles, animation, modal focus trap, and esc event listener
- remove duplicate markup and download button for files with no preview
- unrelated - move incoming call to the first rendered modal. It would get hidden by settings/others. Maybe these should all be v-else-if instead

### Which issue(s) this PR fixes 🔨
- Resolve #5149 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

