### PR TITLE
fix(native-mobile): remove prototype.at functions for compatibility

### DIFF
--- a/components/views/chat/chatbar/Chatbar.vue
+++ b/components/views/chat/chatbar/Chatbar.vue
@@ -179,12 +179,12 @@ const Chatbar = Vue.extend({
     userLastTextMessage(): ConversationMessage | undefined {
       if (!this.conversationId) return
 
-      return Object.values(
+      const sortedMessages = Object.values(
         iridium.chat.state.conversations[this.conversationId].message,
       )
         .filter((m) => m.from === iridium.id && m.type === 'text')
         .sort((a, b) => a.at - b.at)
-        .at(-1)
+      return sortedMessages[sortedMessages.length - 1]
     },
     draftMessage(): string {
       return this.chat.draftMessages[this.conversationId] ?? ''

--- a/components/views/chat/conversation/Conversation.vue
+++ b/components/views/chat/conversation/Conversation.vue
@@ -80,9 +80,10 @@ export default Vue.extend({
       return iridium.chat.ephemeral.conversations?.[this.conversationId] ?? []
     },
     hasUnreadMessages(): boolean {
-      const lastMessage = Object.values(this.conversation.message)
-        .sort((a, b) => a.at - b.at)
-        .at(-1)
+      const sortedMessages = Object.values(this.conversation.message).sort(
+        (a, b) => a.at - b.at,
+      )
+      const lastMessage = sortedMessages[sortedMessages.length - 1]
       if (!lastMessage) {
         return false
       }
@@ -141,7 +142,7 @@ export default Vue.extend({
       return items
     },
     isLastChatItemAuthor(): boolean {
-      const lastItem = this.chatItems.at(-1)
+      const lastItem = this.chatItems[this.chatItems.length - 1]
       if (!lastItem || !iridium.connector) {
         return false
       }
@@ -173,14 +174,15 @@ export default Vue.extend({
     chatItems(newValue, oldValue) {
       if (
         (this.isLastChatItemAuthor || this.isLockedToBottom) &&
-        newValue.at(-1)?.message.id !== oldValue.at(-1)?.message.id
+        newValue[newValue.length - 1]?.message.id !==
+          oldValue[oldValue.length - 1]?.message.id
       ) {
         this.scrollToBottom()
       }
 
       const maxTime = Math.max(...this.messages.map((message) => message.at))
       if (
-        oldValue.at(-1) !== newValue.at(-1) &&
+        oldValue[oldValue.length - 1] !== newValue[newValue.length - 1] &&
         (!maxTime || maxTime > this.conversation.lastReadAt) &&
         !this.isBlurred &&
         this.isLockedToBottom

--- a/components/views/files/controls/Controls.vue
+++ b/components/views/files/controls/Controls.vue
@@ -82,7 +82,7 @@ const Controls = Vue.extend({
       try {
         iridium.files.addDirectory(
           this.newFolderName,
-          this.path.at(-1)?.id ?? '',
+          this.path[this.path.length - 1]?.id ?? '',
         )
       } catch (e: any) {
         this.errors.push(this.$t(e?.message))
@@ -132,7 +132,7 @@ const Controls = Vue.extend({
         await iridium.files
           .addFile({
             file,
-            parentId: this.path.at(-1)?.id ?? '',
+            parentId: this.path[this.path.length - 1]?.id ?? '',
             // options: { progress: this.setProgress },
           })
           .catch(({ message }) => {

--- a/components/views/navigation/sidebar/list/item/Item.vue
+++ b/components/views/navigation/sidebar/list/item/Item.vue
@@ -69,7 +69,7 @@ export default Vue.extend({
     })
 
     const lastMessageDisplay: ComputedRef<string> = computed(() => {
-      const message = sortedMessages.value.at(-1)
+      const message = sortedMessages.value[sortedMessages.value.length - 1]
       if (!message) {
         return $nuxt.$i18n.t('messaging.say_hi')
       }

--- a/libraries/Iridium/chat/ChatManager.ts
+++ b/libraries/Iridium/chat/ChatManager.ts
@@ -376,7 +376,7 @@ export default class ChatManager extends Emitter<ConversationMessage> {
     const messages = Object.values(
       this.state.conversations[conversation.id].message,
     ).sort((a, b) => a.at - b.at)
-    return messages.at(-1)?.at ?? (conversation.createdAt || 0)
+    return messages[messages.length - 1]?.at ?? (conversation.createdAt || 0)
   }
 
   getSortedConversations(): Conversation[] {

--- a/store/files/getters.ts
+++ b/store/files/getters.ts
@@ -24,7 +24,7 @@ const getters: GetterTree<FilesState, RootState> & FilesGetters = {
       if (state.search.searchAll) {
         items = iridium.files.flat
       } else {
-        const parentId = state.path.at(-1)?.id
+        const parentId = state.path[state.path.length - 1]?.id
         const parent = iridium.files.flat.find(
           (e) => e.id === parentId,
         ) as IridiumDirectory
@@ -50,7 +50,7 @@ const getters: GetterTree<FilesState, RootState> & FilesGetters = {
 
       // If "SearchAll" is inactive, we only want to sort the items that are in the current directory
       if (!searchAllActive && state.path.length) {
-        const parentId = state.path.at(-1)?.id
+        const parentId = state.path[state.path.length - 1]?.id
         const parent = iridium.files.flat.find(
           (e) => e.id === parentId,
         ) as IridiumDirectory


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- Array.prototype.at() isn't compatible with Capacitor. The changes made in this PR replaces .at(-1) with [array.length - 1]

### Which issue(s) this PR fixes 🔨
- Resolve #5217 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

