### PR TITLE
test(cypress): emoji size and messages persisting

### DIFF
--- a/cypress/e2e/chat-features.js
+++ b/cypress/e2e/chat-features.js
@@ -257,4 +257,43 @@ describe('Chat Features Tests', () => {
     //Close Emoji Picker
     cy.get('body').type('{esc}')
   })
+
+  it('Chat - Emoji Size - Big Emoji when sending one emoji', () => {
+    //Send a message with one emoji
+    cy.chatFeaturesSendEmoji('[title="joy"]', '😂', true)
+
+    //Validate chat message has class bigmoji
+    cy.get('[data-cy=chat-message]')
+      .last()
+      .scrollIntoView()
+      .should('have.text', '😂')
+      .and('have.class', 'bigmoji')
+  })
+
+  it('Chat - Emoji Size - Big Emoji when sending more than one emoji', () => {
+    //Send a message with three emojis
+    cy.chatFeaturesSendEmoji('[title="heart_eyes"]', '😍', false)
+    cy.chatFeaturesSendEmoji('[title="joy"]', '😂', false)
+    cy.chatFeaturesSendEmoji('[title="wink"]', '😉', true)
+
+    //Validate chat message has class bigmoji
+    cy.get('[data-cy=chat-message]')
+      .last()
+      .scrollIntoView()
+      .should('have.text', '😍😂😉')
+      .and('have.class', 'bigmoji')
+  })
+
+  it('Chat - Emoji Size - Small Emoji when sending emoji with text', () => {
+    //Send a message with one character and one emoji
+    cy.get('[data-cy=editable-input]').trigger('input').type('a')
+    cy.chatFeaturesSendEmoji('[title="wink"]', '😉', true)
+
+    //Validate chat message does not have class bigmoji
+    cy.get('[data-cy=chat-message]')
+      .last()
+      .scrollIntoView()
+      .should('have.text', 'a😉')
+      .and('not.have.class', 'bigmoji')
+  })
 })

--- a/cypress/e2e/chat-pair-features.js
+++ b/cypress/e2e/chat-pair-features.js
@@ -1,5 +1,6 @@
 const faker = require('faker')
 const randomMessage = faker.lorem.sentence() // generate random sentence
+const randomMessageTwo = faker.lorem.sentence() // generate a second random sentence
 const imageLocalPath = 'cypress/fixtures/images/logo.png'
 const fileLocalPath = 'cypress/fixtures/test-file.txt'
 let glyphURL,
@@ -14,11 +15,17 @@ const textReply = 'This is a reply to the message'
 
 describe('Chat pair features with Chat User A  - Part 1', () => {
   before(() => {
-    //Retrieve username from Chat User B
+    //Retrieve username from Chat User B and Chat User C
     cy.restoreLocalStorage('Chat User B')
     cy.getLocalStorage('Satellite-Store').then((ls) => {
       let tempLS = JSON.parse(ls)
       secondUserName = tempLS.accounts.details.name
+    })
+    //Retrieve username from Chat User B and Chat User C
+    cy.restoreLocalStorage('Chat User C')
+    cy.getLocalStorage('Satellite-Store').then((ls) => {
+      let tempLS = JSON.parse(ls)
+      thirdUserName = tempLS.accounts.details.name
     })
   })
 
@@ -137,6 +144,23 @@ describe('Chat pair features with Chat User A  - Part 1', () => {
   //Skipping since there is no context menu now for file messages
   it.skip('File messages cannot be edited', () => {
     cy.validateOptionNotInContextMenu('[data-cy=chat-file]', 'Edit')
+  })
+
+  it('Messages not sent should persist when switching conversations', () => {
+    // Type a message without sent it in conversation with Chat User B
+    cy.get('[data-cy=editable-input]').trigger('input').type(randomMessage)
+
+    // Go to Conversation with Chat User C and type a different message
+    cy.goToConversation(thirdUserName)
+    cy.get('[data-cy=editable-input]').trigger('input').type(randomMessageTwo)
+
+    // Return to conversation with Chat User B and assert that first message not sent yet is still present
+    cy.goToConversation(secondUserName)
+    cy.get('[data-cy=editable-input]').should('have.text', randomMessage)
+
+    // Return to conversation with Chat User C and assert that last message not sent yet is still present
+    cy.goToConversation(thirdUserName)
+    cy.get('[data-cy=editable-input]').should('have.text', randomMessageTwo)
   })
 })
 


### PR DESCRIPTION
### What this PR does 📖
- Add cypress tests for emoji size validations on chat-features.js (AP-1033)
- Add cypress tests for message persisting on editable input when switching conversations on chat-pair-features.js (AP-1034)

### Which issue(s) this PR fixes 🔨
- Resolve #AP-1033 and #AP-1034

### Special notes for reviewers 🗒️
- 

### Additional comments 🎤
- Cypress Video for Chat Features js
https://user-images.githubusercontent.com/35935591/201247749-58cfe426-b35d-4106-bbd5-07eea3f4f80e.mp4

- Cypress Video for Chat Pair Features
https://user-images.githubusercontent.com/35935591/201247768-b70337fd-2558-43bd-94b4-da18bf6a345d.mp4

- All Cypress test specs passing:
![image](https://user-images.githubusercontent.com/35935591/201247701-b18fe6eb-a1a0-4e4f-89da-7b38667afb11.png)

- No updates to any files related to videocall tests for now