### PR TITLE
test(cypress): adding emoji picker tests

### DIFF
--- a/components/views/chat/enhancers/Enhancers.vue
+++ b/components/views/chat/enhancers/Enhancers.vue
@@ -6,6 +6,11 @@
           v-for="el in buttons"
           :key="el.id"
           :text="el.label"
+          :data-cy="
+            enhancersRoute === el.id
+              ? 'glyphs-emoji-active'
+              : 'glyphs-emoji-inactive'
+          "
           :color="enhancersRoute === el.id ? 'primary' : 'dark'"
           @click="enhancersRoute = el.id"
         >

--- a/components/views/chat/enhancers/emoji/Emoji.html
+++ b/components/views/chat/enhancers/emoji/Emoji.html
@@ -24,11 +24,13 @@
         <div class="emoji-section">
           <div
             class="emojis"
+            data-cy="emoji-frequently-used-list"
             v-if="category === 'Frequently used' && mostUsedEmojis.length"
           >
             <div
               v-for="(emoji, index) in mostUsedEmojis"
               class="emoji"
+              data-cy="emoji-frequently-used-item"
               :key="index"
               @click="addEmoji(emoji.content, emoji.code)"
               :title="index"

--- a/cypress/e2e/chat-features.js
+++ b/cypress/e2e/chat-features.js
@@ -2,6 +2,7 @@ const faker = require('faker')
 const randomNumber = faker.datatype.number() // generate random number
 const randomMessage = faker.lorem.sentence() // generate random sentence
 const imageLocalPath = 'cypress/fixtures/images/logo.png'
+let expectedEmojiFrequentList
 let imageURL, expecedEditedMessage, secondUserName
 
 describe('Chat Features Tests', () => {
@@ -9,7 +10,7 @@ describe('Chat Features Tests', () => {
     //Retrieve username from Chat User B
     cy.restoreLocalStorage('Chat User B')
     cy.getLocalStorage('Satellite-Store').then((ls) => {
-      let tempLS = JSON.parse(ls)
+      const tempLS = JSON.parse(ls)
       secondUserName = tempLS.accounts.details.name
     })
   })
@@ -145,6 +146,47 @@ describe('Chat Features Tests', () => {
       })
   })
 
+  it('Chat - Switching Glyphs/Emoji pickers ', () => {
+    // Open Emoji Picker and ensure that only emoji picker its visible
+    cy.get('[data-cy=send-emoji]').click()
+    cy.validateActiveGlyphsEmojiPicker('emoji')
+
+    // Click on Emoji Tab and ensure that only emoji picker its visible
+    cy.get('[data-cy=glyphs-emoji-active]').click()
+    cy.validateActiveGlyphsEmojiPicker('emoji')
+
+    // Click on Glyphs Tab and ensure that only glyphs picker its visible
+    cy.get('[data-cy=glyphs-emoji-inactive]').click()
+    cy.validateActiveGlyphsEmojiPicker('glyphs')
+
+    // Click on Emoji Tab again and ensure that only emoji picker its visible
+    cy.get('[data-cy=glyphs-emoji-inactive]').click()
+    cy.validateActiveGlyphsEmojiPicker('emoji')
+
+    // Click on Send Glyph button and ensure that only glyphs picker its visible
+    cy.get('[data-cy=send-glyph]').click()
+    cy.validateActiveGlyphsEmojiPicker('glyphs')
+
+    // Click on Send Emoji button and ensure that only emoji picker its visible
+    cy.get('[data-cy=send-emoji]').click()
+    cy.validateActiveGlyphsEmojiPicker('emoji')
+
+    // Click again on Send Glyph button and ensure that only glyphs picker its visible
+    cy.get('[data-cy=send-glyph]').click()
+    cy.validateActiveGlyphsEmojiPicker('glyphs')
+
+    // Click on Glyphs Tab and ensure that only glyphs picker its visible
+    cy.get('[data-cy=glyphs-emoji-active]').click()
+    cy.validateActiveGlyphsEmojiPicker('glyphs')
+
+    // Click on Emoji Tab and ensure that only glyphs picker its visible
+    cy.get('[data-cy=glyphs-emoji-active]').click()
+    cy.validateActiveGlyphsEmojiPicker('glyphs')
+
+    // Click on Esc to close Glyphs/Emoji picker
+    cy.get('body').type('{esc}')
+  })
+
   it('Chat - Validate User ID can be copied when clicked on it', () => {
     cy.chatFeaturesProfileName()
   })
@@ -159,10 +201,60 @@ describe('Chat Features Tests', () => {
     cy.addOrAssertProfileNote('This is a test note' + randomNumber, 'assert')
   })
 
-  it('Chat - Send each letter on alphabet as message', () => {
-    const alphabet = 'abcdefghijklmnopqrstuvwxyz'
-    for (let letter of alphabet) {
-      cy.chatFeaturesSendMessage(letter, true)
-    }
+  it('Chat - Emoji Picker - Frequently used - Validate list order', () => {
+    //Assign the same emojis previously sent to our expected list variable
+    expectedEmojiFrequentList = '😄😃😀😊😉😍😘😚😗😙'
+
+    // Send 9 different emojis, so we can have 10 emojis sent on the list
+    cy.chatFeaturesSendEmoji('[title="smiley"]', '😃', false)
+    cy.chatFeaturesSendEmoji('[title="grinning"]', '😀', false)
+    cy.chatFeaturesSendEmoji('[title="blush"]', '😊', false)
+    cy.chatFeaturesSendEmoji('[title="wink"]', '😉', false)
+    cy.chatFeaturesSendEmoji('[title="heart_eyes"]', '😍', false)
+    cy.chatFeaturesSendEmoji('[title="kissing_heart"]', '😘', false)
+    cy.chatFeaturesSendEmoji('[title="kissing_closed_eyes"]', '😚', false)
+    cy.chatFeaturesSendEmoji('[title="kissing"]', '😗', false)
+    cy.chatFeaturesSendEmoji('[title="kissing_smiling_eyes"]', '😙', false)
+
+    //Validate emoji frequently used list has the expected order
+    cy.validateFrequentEmojiItems(expectedEmojiFrequentList)
+
+    //Clear editable input
+    cy.get('[data-cy=editable-input]').click().clear()
+  })
+
+  it('Chat - Emoji - Frequently used - List will be updated and emoji sent more times will be first', () => {
+    // Select 3x times joy emoji (not previously clicked)
+    cy.chatFeaturesSendEmoji('[title="joy"]', '😂', false)
+    cy.chatFeaturesSendEmoji('[title="joy"]', '😂', false)
+    cy.chatFeaturesSendEmoji('[title="joy"]', '😂', false)
+
+    // Select 3x times heart eyes emoji (now clicked 4 times)
+    cy.chatFeaturesSendEmoji('[title="heart_eyes"]', '😍', false)
+    cy.chatFeaturesSendEmoji('[title="heart_eyes"]', '😍', false)
+    cy.chatFeaturesSendEmoji('[title="heart_eyes"]', '😍', false)
+
+    // Send 1x time wink emoji and then validate (now clicked 2 times)
+    cy.chatFeaturesSendEmoji('[title="wink"]', '😉', true).then(() => {
+      // Update our existing expected list variable, the last emoji just 1x used will be removed from the list
+      expectedEmojiFrequentList = '😍😂😉😄😃😀😊😘😚😗'
+
+      //Validate emoji frequently used list has the expected order
+      cy.validateFrequentEmojiItems(expectedEmojiFrequentList)
+    })
+
+    //Clear editable input
+    cy.get('[data-cy=editable-input]').click().clear()
+  })
+
+  it('Chat - Emoji Picker - Frequently used - List length is capped to 10', () => {
+    //Open emoji picker and validate frequent used list length
+    cy.get('[data-cy=send-emoji]').click()
+    cy.get('[data-cy=emoji-frequently-used-list]')
+      .children()
+      .should('have.length', 10)
+
+    //Close Emoji Picker
+    cy.get('body').type('{esc}')
   })
 })

--- a/cypress/e2e/chat-text-validations.js
+++ b/cypress/e2e/chat-text-validations.js
@@ -1,10 +1,10 @@
 const faker = require('faker')
 const randomMessage = faker.lorem.sentence() // generate random sentence
-let longMessage = faker.random.alphaNumeric(2060) // generate random alphanumeric text with 2060 chars
+const longMessage = faker.random.alphaNumeric(2060) // generate random alphanumeric text with 2060 chars
 const randomURL = faker.internet.url() // generate random url
-let urlToValidate = 'https://www.google.com'
-let urlToValidateTwo = 'http://www.google.com'
-let urlToValidateThree = 'www.google.com'
+const urlToValidate = 'https://www.google.com'
+const urlToValidateTwo = 'http://www.google.com'
+const urlToValidateThree = 'www.google.com'
 let secondUserName
 
 describe('Chat Text and Sending Links Validations', () => {
@@ -12,7 +12,7 @@ describe('Chat Text and Sending Links Validations', () => {
     //Retrieve username from Chat User B
     cy.restoreLocalStorage('Chat User B')
     cy.getLocalStorage('Satellite-Store').then((ls) => {
-      let tempLS = JSON.parse(ls)
+      const tempLS = JSON.parse(ls)
       secondUserName = tempLS.accounts.details.name
     })
   })
@@ -36,7 +36,7 @@ describe('Chat Text and Sending Links Validations', () => {
       'have.text',
       longMessage,
     )
-    let expectedMessage = longMessage.length.toString() + '/2048'
+    const expectedMessage = longMessage.length.toString() + '/2048'
     cy.validateCharlimit(expectedMessage, true)
   })
 
@@ -51,7 +51,7 @@ describe('Chat Text and Sending Links Validations', () => {
     )
 
     //Charlimit will continue to be red since message was not sent
-    let expectedMessage = longMessage.length.toString() + '/2048'
+    const expectedMessage = longMessage.length.toString() + '/2048'
     cy.validateCharlimit(expectedMessage, true)
 
     //Attempt to send message again now by pressing ENTER key
@@ -120,7 +120,7 @@ describe('Chat Text and Sending Links Validations', () => {
     )
     cy.validateCharlimit('22/2048', false)
     cy.get('[data-cy=send-message]').click()
-    let locatorURL = 'a[href="' + urlToValidate + '"]'
+    const locatorURL = 'a[href="' + urlToValidate + '"]'
     cy.get(locatorURL).last().scrollIntoView().should('have.attr', 'href')
   })
 
@@ -139,7 +139,7 @@ describe('Chat Text and Sending Links Validations', () => {
     )
     cy.validateCharlimit('21/2048', false)
     cy.get('[data-cy=send-message]').click()
-    let locatorURL = 'a[href="' + urlToValidateTwo + '"]'
+    const locatorURL = 'a[href="' + urlToValidateTwo + '"]'
     cy.get(locatorURL).last().scrollIntoView().should('have.attr', 'href')
   })
 
@@ -215,8 +215,8 @@ describe('Chat Text and Sending Links Validations', () => {
   })
 
   it('User should use markdown "<>" to insert an autolink', () => {
-    let locatorURL = 'a[href="' + randomURL + '"]'
-    let autolink = '<' + randomURL + '>'
+    const locatorURL = 'a[href="' + randomURL + '"]'
+    const autolink = '<' + randomURL + '>'
     cy.chatFeaturesSendMessage(autolink, false)
     cy.get(locatorURL)
       .last()
@@ -230,5 +230,12 @@ describe('Chat Text and Sending Links Validations', () => {
 
   it('User should use markdown "||" to insert an spoiler', () => {
     cy.sendMessageWithMarkdown(randomMessage, '||')
+  })
+
+  it('Chat - Send each letter on alphabet as message', () => {
+    const alphabet = 'abcdefghijklmnopqrstuvwxyz'
+    for (let letter of alphabet) {
+      cy.chatFeaturesSendMessage(letter, true)
+    }
   })
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -315,14 +315,44 @@ Cypress.Commands.add(
   },
 )
 
-Cypress.Commands.add('chatFeaturesSendEmoji', (emojiLocator, emojiValue) => {
+Cypress.Commands.add(
+  'chatFeaturesSendEmoji',
+  (emojiLocator, emojiValue, sendMessage = true) => {
+    cy.get('[data-cy=send-emoji]').click()
+    cy.get(emojiLocator).click() // sending emoji
+
+    // Only if sendMessage is true, then send message and assert it appears on chat
+    if (sendMessage) {
+      cy.get('[data-cy=send-message]').click() //sending emoji message
+      cy.contains(emojiValue)
+        .last()
+        .scrollIntoView({ timeout: 20000 })
+        .should('exist')
+    }
+  },
+)
+
+Cypress.Commands.add('validateFrequentEmojiItems', (expectedEmojiList) => {
+  let actualEmojiList = ''
+
+  //Open Emoji Picker
   cy.get('[data-cy=send-emoji]').click()
-  cy.get(emojiLocator).click() // sending emoji
-  cy.get('[data-cy=send-message]').click() //sending emoji message
-  cy.contains(emojiValue)
-    .last()
-    .scrollIntoView({ timeout: 20000 })
-    .should('exist')
+
+  //Validate Frequent Emoji List
+  cy.get('[data-cy=emoji-frequently-used-list]')
+    .find('[data-cy=emoji-frequently-used-item]')
+    .should('have.length', 10)
+    .each(($emoji) => {
+      actualEmojiList += $emoji.text().trim()
+    })
+    .then(() => {
+      cy.log('actual emoji list is: ' + actualEmojiList)
+      cy.log('expected emoji list is: ' + expectedEmojiList)
+      expect(actualEmojiList).to.eq(expectedEmojiList)
+    })
+
+  //Close Emoji Picker
+  cy.get('body').type('{esc}')
 })
 
 Cypress.Commands.add(
@@ -374,6 +404,28 @@ Cypress.Commands.add('validateCharlimit', (text, error) => {
         cy.get('[data-cy=chatbar-wrap]').should('not.have.class', 'is-error')
       }
     })
+})
+
+Cypress.Commands.add('validateActiveGlyphsEmojiPicker', (active = 'emoji') => {
+  if (active === 'emoji') {
+    cy.get('[data-cy=emoji-picker]').should('be.visible')
+    cy.get('[data-cy=glyphs-picker]').should('not.exist')
+    cy.get('[data-cy=glyphs-emoji-active]')
+      .find('span')
+      .should('contain', 'Emoji')
+    cy.get('[data-cy=glyphs-emoji-inactive]')
+      .find('span')
+      .should('contain', 'Glyphs')
+  } else if (active === 'glyphs') {
+    cy.get('[data-cy=glyphs-picker]').should('be.visible')
+    cy.get('[data-cy=emoji-picker]').should('not.exist')
+    cy.get('[data-cy=glyphs-emoji-active]')
+      .find('span')
+      .should('contain', 'Glyphs')
+    cy.get('[data-cy=glyphs-emoji-inactive]')
+      .find('span')
+      .should('contain', 'Emoji')
+  }
 })
 
 // Chat - Replies Commands


### PR DESCRIPTION
### What this PR does 📖
- Adding new data-cy attributes for emoji/glyphs picker tab and emojis frequently used
- Adding new cypress tests for glyphs/emoji picker (AP-1343) on chat-features.js
- Adding new cypress tests for emojis frequently used (AP-1032) on chat-features.js
- Moved the alphabet text message cypress test to chat-text-validations.js file, because it makes more sense to be in this spec
- Found some variables declared with "let" in chat-features.js and chat-text-validations.js cypress spec files that are not reassigned at any moment, so I changed the declaration for these to use const, as per best coding practices
- Added one cypress command for validating emojis recently used displayed on emojis picker. Also, modified the send emoji cypress command to allow the option of just selecting the emoji from picker but not sending the message

### Which issue(s) this PR fixes 🔨
- Resolve #AP-1032 and #AP-1343

### Special notes for reviewers 🗒️


### Additional comments 🎤
- Chat Features Cypress Video:
https://user-images.githubusercontent.com/35935591/200996120-65bf18d8-cd32-448e-aafd-5408dbb9ffff.mp4

- Chat Text Validations Cypress Video:
https://user-images.githubusercontent.com/35935591/200996133-4eb64d88-98cf-41d9-8b6a-c6b053eaf5bd.mp4

- Cypress specs passing:
![image](https://user-images.githubusercontent.com/35935591/200996036-e03acd93-9276-4b58-94d6-4c5719033005.png)

- Videocall cypress specs passing:
![image](https://user-images.githubusercontent.com/35935591/200996071-16e0b721-d21c-459b-8813-41f27eb583b4.png)
