### PR TITLE
test(cypress): fixes for chat toolbar and text tests

### DIFF
--- a/components/views/chat/chatbar/Chatbar.html
+++ b/components/views/chat/chatbar/Chatbar.html
@@ -6,6 +6,7 @@
   <ChatbarUploadPreview v-if="files.length" />
   <div
     class="chatbar-wrap"
+    data-cy="chatbar-wrap"
     :class="{'is-error': charlimit, 'top-corners-sharp': isSharpCorners, 'outline': isA11yFocused}"
   >
     <ChatbarUpload ref="upload" :disabled="!isSubscribed" />

--- a/components/views/chat/chatbar/footer/Footer.html
+++ b/components/views/chat/chatbar/footer/Footer.html
@@ -1,4 +1,4 @@
-<div class="chatbar-footer">
+<div class="chatbar-footer" data-cy="chatbar-footer">
   <TypographyText size="sm" :color="charlimit ? 'danger' : 'dark'">
     {{ lengthCount }}
   </TypographyText>

--- a/cypress/e2e/chat-glyphs-validations.js
+++ b/cypress/e2e/chat-glyphs-validations.js
@@ -53,12 +53,9 @@ describe('Chat - Sending Glyphs Tests', () => {
     cy.closeModal('[data-cy=modal-cta]')
   })
 
-  //Skipped until bug #5069 - Modals extra close icon is fixed
-  it.skip('Validate glyph pack modal can be closed', () => {
+  it('Validate glyph pack modal can be closed', () => {
     cy.goToLastGlyphOnChat().should('be.visible').click()
     cy.get('[data-cy=glyphs-modal]').should('be.visible')
-    cy.closeModal('[data-cy=glyphs-modal]').then(() => {
-      cy.get('[data-cy=glyphs-modal]').should('not.exist')
-    })
+    cy.closeModal('[data-cy=glyphs-modal]')
   })
 })

--- a/cypress/e2e/chat-search.js
+++ b/cypress/e2e/chat-search.js
@@ -1,35 +1,50 @@
-import { dataRecovery } from '../fixtures/test-data-accounts.json'
-
 const faker = require('faker')
-const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
-const randomMessage = faker.lorem.sentence() // generate random sentence
-const recoverySeed =
-  dataRecovery.accounts
-    .filter((item) => item.description === 'Only Text')
-    .map((item) => item.recoverySeed) + '{enter}'
+const randomMessageOne = faker.lorem.sentence() // generate random sentence
+const randomMessageTwo = faker.lorem.sentence() // generate random sentence
+const randomMessageThree = faker.lorem.sentence() // generate random sentence
+let secondUserName
 
 describe.skip('Chat Search Tests', () => {
-  // Skipping since import account is not working
-  it('Chat - Search - Load account for testing', { retries: 2 }, () => {
-    // Import account
-    cy.importAccount(randomPIN, recoverySeed)
+  //Skipping Chat Search Tests since this is a coming soon functionality
+  before(() => {
+    //Retrieve username from Chat User B
+    cy.restoreLocalStorage('Chat User B')
+    cy.getLocalStorage('Satellite-Store').then((ls) => {
+      let tempLS = JSON.parse(ls)
+      secondUserName = tempLS.accounts.details.name
+    })
+  })
 
-    // Validate profile name displayed
-    cy.validateChatPageIsLoaded()
+  it('Chat - Search - Load account for testing', () => {
+    // Login with User A by restoring LocalStorage Snapshot
+    cy.loginWithLocalStorage('Chat User A')
 
-    // Go to chat
-    cy.goToConversation('Only Text Friend')
+    // Validate message is sent
+    cy.goToConversation(secondUserName)
+  })
+
+  it('Chat - Search - Pretest - Send messages needed for further testing', () => {
+    // Send 25 times a message to validate navigation through search results
+    for (let i = 0; i < 25; i++) {
+      // Validate message is sent
+      cy.chatFeaturesSendMessage(randomMessageTwo)
+    }
+    // Send 5 times a message to validate navigation through search results
+    for (let i = 0; i < 5; i++) {
+      // Validate message is sent
+      cy.chatFeaturesSendMessage(randomMessageThree)
+    }
   })
 
   it('Chat - Search - Send message on chat', () => {
     // Validate message is sent
-    cy.chatFeaturesSendMessage(randomMessage)
+    cy.chatFeaturesSendMessage(randomMessageOne)
   })
 
   it('Chat - Search - Text message - Exact match', () => {
     //Get text from last chat-message and look for it in search bar
     cy.get('[data-cy=chat-message]')
-      .contains(randomMessage)
+      .contains(randomMessageOne)
       .last()
       .invoke('text')
       .then(($message) => {
@@ -37,7 +52,7 @@ describe.skip('Chat Search Tests', () => {
       })
 
     //Assert results and close search modal
-    cy.assertFirstMatchOnSearch(randomMessage)
+    cy.assertFirstMatchOnSearch(randomMessageOne)
     cy.get('[data-cy=chat-search-result]').find('.close-button').click()
   })
 
@@ -62,7 +77,7 @@ describe.skip('Chat Search Tests', () => {
 
   it('Chat - Search Results - Pagination is displayed when more than 10 matches are found', () => {
     //Look for a word showing more than 10 results in chat and ensure pagination is displayed
-    cy.searchFromTextInChat('9876543210')
+    cy.searchFromTextInChat(randomMessageTwo)
     cy.get('[data-cy=chat-search-result-pagination]').should('exist')
   })
 
@@ -79,7 +94,7 @@ describe.skip('Chat Search Tests', () => {
     cy.navigateThroughSearchResults()
   })
 
-  it('Chat - Search Results - Navigate through results oredered by Relevant', () => {
+  it('Chat - Search Results - Navigate through results ordered by Relevant', () => {
     //Click on Sort By Relevant
     cy.get('.orderby-item').contains('Relevant').click()
 
@@ -92,8 +107,8 @@ describe.skip('Chat Search Tests', () => {
 
   it('Chat - Search - Results - Pagination is NOT displayed when 10 or less matches are found', () => {
     //Search for a random number and assert results
-    cy.searchFromTextInChat('1234567890')
-    cy.assertFirstMatchOnSearch('1234567890')
+    cy.searchFromTextInChat(randomMessageThree)
+    cy.assertFirstMatchOnSearch(randomMessageThree)
 
     //Validate that pagination is not displayed and close search modal
     cy.get('[data-cy=chat-search-result-pagination]').should('not.exist')

--- a/cypress/e2e/chat-top-toolbar.js
+++ b/cypress/e2e/chat-top-toolbar.js
@@ -1,26 +1,22 @@
-import { dataRecovery } from '../fixtures/test-data-accounts.json'
+let secondUserName
 
-const faker = require('faker')
-const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
-const recoverySeed =
-  dataRecovery.accounts
-    .filter((item) => item.description === 'cypress')
-    .map((item) => item.recoverySeed) + '{enter}'
+describe('Chat Toolbar Tests', () => {
+  before(() => {
+    //Retrieve username from Chat User B
+    cy.restoreLocalStorage('Chat User B')
+    cy.getLocalStorage('Satellite-Store').then((ls) => {
+      let tempLS = JSON.parse(ls)
+      secondUserName = tempLS.accounts.details.name
+    })
+  })
 
-describe.skip('Chat Toolbar Tests', () => {
-  // Skipping since import account is not working
-  it(
-    'Chat - Toolbar - Load Account for Testing Scenarios',
-    { retries: 2 },
-    () => {
-      //Import account
-      cy.importAccount(randomPIN, recoverySeed)
+  it('Chat - Toolbar - Load Account for Testing Scenarios', () => {
+    // Login with User A by restoring LocalStorage Snapshot
+    cy.loginWithLocalStorage('Chat User A')
 
-      //Ensure messages are displayed before starting
-      cy.validateChatPageIsLoaded()
-      cy.goToConversation('cypress friend')
-    },
-  )
+    // Validate message is sent
+    cy.goToConversation(secondUserName)
+  })
 
   it('Chat - Toolbar - Audio icon is active', () => {
     //Start validations
@@ -30,26 +26,19 @@ describe.skip('Chat Toolbar Tests', () => {
     )
   })
 
-  it('Chat - Toolbar - Alerts icon is active', () => {
-    cy.hoverOnActiveIcon('[data-cy=toolbar-alerts]', 'Alerts')
-  })
-
-  it('Chat - Toolbar - Archived Messages icon shows Coming Soon', () => {
-    cy.hoverOnComingSoonIcon(
-      '[data-cy=toolbar-archived-messages]',
-      'Archived Messages Coming Soon',
-    )
-  })
-
   it('Chat - Toolbar - Marketplace icon shows Coming Soon', () => {
     cy.hoverOnComingSoonIcon(
       '[data-cy=toolbar-marketplace]',
-      'Marketplace Coming soon',
+      'Marketplace (Coming Soon)',
     )
   })
 
   it('Chat - Toolbar - Wallet icon shows Coming Soon', () => {
-    cy.hoverOnComingSoonIcon('[data-cy=toolbar-wallet]', 'Wallet Coming Soon')
+    cy.hoverOnComingSoonIcon('[data-cy=toolbar-wallet]', 'Wallet (Coming Soon)')
+  })
+
+  it('Chat - Toolbar - Search Bar shows Coming Soon', () => {
+    cy.hoverOnComingSoonIcon('[data-cy=chat-search-input]', 'Coming Soon', true)
   })
 
   it('Chat - Marketplace - Coming Soon modal content is correct', () => {
@@ -83,8 +72,9 @@ describe.skip('Chat Toolbar Tests', () => {
     cy.closeModal('[data-cy=glyphs-modal]')
   })
 
-  it('Chat - Glyphs Selection - Coming soon modal', () => {
-    cy.get('#glyph-toggle').click()
+  //Skipped due to bug of Coming Soon modal showing on background when clicking on Glyphs Marketplace
+  it.skip('Chat - Glyphs Selection - Coming soon modal', () => {
+    cy.get('[data-cy=send-glyph]').click()
     cy.get('[data-cy=glyphs-marketplace]').click()
     cy.get('[data-cy=modal-cta]').should('be.visible')
     cy.closeModal('[data-cy=modal-cta]')


### PR DESCRIPTION
### What this PR does 📖
- Fixes for chat-text-validations.js, chat-top-toolbar.js cypress tests to work now
- Updates for chat-search.js cypress test to use an account restored from localstorage. Keeping the test skipped since search bar is a coming soon feature
- Removed skip from one chat-glyphs cypress test now working correctly
- Added data-cy attributes for chatbar footer
- Improvements to cypress commands used in the tests fixed

### Which issue(s) this PR fixes 🔨
- Resolve #AP-2846

### Special notes for reviewers 🗒️

### Additional comments 🎤
Cypress Tests Passing:
<img width="717" alt="image" src="https://user-images.githubusercontent.com/35935591/195450344-003842bf-f68e-4995-a7db-d8064b6580ff.png">

Chat Search Cypress Video:
https://user-images.githubusercontent.com/35935591/195450394-f5d945c2-313a-4e52-90e7-7be4448a8d92.mp4

Chat Top Toolbar Cypress Video:
https://user-images.githubusercontent.com/35935591/195450421-da05a28f-5956-4cb7-87bf-bbaa11a6112a.mp4

Chat Text Validations Cypress Video:
https://user-images.githubusercontent.com/35935591/195450441-5fdc2484-d57d-47a4-af0b-f72a91ab77ab.mp4

Chat Glyphs Cypress Video:
https://user-images.githubusercontent.com/35935591/195450456-ef93add4-5ae0-4b66-832a-22a2a9ded1c1.mp4
