### PR TITLE
test(cypress): fixes for cypress call tests

### DIFF
--- a/cypress/integration-pair-chat/chat-first-user.js
+++ b/cypress/integration-pair-chat/chat-first-user.js
@@ -3,14 +3,16 @@ const longMessage = faker.lorem.words(25) // generate random sentence
 let urlToValidate = 'https://www.satellite.im'
 
 describe('Chat features with two accounts at the same time - First User', () => {
-  Cypress.on('uncaught:exception', (err, runnable) => {
-    if (err.message.includes('multiaddr must have a valid')) {
-      console.log(
-        'Error: multiaddr must have a valid format: /{ip4, ip6, dns4, dns6, dnsaddr}/{address}/{tcp, udp}/{port',
-      )
-    }
-    // returning false here prevents Cypress from failing the test
-    return false
+  beforeEach(() => {
+    Cypress.on('uncaught:exception', (err, runnable) => {
+      if (err.message.includes('multiaddr must have a valid')) {
+        console.log(
+          'Error: multiaddr must have a valid format: /{ip4, ip6, dns4, dns6, dnsaddr}/{address}/{tcp, udp}/{port',
+        )
+      }
+      // returning false here prevents Cypress from failing the test
+      return false
+    })
   })
 
   it('Create test account for First User', () => {
@@ -339,7 +341,7 @@ describe('Chat features with two accounts at the same time - First User', () => 
 
   it('Remote screen share stopped - User will stop seeing the remote screen', () => {
     // Remote Screenshare is removed
-    cy.validateScreenSharePresentOnCall('remote', false)
+    cy.validateScreenSharePresentOnCall('remote', false, 30000)
   })
 
   it('Videocall Audio Indicator - Is displayed in screen', () => {
@@ -416,7 +418,6 @@ describe('Chat features with two accounts at the same time - First User', () => 
     cy.get('[data-cy=incoming-call-deny]').click()
   })
 
-  // Skipped since refreshing page on Cypress is showing Choose Your Password Screen instead of Decrypt Account
   it('If remote users refreshes the page, the call is eneded on both sides', () => {
     //Accept the third incoming call from Chat User B
     cy.answerVideocall()

--- a/cypress/integration-pair-chat/chat-second-user.js
+++ b/cypress/integration-pair-chat/chat-second-user.js
@@ -1,17 +1,19 @@
 describe('Chat features with two accounts at the same time - Second User', () => {
-  Cypress.on('uncaught:exception', (err, runnable) => {
-    if (err.message.includes('multiaddr must have a valid')) {
-      console.log(
-        'Error: multiaddr must have a valid format: /{ip4, ip6, dns4, dns6, dnsaddr}/{address}/{tcp, udp}/{port',
-      )
-    }
-    // returning false here prevents Cypress from failing the test
-    return false
+  beforeEach(() => {
+    Cypress.on('uncaught:exception', (err, runnable) => {
+      if (err.message.includes('multiaddr must have a valid')) {
+        console.log(
+          'Error: multiaddr must have a valid format: /{ip4, ip6, dns4, dns6, dnsaddr}/{address}/{tcp, udp}/{port',
+        )
+      }
+      // returning false here prevents Cypress from failing the test
+      return false
+    })
   })
 
   it('Create test account for Second User', () => {
     // Create one account
-    cy.createAccount('12345', 'Chat User B')
+    cy.createAccount('12345', 'Chat User B', false)
 
     // Validate chat page is loaded
     cy.validateChatPageIsLoaded()
@@ -165,8 +167,14 @@ describe('Chat features with two accounts at the same time - Second User', () =>
     cy.get('[data-cy=mediastream]').should('not.exist')
   })
 
-  // Test skipped because local page gets stuck in Linking Satellites screen after refreshing
+  // Skipped since refreshing page on Cypress is showing Choose Your Password Screen instead of Decrypt Account
   it.skip('Call again to User A and close the browser', () => {
+    //Enter Pin once that Decrypt Account is displayed
+
+    cy.contains('Decrypt Account', { timeout: 30000 }).should('be.visible')
+    cy.get('[data-cy=input-group]').trigger('input').type('12345')
+    cy.get('[data-cy=submit-input]').click()
+
     // Validate chat page is loaded
     cy.validateChatPageIsLoaded()
 


### PR DESCRIPTION
### What this PR does 📖
- Modifying chat-first-user.js cypress spece by adding more timeout to wait until remote screen is not present on screen, since there was a timeout issue in one cypress CI execution
- Changed the Cypress.on('uncaught:exception') block to be executed on beforeEach blocks for cypress first user and second user tests
- Small update to use save pin false when creating second account to test the refresh scenario

### Which issue(s) this PR fixes 🔨
- Resolve #

### Special notes for reviewers 🗒️
- 

### Additional comments 🎤
- 