### PR TITLE
refactor(notifications): move all notification logic to global component

### DIFF
--- a/components/compositions/listenToNotifications.ts
+++ b/components/compositions/listenToNotifications.ts
@@ -1,0 +1,88 @@
+import {
+  Notification,
+  NotificationType,
+  NotificationBase,
+} from '~/libraries/Iridium/notifications/types'
+import iridium from '~/libraries/Iridium/IridiumManager'
+
+export function listenToNotifications() {
+  // @ts-ignore
+  const $nuxt = useNuxtApp()
+
+  iridium.notifications.on('notification/create', (data: NotificationBase) => {
+    const { title, description } = getNotificationText(data)
+
+    const notification: Notification = {
+      at: data.at || Date.now(),
+      type: data.type,
+      senderId: data.senderId,
+      title,
+      description,
+      seen: false,
+      image: data.image || '',
+      onNotificationClick: () => handleNotificationClick(data),
+    }
+
+    iridium.notifications.sendNotification(notification)
+  })
+
+  const getNotificationText = (notification: NotificationBase) => {
+    const { type, senderId, conversationId } = notification
+    const sender = iridium.users.getUser(senderId)
+    const defaultText = {
+      title: 'Notification',
+      description: 'You have a new notification',
+    }
+
+    switch (type) {
+      case NotificationType.FRIEND_REQUEST:
+        return {
+          title: 'New Friend Request',
+          description: `${sender?.name} sent you a friend request`,
+        }
+
+      case NotificationType.GROUP_MESSAGE:
+      case NotificationType.DIRECT_MESSAGE: {
+        if (!conversationId) return defaultText
+        const conversation = iridium.chat.getConversation(conversationId)
+        if (!conversation) return defaultText
+        if (!notification.messageId) return defaultText
+        const message = conversation.message[notification.messageId]
+
+        const isGroup = type === NotificationType.GROUP_MESSAGE
+        const groupTitle = $nuxt.$t('notifications.new_message.group_title', {
+          name: conversation.name,
+          server: conversation.name,
+        })
+
+        return {
+          title: isGroup ? groupTitle : `${sender?.name}`,
+          description: message.body || 'You have a new message',
+        }
+      }
+
+      default:
+        return defaultText
+    }
+  }
+
+  const handleNotificationClick = (notification: NotificationBase) => {
+    switch (notification.type) {
+      case NotificationType.FRIEND_REQUEST: {
+        const mobileLink = '/mobile/friends?route=requests'
+        const desktopLink = '/friends?route=requests'
+        $nuxt.$router.push($nuxt.$device.isMobile ? mobileLink : desktopLink)
+        break
+      }
+      case NotificationType.GROUP_MESSAGE:
+      case NotificationType.DIRECT_MESSAGE:
+      case NotificationType.MENTION: {
+        const conversationId = notification.conversationId
+        const mobileLink = `/mobile/chat/${conversationId}`
+        const desktopLink = `/chat/${conversationId}`
+        $nuxt.$router.push($nuxt.$device.isMobile ? mobileLink : desktopLink)
+        break
+      }
+    }
+  }
+}

--- a/components/interactables/TextButton/TextButton.vue
+++ b/components/interactables/TextButton/TextButton.vue
@@ -1,0 +1,21 @@
+<template>
+  <button class="text-button" v-bind="$attrs">
+    <TypographyText>
+      <slot />
+    </TypographyText>
+  </button>
+</template>
+
+<script lang="ts"></script>
+
+<style lang="less" scoped>
+.text-button {
+  font-style: italic;
+  white-space: nowrap;
+  color: @text-muted;
+  transition: @animation-speed-long ease-in-out;
+  &:hover {
+    opacity: 0.8;
+  }
+}
+</style>

--- a/components/ui/Global/Global.vue
+++ b/components/ui/Global/Global.vue
@@ -12,9 +12,13 @@ import {
   NotificationType,
   NotificationBase,
 } from '~/libraries/Iridium/notifications/types'
+import { listenToNotifications } from '~/components/compositions/listenToNotifications'
 
 export default Vue.extend({
   name: 'Global',
+  setup() {
+    listenToNotifications()
+  },
   data() {
     return {
       webrtc: iridium.webRTC.state,
@@ -92,56 +96,8 @@ export default Vue.extend({
     iridium.chat.on('routeCheck', (conversationId: string) =>
       routeCheck(conversationId),
     )
-    this.listenForNotifications()
   },
   methods: {
-    listenForNotifications() {
-      iridium.notifications.on(
-        'notification/create',
-        (data: NotificationBase) => {
-          const notification: Notification = {
-            at: data.at || Date.now(),
-            type: data.type,
-            fromName: data.fromName,
-            title: this.$t(data.title, data.titleValues) as string,
-            description: this.$t(
-              data.description,
-              data.descriptionValues,
-            ) as string,
-            seen: false,
-            image: data.image || '',
-            onNotificationClick: () =>
-              this.handleNotificationClick(
-                data.type,
-                data.notificationClickParams,
-              ),
-          }
-
-          iridium.notifications.sendNotification(notification)
-        },
-      )
-    },
-    handleNotificationClick(
-      type: NotificationType,
-      params: Record<string, any> = {},
-    ) {
-      switch (type) {
-        case NotificationType.FRIEND_REQUEST: {
-          const mobileLink = '/mobile/friends?route=requests'
-          const desktopLink = '/friends?route=requests'
-          this.$router.push(this.$device.isMobile ? mobileLink : desktopLink)
-          break
-        }
-        case NotificationType.GROUP_MESSAGE:
-        case NotificationType.DIRECT_MESSAGE: {
-          const conversationId = params.conversationId
-          const mobileLink = `/mobile/chat/${conversationId}`
-          const desktopLink = `/chat/${conversationId}`
-          this.$router.push(this.$device.isMobile ? mobileLink : desktopLink)
-          break
-        }
-      }
-    },
     /**
      * @method toggleModal
      * @description

--- a/components/views/settings/pages/profile/Profile.html
+++ b/components/views/settings/pages/profile/Profile.html
@@ -154,9 +154,9 @@
                 />
               </div>
               <div>
-                <button class="edit-button" type="submit">
+                <InteractablesTextButton class="edit-button" type="submit">
                   {{ getEditButtonText('about') }}
-                </button>
+                </InteractablesTextButton>
               </div>
             </div>
             <div class="about-main">

--- a/components/views/settings/pages/profile/Profile.less
+++ b/components/views/settings/pages/profile/Profile.less
@@ -259,35 +259,6 @@
       flex-grow: 1;
       &:extend(.ellipsis);
     }
-
-    .edit-button {
-      padding: 8px;
-      opacity: 0;
-
-      &.mobile,
-      &.active,
-      &:focus {
-        opacity: 1;
-      }
-    }
-
-    &:hover {
-      .edit-button {
-        opacity: 1;
-        cursor: pointer;
-      }
-    }
-  }
-}
-
-.edit-button {
-  font-style: italic;
-  white-space: nowrap;
-  color: @text-muted;
-  transition: @animation-speed-long ease-in-out;
-
-  &:hover {
-    opacity: 0.8;
   }
 }
 

--- a/libraries/Iridium/chat/ChatManager.ts
+++ b/libraries/Iridium/chat/ChatManager.ts
@@ -34,9 +34,7 @@ import { ChatFileUpload } from '~/store/chat/types'
 import { FILE_TYPE } from '~/libraries/Files/types/file'
 import isNSFW from '~/utilities/NSFW'
 import {
-  Notification,
   NotificationBase,
-  NotificationClickEvent,
   NotificationType,
 } from '~/libraries/Iridium/notifications/types'
 import { uploadFile } from '~/libraries/Iridium/utils'
@@ -314,6 +312,10 @@ export default class ChatManager extends Emitter<ConversationMessage> {
         message,
       )
     } else if (type === 'chat/edit') {
+      if (!payload.body.message) {
+        console.error('no message in payload')
+        return
+      }
       const { messageId, conversationId, body, lastEditedAt } = payload.body
         .message as MessageEdit
 
@@ -353,18 +355,10 @@ export default class ChatManager extends Emitter<ConversationMessage> {
       type: isGroup
         ? NotificationType.GROUP_MESSAGE
         : NotificationType.DIRECT_MESSAGE,
-      title: isGroup
-        ? 'notifications.new_message.group_title'
-        : sender?.name || 'notifications.new_message.title',
-      titleValues: isGroup
-        ? { name: sender?.name, server: conversation.name }
-        : undefined,
-      description,
-      fromName: sender?.name || '',
+      senderId: sender?.did,
+      messageId: message.id,
+      conversationId: conversation.id,
       image: fromDID,
-      notificationClickParams: {
-        conversationId: conversation.id,
-      },
     } as NotificationBase)
   }
 

--- a/libraries/Iridium/chat/ChatManager.ts
+++ b/libraries/Iridium/chat/ChatManager.ts
@@ -38,6 +38,7 @@ import {
   NotificationType,
 } from '~/libraries/Iridium/notifications/types'
 import { uploadFile } from '~/libraries/Iridium/utils'
+import { truthy } from '~/utilities/typeGuard'
 
 export type ConversationPubsubEvent = IridiumMessage<
   IridiumDecodedPayload<{
@@ -604,13 +605,16 @@ export default class ChatManager extends Emitter<ConversationMessage> {
     // (check all users in the userManager because there is the case of groups with people not in participants but still in the userManager list, for example when they left the group)
     await Promise.all(
       iridium.users.list
+        .filter(truthy)
         .filter(
           (u) =>
             !participants.includes(u.did) &&
             !iridium.friends.isFriend(u.did) &&
             !this.isUserInOtherGroups(u.did, [id]),
         )
-        .map((u) => iridium.users.userRemove(u.did, true)),
+        .map(async (u) => {
+          await iridium.users.userRemove(u.did, true)
+        }),
     )
     await this.deleteConversation(id)
   }
@@ -909,8 +913,10 @@ export default class ChatManager extends Emitter<ConversationMessage> {
       return
     }
 
-    const index = conversationMessages.findIndex((msg) => msg.id === message.id)
-    if (index >= 0) conversationMessages.splice(index, 1)
+    const index = conversationMessages?.findIndex(
+      (msg) => msg.id === message.id,
+    )
+    if (index >= 0) conversationMessages?.splice(index, 1)
   }
 
   // Check if user is in other groups other than `exlude` groups.

--- a/libraries/Iridium/friends/FriendsManager.ts
+++ b/libraries/Iridium/friends/FriendsManager.ts
@@ -353,12 +353,7 @@ export default class FriendsManager extends Emitter<IridiumFriendPubsub> {
   private sendNotification(user: User) {
     iridium.notifications.emit('notification/create', {
       type: NotificationType.FRIEND_REQUEST,
-      title: 'notifications.friend_request.title',
-      description: 'notifications.friend_request.body',
-      descriptionValues: {
-        name: user.name,
-      },
-      fromName: user.name,
+      senderId: user.did,
       image: user.photoHash,
     } as NotificationBase)
   }

--- a/libraries/Iridium/notifications/__snapshots__/types.test.ts.snap
+++ b/libraries/Iridium/notifications/__snapshots__/types.test.ts.snap
@@ -1,15 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`test constants of Iridium/notifications/types should return correct value for EmptyNotification 1`] = `
-Object {
-  "at": 0,
-  "description": "",
-  "fromAddress": "",
-  "fromName": "",
-  "id": "",
-  "image": "",
-  "seen": false,
-  "title": "",
-  "type": 12,
-}
-`;
+exports[`test constants of Iridium/notifications/types should return correct value for EmptyNotification 1`] = `undefined`;

--- a/libraries/Iridium/notifications/types.ts
+++ b/libraries/Iridium/notifications/types.ts
@@ -6,62 +6,34 @@ export const NotificationsError = {
 }
 
 export enum NotificationType {
-  FRIEND_REQUEST,
-  MISSED_CALL,
-  FILES_FULL,
-  FILE_UPLOADED,
-  FILE_NSFW,
-  DEV,
-  DIRECT_MESSAGE,
-  GROUP_MESSAGE,
-  MENTIONS_NOTIFICATION,
-  ACCOUNT_NOTIFICATION,
-  APPLICATION_NOTIFICATION,
-  MISCELLANEOUS,
-  SEEN,
+  FRIEND_REQUEST = 'friend_request',
+  DIRECT_MESSAGE = 'direct_message',
+  GROUP_MESSAGE = 'group_message',
+  MENTION = 'mention',
 }
 
 export type Notification = {
   at: number
   type: NotificationType
-  fromName: string
+  senderId: string
   title: string
   description: string
   seen: boolean
   id?: string
-  chatName?: string
-  fromAddress?: string
+  messageId?: string
+  conversationId?: string
   image?: string
   onNotificationClick?: () => void
 }
 
-export type NotificationBase = {
-  type: NotificationType
-  title: string
-  description: string
-  fromName: string
-  at?: number
-  image?: string
-  titleValues?: object
-  descriptionValues?: object
-  onNotificationClick?: void
-  notificationClickParams?: object
+export interface NotificationBase
+  extends Omit<Notification, 'title' | 'description'> {
+  titleValues?: Record<string, string>
+  desriptionValues?: Record<string, string>
 }
 
 export type NotificationClickEvent = {
   from: string
   topic: string
   payload: { type: NotificationType }
-}
-
-export const EmptyNotification: Notification = {
-  at: 0,
-  id: '',
-  type: NotificationType.SEEN,
-  fromName: '',
-  fromAddress: '',
-  title: '',
-  description: '',
-  image: '',
-  seen: false,
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- Handles the logic for notifications, such as fetching text and handling notification click events, inside of the global component
- Moves notification logic inside of the global component into a composition file

### Which issue(s) this PR fixes 🔨
- Resolve #5242 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

