### PR TITLE
fix(chat): close conversation after swiping to chat list on mobile

### DIFF
--- a/pages/mobile/chat/_id.vue
+++ b/pages/mobile/chat/_id.vue
@@ -44,9 +44,7 @@ import { RootState } from '~/types/store/store'
 import 'swiper/css'
 import iridium from '~/libraries/Iridium/IridiumManager'
 import EarlyAccessBanner from '~/components/ui/EarlyAccessBanner/EarlyAccessBanner.vue'
-import { DismissSoftwareKeyboard, swiperOptions } from '~/utilities/swiper'
-
-const SLIDE_TRANSITION_DURATION = 100 // ms
+import { swiperOptions, SWIPER_TRANSITION_SPEED } from '~/utilities/swiper'
 
 export default Vue.extend({
   name: 'MobileChat',
@@ -82,7 +80,7 @@ export default Vue.extend({
 
               setTimeout(() => {
                 this.$router.push({ path: '/mobile/chat' })
-              }, SLIDE_TRANSITION_DURATION)
+              }, SWIPER_TRANSITION_SPEED)
             }
             if (activeIndex === 1) {
               this.swiper.allowSlidePrev = true

--- a/pages/mobile/chat/_id.vue
+++ b/pages/mobile/chat/_id.vue
@@ -46,6 +46,8 @@ import iridium from '~/libraries/Iridium/IridiumManager'
 import EarlyAccessBanner from '~/components/ui/EarlyAccessBanner/EarlyAccessBanner.vue'
 import { DismissSoftwareKeyboard, swiperOptions } from '~/utilities/swiper'
 
+const SLIDE_TRANSITION_DURATION = 100 // ms
+
 export default Vue.extend({
   name: 'MobileChat',
   components: {
@@ -77,6 +79,10 @@ export default Vue.extend({
               this.swiper.allowSlidePrev = false
               this.swiper.allowSlideNext = true
               this.isMobileNavVisible = true
+
+              setTimeout(() => {
+                this.$router.push({ path: '/mobile/chat' })
+              }, SLIDE_TRANSITION_DURATION)
             }
             if (activeIndex === 1) {
               this.swiper.allowSlidePrev = true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

### What this PR does 📖
- Closes a conversation when user returns to chat list to avoid issues such as:
  - Any new messages sent to the conversation being marked as read even though the user is no longer in the chat
  - Current call banner not appearing immediately after swiping away from chat 

### Which issue(s) this PR fixes 🔨
- Resolve #5407 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->