### PR TITLE
fix(notifications): send call notification only after a call is estab…

### DIFF
--- a/components/compositions/webrtc.ts
+++ b/components/compositions/webrtc.ts
@@ -42,22 +42,23 @@ export function webrtcHooks(conversationId?: Conversation['id']) {
       return
     }
 
-    await iridium.chat?.sendMessage({
-      conversationId,
-      type: 'call',
-      at: Date.now(),
-      attachments: [],
-      call: {},
-    })
-
     // todo - refactor to accept multiple recipients for group calls
-    await iridium.webRTC
-      .call({
+    try {
+      await iridium.webRTC.call({
         recipient,
         conversationId,
         kinds,
       })
-      .catch((e) => $nuxt.$toast.error($nuxt.$i18n.t(e.message)))
+      await iridium.chat?.sendMessage({
+        conversationId,
+        type: 'call',
+        at: Date.now(),
+        attachments: [],
+        call: {},
+      })
+    } catch (e) {
+      $nuxt.$toast.error($nuxt.$i18n.t(e.message))
+    }
   }
   return { enableRTC, isActiveCall, call }
 }


### PR DESCRIPTION
…lished

<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- Only send a message to the conversation after a call has been made

### Which issue(s) this PR fixes 🔨
- Resolve #5388 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️
- " started a call message" was sent to the conversation after the call button had been clicked regardless of whether the user had actually established a call or not.
- This can be observed in dev if a user who has not given mic access to the application tries to start a call. If the user decides to not to permit mic acces to the application a call will not be made even though conversation members have been notified that one has.
