### PR TITLE
test(cypress): update random username to have 12 chars

### DIFF
--- a/cypress/e2e/add-friends.js
+++ b/cypress/e2e/add-friends.js
@@ -1,7 +1,7 @@
 const faker = require('faker')
-const firstUserName = faker.internet.userName(name) // generate random username for first user
-const secondUserName = faker.internet.userName(name) // generate random username for first user
-const thirdUserName = faker.internet.userName(name) // generate random username for first user
+const firstUserName = faker.internet.password(12, true) // Generate username with 12 characters
+const secondUserName = faker.internet.password(12, true) // Generate username with 12 characters
+const thirdUserName = faker.internet.password(12, true) // Generate username with 12 characters
 let firstUserID, secondUserID, thirdUserID
 
 describe('Create Test Accounts', () => {

--- a/cypress/e2e/create-account-negative-tests.js
+++ b/cypress/e2e/create-account-negative-tests.js
@@ -1,6 +1,6 @@
 const faker = require('faker')
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
-const randomName = faker.internet.userName(name) // generate random name
+const randomName = faker.internet.password(12, true) // Generate username with 12 characters
 const randomStatus = faker.lorem.word() // generate random status
 const filepathNsfw = 'images/negative-create-account-test.png'
 

--- a/cypress/e2e/create-account.js
+++ b/cypress/e2e/create-account.js
@@ -2,7 +2,7 @@ const faker = require('faker')
 const filepathCorrect = 'images/logo.png'
 const filepathNsfw = 'images/negative-create-account-test.png'
 const invalidImagePath = 'images/incorrect-image.png'
-const randomName = faker.internet.userName(name) // generate random name
+const randomName = faker.internet.password(12, true) // Generate username with 12 characters
 const randomStatus = faker.lorem.word() // generate random status
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 

--- a/cypress/e2e/localstorage-validations.js
+++ b/cypress/e2e/localstorage-validations.js
@@ -2,7 +2,7 @@ import { dataRecovery } from '../fixtures/test-data-accounts.json'
 
 const faker = require('faker')
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
-const randomName = faker.internet.userName(name) // generate random name
+const randomName = faker.internet.password(12, true) // Generate username with 12 characters
 const recoverySeed =
   dataRecovery.accounts
     .filter((item) => item.description === 'Only Text')

--- a/cypress/e2e/mobiles-responsiveness.js
+++ b/cypress/e2e/mobiles-responsiveness.js
@@ -2,7 +2,7 @@ import { data } from '../fixtures/mobile-devices.json'
 
 const faker = require('faker')
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
-const randomName = faker.internet.userName(name) // generate random name
+const randomName = faker.internet.password(12, true) // Generate username with 12 characters
 const randomStatus = faker.lorem.word() // generate random status
 const randomNumber = faker.datatype.number() // generate random number
 const randomMessage = faker.lorem.sentence() // generate random sentence

--- a/cypress/e2e/pin-unlock-validations.js
+++ b/cypress/e2e/pin-unlock-validations.js
@@ -6,9 +6,9 @@ const userPassphrase = dataRecovery.accounts
   .map((item) => item.recoverySeed)
   .toString()
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
-const firstUserName = faker.internet.userName(name) // generate random username for first user
-const secondUserName = faker.internet.userName(name) // generate random username for first user
-const thirdUserName = faker.internet.userName(name) // generate random username for first user
+const firstUserName = faker.internet.password(12, true) // Generate username with 12 characters
+const secondUserName = faker.internet.password(12, true) // Generate username with 12 characters
+const thirdUserName = faker.internet.password(12, true) // Generate username with 12 characters
 
 describe('Unlock pin should be persisted when store pin is enabled', () => {
   it('Create Account with store pin disabled', () => {

--- a/cypress/e2e/snapshots-test.js
+++ b/cypress/e2e/snapshots-test.js
@@ -6,7 +6,7 @@ const recoverySeed = dataRecovery.accounts
   .filter((item) => item.description === 'Snap QA')
   .map((item) => item.recoverySeed)
   .toString()
-const randomName = faker.internet.userName(name) // generate random name
+const randomName = faker.internet.password(12, true) // Generate username with 12 characters
 const randomStatus = faker.lorem.word() // generate random status
 
 describe.skip('Snapshots Testing', () => {


### PR DESCRIPTION
### What this PR does 📖
- Implemented the usage of faker.internet.password on several cypress tests to create usernames, since this one have the capability to set the length of the username created. Setting this to 12 chars. 

### Which issue(s) this PR fixes 🔨
- Resolve #

### Special notes for reviewers 🗒️
- 

### Additional comments 🎤
- All tests passing:
![image](https://user-images.githubusercontent.com/35935591/196574129-a3ed0d10-8ea0-4b98-af82-5887a850b5a5.png)
 