### PR TITLE
test(cypress): add settings themes tests

### DIFF
--- a/components/interactables/Select/Select.html
+++ b/components/interactables/Select/Select.html
@@ -18,19 +18,25 @@
       {{ option.text }}
     </option>
   </select>
-  <div v-else class="list-container" v-click-outside="hideListbox">
+  <div
+    v-else
+    class="list-container"
+    data-cy="list-container"
+    v-click-outside="hideListbox"
+  >
     <button
       :id="`${label}-button-label`"
       :disabled="disabled"
       :aria-labelledby="`${label}-label ${label}-button-label`"
       type="button"
+      data-cy="list-container-button"
       :title="value ? selectedOptionLabel : placeholder"
       aria-haspopup="listbox"
       @click="toggleListbox"
       @keydown="checkShow"
       ref="button"
     >
-      <div class="label">
+      <div class="label" data-cy="list-container-selected">
         {{ value ? selectedOptionLabel : placeholder }}
         <div class="width-buffer" aria-hidden="true">
           <div v-for="(option, index) in options">{{ option.text }}</div>
@@ -53,6 +59,7 @@
           v-for="(option, index) in options"
           :key="`${label}-option-${index}`"
           :aria-selected="option.value === value"
+          data-cy="list-value"
           :data-value="option.value"
           :style="option.color ? 'background:' + option.color : ''"
           role="option"

--- a/components/views/settings/pages/personalize/Personalize.html
+++ b/components/views/settings/pages/personalize/Personalize.html
@@ -10,6 +10,7 @@
     <SettingsUnit>
       <InteractablesSelect
         v-model="theme"
+        data-cy="settings-color-theme-selector"
         :options="themeOptions"
         :label="$t('pages.settings.personalize.theme')"
         show-label
@@ -22,6 +23,7 @@
       <InteractablesSelect
         v-model="flair"
         :options="flairOptions"
+        data-cy="settings-flair-selector"
         :label="$t('pages.settings.personalize.flair')"
         :disabled="theme === ThemeKeys.DEFAULT"
         show-label
@@ -34,6 +36,7 @@
       <InteractablesSelect
         v-model="language"
         :options="[{ text: 'English (USA)', value: 'en_US' }]"
+        data-cy="settings-language-selector"
         :label="$t('pages.settings.personalize.language')"
         show-label
       />

--- a/cypress/e2e/settings-personalize.js
+++ b/cypress/e2e/settings-personalize.js
@@ -1,0 +1,72 @@
+const expectedThemeOptions = ['Default', 'Moonless Night']
+const expectedFlairOptions = [
+  'Satellite',
+  'Peach',
+  'Pink',
+  'Lime',
+  'Purple',
+  'Lavender',
+  'Sunflower',
+  'Deep Blue',
+  'Void',
+]
+describe('Settings - Personalize Features Tests', () => {
+  beforeEach(() => {
+    //Setting a viewport visible for all toggles
+    cy.viewport(1800, 1200)
+  })
+
+  it('Settings - Personalize - Themes default selection', () => {
+    // Login with User A by restoring LocalStorage Snapshot
+    cy.loginWithLocalStorage('Chat User A')
+
+    // Go to settings
+    cy.get('[data-cy=go-to-settings]').click()
+
+    // Ensure Settings Modal is displayed
+    cy.get('[data-cy=settings-modal]').should('be.visible')
+
+    // Ensure that personalize tab is displayed
+    cy.contains('Personalize Satellite')
+
+    //Validate that "Default" is current theme displayed in Application and the option selected in dropdown list
+    cy.validateAppTheme('Default')
+
+    // Validate that when Color Theme is "Default", Flair selector is deactivated
+    cy.get('[data-cy=settings-flair-selector]')
+      .find('[data-cy=list-container-button]')
+      .should('have.attr', 'disabled', 'disabled')
+
+    // Validate that when Color Theme is "Default", Flair value selected is "Satellite" and this is the current flair displayed in Application
+    cy.validateAppFlair('Satellite')
+  })
+
+  it('Settings - Personalize - Change theme to Moonless Night', () => {
+    // Click on Color Theme selector to see the options
+    // Validate the correct two options are contained in Color Theme Selector
+    cy.validateListOptions('theme', expectedThemeOptions)
+
+    // Change Theme to "Moonless Night"
+    cy.selectThemeOrFlair('theme', 'Moonless Night')
+
+    // Validate that Color Theme selected is now "Moonless Night" and it is the current theme displayed in Application
+    cy.validateAppTheme('Moonless Night')
+  })
+
+  it('Settings - Personalize - Flair options for Moonless Night Theme', () => {
+    // Click on Flair selector to see the options
+    // Validate the correct nine options are contained in Flair Selector
+    cy.validateListOptions('flair', expectedFlairOptions)
+  })
+
+  it('Settings - Personalize - Change Flair to "Lime"', () => {
+    // Click on "Flair" and change the selected value to "Lime"
+    cy.selectThemeOrFlair('flair', 'Lime')
+
+    // Validate that Flair selected is now "Lime" and this is the current flair color displayed in Application
+    cy.validateAppFlair('Lime')
+
+    //Close modal
+    cy.closeModal('[data-cy=settings-modal]')
+  })
+})

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -931,6 +931,63 @@ Cypress.Commands.add(
   },
 )
 
+Cypress.Commands.add('validateAppTheme', (themeName = 'Default') => {
+  let expectedClass
+  if (themeName === 'Default') {
+    expectedClass = 'theme-default'
+  } else if (themeName === 'Moonless Night') {
+    expectedClass = 'theme-moonlessNight'
+  }
+  cy.get('#app').should('have.class', expectedClass)
+  cy.get('[data-cy=settings-color-theme-selector]')
+    .find('[data-cy=list-container-selected]')
+    .should('contain', themeName)
+})
+
+Cypress.Commands.add('validateAppFlair', (flairName = 'Satellite') => {
+  let expectedRgb
+  if (flairName === 'Satellite') {
+    expectedRgb = 'rgb(39, 97, 253)'
+  } else if (flairName === 'Lime') {
+    expectedRgb = 'rgb(163, 203, 56)'
+  }
+  cy.get('body').should('have.css', 'caret-color', expectedRgb)
+  cy.get('[data-cy=settings-flair-selector]')
+    .find('[data-cy=list-container-selected]')
+    .should('contain', flairName)
+})
+
+Cypress.Commands.add('validateListOptions', (option, expectedList) => {
+  // Determine the selector to be assigned to the alias based on the option to validate
+  if (option === 'theme') {
+    cy.get('[data-cy=settings-color-theme-selector]').as('option')
+  } else if (option === 'flair') {
+    cy.get('[data-cy=settings-flair-selector]').as('option')
+  }
+
+  //Click on the option to display the list
+  cy.get('@option').find('[data-cy=list-container-button]').click()
+
+  //Validate the options displayed in the list
+  cy.get('@option')
+    .find('[data-cy=list-value]')
+    .should('have.length', expectedList.length)
+    .each(($option, $index, $list) => {
+      expect($option.text().trim()).to.be.eq(expectedList[$index])
+    })
+})
+
+Cypress.Commands.add('selectThemeOrFlair', (option, value) => {
+  // Determine the selector to be assigned to the alias based on the option to validate
+  if (option === 'theme') {
+    cy.get('[data-cy=settings-color-theme-selector]').as('option')
+  } else if (option === 'flair') {
+    cy.get('[data-cy=settings-flair-selector]').as('option')
+  }
+  // Click on "Flair" and change the selected value to "Lime"
+  cy.get('@option').find('[data-cy=list-value]').contains(value).click()
+})
+
 // LocalStorage Validations
 
 Cypress.Commands.add('validatePopulatedLocalStorage', (username = 'qa123') => {


### PR DESCRIPTION
### What this PR does 📖
- Adding data-cy attributes on [components/interactables/Select/Select.html](https://github.com/Satellite-im/Core-PWA/compare/AP-1345?expand=1#diff-28f900f4864e84fdc40c6cb08e46a6959d2c52aa2a3ed31d3b5213bddea77dc9) and [components/views/settings/pages/personalize/Personalize.html](https://github.com/Satellite-im/Core-PWA/compare/AP-1345?expand=1#diff-df523a93903d79cbd99ada5db9c40ed16b500e21ab2d62af1169a2af015c257b)
- Adding new cypress commands for settings personalize features
- Adding cypress tests for settings personalize change theme and flair

### Which issue(s) this PR fixes 🔨
- Resolve #AP-1345

### Special notes for reviewers 🗒️
- 

### Additional comments 🎤
- Cypress Video for Settings-Personalize.js:
https://user-images.githubusercontent.com/35935591/200701768-7bef46ff-2250-4aa9-873e-6d6688bfb0c4.mp4

- Cypress Specs Passed:
<img width="468" alt="image" src="https://user-images.githubusercontent.com/35935591/200701607-a9025240-267b-4a5b-9aa2-1981f8b98d30.png">

- Cypress Videocall Specs Passed:
![image](https://user-images.githubusercontent.com/35935591/200701621-67ef714a-e9fe-4d10-a013-cd3086ef289b.png)
