### PR TITLE
chore(ci): generate android apk

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -7,12 +7,60 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install modules
-        run: yarn install
-      - name: Run tests
+      - name: Checkout 🔖
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js 🔨
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Git Clone Iridium Repo 🗳️
+        run: |
+          cd ..
+          git clone https://github.com/Satellite-im/iridium.git
+      - name: Change permissions on scripts and run Linkscript 🔨
+        run: |
+          chmod +x ./linkscript.sh
+          chmod +x ./cypress/scripts/watch-script.sh
+          chmod +x ./cypress/scripts/sync-node-script.sh
+          ./linkscript.sh
+      - name: Install Yarn Dependencies on Core 🔨
+        run: yarn
+
+      - name: Create env file - Iridium 🔨
+        run: |
+          cd ..
+          cd iridium
+          echo HOSTNAME=${{ secrets.HOSTNAME }} >> .env
+          echo CERTBOT_EMAIL="support@satellite.im" >> .env
+          echo SYNC_NODE_SEED="sync node a seed" >> .env
+          echo SYNC_NODE_ADDR=${{ secrets.SYNC_NODE_ADDR }} >> .env
+          echo SERVERDATAVOLUME=${{ secrets.SERVERDATAVOLUME }} >> .env
+          echo NODE_ENV="development" >> .env
+          echo SAFER_URL=${{ secrets.SAFER_URL }} >> .env
+          cat .env
+      - name: Create env file - Core 🔨
+        working-directory: ./
+        run: |
+          touch .env
+          echo ENVIRONMENT="dev" >> .env
+          echo NUXT_ENV_IRIDIUM_SYNC_NODES=${{ secrets.NUXT_ENV_IRIDIUM_SYNC_NODES }} >> .env
+          echo NUXT_ENV_IRIDIUM_APIS=${{ secrets.NUXT_ENV_IRIDIUM_APIS }} >> .env
+          echo NUXT_ENV_IRIDIUM_GATEWAYS=${{ secrets.NUXT_ENV_IRIDIUM_GATEWAYS }} >> .env
+          cat .env
+      - name: Install PNPM dependencies on Iridium 🔨
+        working-directory: ../iridium
+        run: pnpm i
+
+      - name: Yarn Link Iridium Repo 🔨
+        working-directory: ./
+        run: yarn link "@satellite-im/iridium"
+      
+      - name: Generate Android APK 🔨
         run: yarn android-generate
-      - uses: actions/upload-artifact@v2
+      
+      - uses: actions/upload-artifact@v2	
         with:
           name: debug-apk
           path: android/app/build/outputs/apk/debug/android-debug.apk

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -15,47 +15,16 @@ jobs:
         with:
           node-version: 16
 
-      - name: Git Clone Iridium Repo 🗳️
-        run: |
-          cd ..
-          git clone https://github.com/Satellite-im/iridium.git
-      - name: Change permissions on scripts and run Linkscript 🔨
+      - name: Change permissions on scripts 🔨
         run: |
           chmod +x ./linkscript.sh
           chmod +x ./cypress/scripts/watch-script.sh
           chmod +x ./cypress/scripts/sync-node-script.sh
-          ./linkscript.sh
-      - name: Install Yarn Dependencies on Core 🔨
-        run: yarn
 
-      - name: Create env file - Iridium 🔨
-        run: |
-          cd ..
-          cd iridium
-          echo HOSTNAME=${{ secrets.HOSTNAME }} >> .env
-          echo CERTBOT_EMAIL="support@satellite.im" >> .env
-          echo SYNC_NODE_SEED="sync node a seed" >> .env
-          echo SYNC_NODE_ADDR=${{ secrets.SYNC_NODE_ADDR }} >> .env
-          echo SERVERDATAVOLUME=${{ secrets.SERVERDATAVOLUME }} >> .env
-          echo NODE_ENV="development" >> .env
-          echo SAFER_URL=${{ secrets.SAFER_URL }} >> .env
-          cat .env
-      - name: Create env file - Core 🔨
-        working-directory: ./
-        run: |
-          touch .env
-          echo ENVIRONMENT="dev" >> .env
-          echo NUXT_ENV_IRIDIUM_SYNC_NODES=${{ secrets.NUXT_ENV_IRIDIUM_SYNC_NODES }} >> .env
-          echo NUXT_ENV_IRIDIUM_APIS=${{ secrets.NUXT_ENV_IRIDIUM_APIS }} >> .env
-          echo NUXT_ENV_IRIDIUM_GATEWAYS=${{ secrets.NUXT_ENV_IRIDIUM_GATEWAYS }} >> .env
-          cat .env
-      - name: Install PNPM dependencies on Iridium 🔨
-        working-directory: ../iridium
-        run: pnpm i
-
-      - name: Yarn Link Iridium Repo 🔨
-        working-directory: ./
-        run: yarn link "@satellite-im/iridium"
+      - name: Build Core 🔨
+        run: yarn && ./linkscript.sh
+      - name: Export env 🔨
+        run: echo "ENVIRONMENT=dev" >> $GITHUB_ENV
       - name: Generate Android APK 🔨
         run: yarn android-generate
 

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -56,7 +56,6 @@ jobs:
       - name: Yarn Link Iridium Repo 🔨
         working-directory: ./
         run: yarn link "@satellite-im/iridium"
-      
       - name: Generate Android APK 🔨
         run: yarn android-generate
 

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -1,0 +1,18 @@
+name: Generate Android APK
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install modules
+        run: yarn install
+      - name: Run tests
+        run: yarn android-generate
+      - uses: actions/upload-artifact@v2
+        with:
+          name: debug-apk
+          path: android/app/build/outputs/apk/debug/android-debug.apk

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -62,4 +62,4 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: debug-apk
-          path: android/app/build/outputs/apk/debug/android-debug.apk
+          path: android/app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -59,8 +59,8 @@ jobs:
       
       - name: Generate Android APK 🔨
         run: yarn android-generate
-      
-      - uses: actions/upload-artifact@v2	
+
+      - uses: actions/upload-artifact@v2
         with:
           name: debug-apk
           path: android/app/build/outputs/apk/debug/android-debug.apk

--- a/.github/workflows/comment-PR-apk.yml
+++ b/.github/workflows/comment-PR-apk.yml
@@ -1,0 +1,54 @@
+name: Comment on pull request with APK file
+on:
+  workflow_run:
+    workflows: ['Generate Android APK']
+    types: [completed]
+jobs:
+  pr_comment:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v5
+        with:
+          # This snippet is public-domain, taken from
+          # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
+          script: |
+            async function upsertComment(owner, repo, issue_number, purpose, body) {
+              const {data: comments} = await github.rest.issues.listComments(
+                {owner, repo, issue_number});
+              const marker = `<!-- bot: ${purpose} -->`;
+              body = marker + "\n" + body;
+              const existing = comments.filter((c) => c.body.includes(marker));
+              if (existing.length > 0) {
+                const last = existing[existing.length - 1];
+                core.info(`Updating comment ${last.id}`);
+                await github.rest.issues.updateComment({
+                  owner, repo,
+                  body,
+                  comment_id: last.id,
+                });
+              } else {
+                core.info(`Creating a comment in issue / PR #${issue_number}`);
+                await github.rest.issues.createComment({issue_number, body, owner, repo});
+              }
+            }
+            const {owner, repo} = context.repo;
+            const run_id = ${{github.event.workflow_run.id}};
+            const pull_requests = ${{ toJSON(github.event.workflow_run.pull_requests) }};
+            if (!pull_requests.length) {
+              return core.error("This workflow doesn't match any pull requests!");
+            }
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts, {owner, repo, run_id});
+            if (!artifacts.length) {
+              return core.error(`No artifacts found`);
+            }
+            let body = `Download the .APK for this pull request:\n`;
+            for (const art of artifacts) {
+              body += `\n* [${art.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
+            }
+            core.info("Review thread message body:", body);
+            for (const pr of pull_requests) {
+              await upsertComment(owner, repo, pr.number,
+                "nightly-link", body);
+            }


### PR DESCRIPTION
### What this PR does 📖

Adds CI to generate a APK on each PR, that way if the compilation on APK breaks, we can have info about it

<img width="1130" alt="Captura de ecrã 2022-10-11, às 01 28 49" src="https://user-images.githubusercontent.com/29093946/194972056-fe719ca9-6aa9-4622-acc4-8da83b669713.png">

I also added CI to automatically add a comment when each APK finishes generating, can add a comment with the artifact like this

<img width="929" alt="Captura de ecrã 2022-10-11, às 01 29 50" src="https://user-images.githubusercontent.com/29093946/194972134-af3392c3-bd7a-4b8f-99d0-99022ecd2df7.png">

and if we add more commits the same comment updates as well

I can remove that part if we don't want the comment from the bot
